### PR TITLE
Changed uniqueness from just the id to id and the namespace

### DIFF
--- a/pkg/flow/ent/migrate/schema.go
+++ b/pkg/flow/ent/migrate/schema.go
@@ -11,7 +11,7 @@ var (
 	// CloudEventsColumns holds the columns for the "cloud_events" table.
 	CloudEventsColumns = []*schema.Column{
 		{Name: "oid", Type: field.TypeUUID},
-		{Name: "event_id", Type: field.TypeString, Unique: true},
+		{Name: "event_id", Type: field.TypeString},
 		{Name: "event", Type: field.TypeJSON},
 		{Name: "fire", Type: field.TypeTime},
 		{Name: "created", Type: field.TypeTime},
@@ -29,6 +29,13 @@ var (
 				Columns:    []*schema.Column{CloudEventsColumns[6]},
 				RefColumns: []*schema.Column{NamespacesColumns[0]},
 				OnDelete:   schema.Cascade,
+			},
+		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "cloudevents_event_id_namespace_cloudevents",
+				Unique:  true,
+				Columns: []*schema.Column{CloudEventsColumns[1], CloudEventsColumns[6]},
 			},
 		},
 	}

--- a/pkg/flow/ent/schema/cloudevents.go
+++ b/pkg/flow/ent/schema/cloudevents.go
@@ -7,6 +7,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 )
@@ -20,7 +21,7 @@ type CloudEvents struct {
 func (CloudEvents) Fields() []ent.Field {
 	return []ent.Field{
 		field.UUID("id", uuid.UUID{}).Default(uuid.New).Immutable().StorageKey("oid").StructTag(`json:"id"`).Annotations(entgql.OrderField("ID")),
-		field.String("eventId").Immutable().Unique().NotEmpty(),
+		field.String("eventId").Immutable().NotEmpty(),
 		field.JSON("event", cloudevents.Event{}),
 		field.Time("fire").Immutable().Default(time.Now),
 		field.Time("created").Immutable().Default(time.Now),
@@ -32,5 +33,12 @@ func (CloudEvents) Fields() []ent.Field {
 func (CloudEvents) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("namespace", Namespace.Type).Ref("cloudevents").Unique().Required(),
+	}
+}
+
+// Indexes of the CloudEvents.
+func (CloudEvents) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("eventId").Edges("namespace").Unique(),
 	}
 }


### PR DESCRIPTION
Addresses the issue of sending a cloud event to different namespaces but with the same ID. 

Closes #277 