### PR TITLE
Adds a workaround to support Azure's non-compliant cloudevents.

### DIFF
--- a/pkg/flow/db-events.go
+++ b/pkg/flow/db-events.go
@@ -78,7 +78,17 @@ func (events *events) addEvent(ctx context.Context, cevc *ent.CloudEventsClient,
 
 	ev := event.Event(*eventin)
 
-	_, err := cevc.
+	// NOTE: this validate check added to sanitize Azure's dodgy cloudevents.
+	err := ev.Validate()
+	if err != nil && strings.Contains(err.Error(), "dataschema") {
+		ev.SetDataSchema("")
+		err = ev.Validate()
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = cevc.
 		Create().
 		SetEvent(ev).
 		SetNamespace(ns).


### PR DESCRIPTION
Azure's cloudevents seemingly have (or had) an invalid context value, and our library was refusing them as a result. This commint sanitizes incoming cloud events so we can proceed anyway.