### PR TITLE
Fix link to installation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ curl -vv -X PUT "http://localhost:8080/api/namespaces/demo"
 
 ### Kubernetes Install
 
-For full instructions on how to install Direktiv on a Kubernetes environment go to the [installation pages](https://docs.direktiv.io/docs/install.html)
+For full instructions on how to install Direktiv on a Kubernetes environment go to the [installation pages](https://docs.direktiv.io/docs/install/install.html)
 
 ### Workflow specification
 


### PR DESCRIPTION
The README link for `installation pages` is broken. This fixes that issue.