### PR TITLE
default encryption key set

### DIFF
--- a/kubernetes/charts/direktiv/templates/flow/flow-secrets.yaml
+++ b/kubernetes/charts/direktiv/templates/flow/flow-secrets.yaml
@@ -8,7 +8,7 @@ type: Opaque
 data:
    db: {{ printf "host=%s port=%d user=%s dbname=%s password=%s sslmode=%s" .Values.database.host ( .Values.database.port | int64 )  .Values.database.user .Values.database.name .Values.database.password .Values.database.sslmode | b64enc | quote }}
    {{- if .Values.encryptionKey }}
-   key: {{ .Values.encryptionKey | quote }}
+   key: {{ .Values.encryptionKey | b64enc | quote }}
    {{- else }}
    key: {{ randAlphaNum 32 | b64enc | quote }}
    {{- end }}

--- a/kubernetes/charts/direktiv/values.yaml
+++ b/kubernetes/charts/direktiv/values.yaml
@@ -16,7 +16,7 @@ apikey: ""
 
 # used for encrpytion in the following resources: secrets
 # if set to empty, one will be generated on install
-encryptionKey: ""
+encryptionKey: "01234567890123456789012345678912"
 
 opentelemetry:
   # -- opentelemetry address where Direktiv is sending data to


### PR DESCRIPTION
## Description

The key for secrets was generated by default. Which makes all secrets invalid on redeploy. Set the default to some dummy value prevents this from happening. 

If key was set it was not base64 encoded also and did not work at all.