### PR TITLE
Added rename api and fixed some error responses

### DIFF
--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -1063,6 +1063,8 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	pathHandler(r, http.MethodPost, RN_ValidateRef, "validate-ref", h.ValidateRef)
 	// TODO: SWAGGER-SPEC
 	pathHandler(r, http.MethodPost, RN_ValidateRouter, "validate-router", h.ValidateRouter)
+	// TODO: SWAGGER_SPEC
+	pathHandler(r, http.MethodPost, RN_RenameNode, "rename-node", h.RenameNode)
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging Workflows setWorkflowCloudEventLogs
 	// ---
@@ -2100,6 +2102,33 @@ func (h *flowHandler) DiscardWorkflow(w http.ResponseWriter, r *http.Request) {
 	respond(w, resp, err)
 	return
 
+}
+
+func (h *flowHandler) RenameNode(w http.ResponseWriter, r *http.Request) {
+	h.logger.Debugf("Handling request: %s", this())
+
+	ctx := r.Context()
+	namespace := mux.Vars(r)["ns"]
+	path, _ := pathAndRef(r)
+
+	in := &grpc.RenameNodeRequest{}
+
+	data, err := loadRawBody(r)
+	if err != nil {
+		respond(w, nil, err)
+		return
+	}
+
+	err = json.Unmarshal(data, &in)
+	if err != nil {
+		respond(w, nil, err)
+		return
+	}
+	in.Namespace = namespace
+	in.Old = path
+
+	resp, err := h.client.RenameNode(ctx, in)
+	respond(w, resp, err)
 }
 
 func (h *flowHandler) DeleteNode(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -15,6 +15,7 @@ const (
 	RN_SaveWorkflow         = "saveWorkflow"
 	RN_DiscardWorkflow      = "discardWorkflow"
 	RN_DeleteNode           = "deleteNode"
+	RN_RenameNode           = "renameNode"
 	RN_GetWorkflowTags      = "getWorkflowTags"
 	RN_GetWorkflowRevisions = "getWorkflowRevisions"
 	RN_GetWorkflowRefs      = "getWorkflowRefs"

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -183,15 +183,16 @@ func respond(w http.ResponseWriter, resp interface{}, err error) {
 		// TODO fix grpc to send back useful error code for http translation
 		code := ConvertGRPCStatusCodeToHTTPCode(status.Code(err))
 
-		var msg string
+		// var msg string
 		// if code < 500 {
 		// 	msg = err.Error()
 		// } else {
 		// 	msg = http.StatusText(code)
 		// }
 
-		msg = err.Error()
-		http.Error(w, msg, code)
+		// return only the message part of the grpc error
+		st := status.Convert(err)
+		http.Error(w, st.Message(), code)
 		return
 
 	}

--- a/pkg/model/function-common.go
+++ b/pkg/model/function-common.go
@@ -151,9 +151,9 @@ func getFunctionDefFromType(ftype string) (FunctionDefinition, error) {
 	case SubflowFunctionType.String():
 		f = new(SubflowFunctionDefinition)
 	case "":
-		err = errors.New("type required")
+		err = errors.New("type required(reusable, isolated, knative-namespace, knative-global, subflow)")
 	default:
-		err = errors.New("type unimplemented/unrecognized")
+		err = errors.New("type unrecognized(reusable, isolated, knative-namespace, knative-global, subflow)")
 	}
 
 	return f, err

--- a/pkg/model/start-common.go
+++ b/pkg/model/start-common.go
@@ -85,9 +85,9 @@ func getStartFromType(startType string) (StartDefinition, error) {
 	case StartTypeDefault.String():
 		s = new(DefaultStart)
 	case "":
-		err = errors.New("type required")
+		err = errors.New("type required(scheduled, event, eventsXor, eventsAnd, default)")
 	default:
-		err = errors.New("type unimplemented/unrecognized")
+		err = errors.New("type unrecognized(scheduled, event, eventsXor, eventsAnd, default)")
 	}
 
 	return s, err

--- a/pkg/model/state-common.go
+++ b/pkg/model/state-common.go
@@ -172,9 +172,9 @@ func getStateFromType(stype string) (State, error) {
 	case StateTypeSetter.String():
 		s = new(SetterState)
 	case "":
-		err = errors.New("type required")
+		err = errors.New("type required(switch, foreach, consumeEvent, delay, eventsAnd, eventsXor, noop, validate, parallel, getter, setter)")
 	default:
-		err = errors.New("type unimplemented/unrecognized")
+		err = errors.New("type unrecognized(switch, foreach, consumeEvent, delay, eventsAnd, eventsXor, noop, validate, parallel, getter, setter)")
 	}
 
 	return s, err


### PR DESCRIPTION
- Added type examples to errors when the type is invalid or not added.
- Added a rename api for workflows and directories
- Trimmed grpc error to only return the message instead of prefixing with ` rpc error: code = InvalidArgument desc = ` can be further improved to handle internal errors better

closes #171 #248 