### PR TITLE
Removed dedicated field from repoHost as it failed validation

### DIFF
--- a/kubernetes/install/db/pg.yaml
+++ b/kubernetes/install/db/pg.yaml
@@ -24,7 +24,7 @@ spec:
       image: >-
         registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.33-2
       repoHost:
-        dedicated: {}
+        affinity: {}
       repos:
         - name: repo1
           volume:


### PR DESCRIPTION
https://access.crunchydata.com/documentation/postgres-operator/v5/references/crd/#postgresclusterspecbackupspgbackrestrepohost

As you can the field doesn't exist anymore hence why it keeps failing validation.

error: error validating "/home/trentis/go/src/github.com/vorteil/direktiv/scripts/../kubernetes/install/db/pg.yaml": error validating data: ValidationError(PostgresCluster.spec.backups.pgbackrest.repoHost): unknown field "dedicated" in com.crunchydata.postgres-operator.v1beta1.PostgresCluster.spec.backups.pgbackrest.repoHost; if you choose to ignore these errors, turn validation off with --validate=false
