### PR TITLE
New Ordering Fields Added

### DIFF
--- a/pkg/flow/ent/pagination.go
+++ b/pkg/flow/ent/pagination.go
@@ -1250,6 +1250,26 @@ func (i *InodeQuery) Paginate(
 }
 
 var (
+	// InodeOrderFieldCreatedAt orders Inode by created_at.
+	InodeOrderFieldCreatedAt = &InodeOrderField{
+		field: inode.FieldCreatedAt,
+		toCursor: func(i *Inode) Cursor {
+			return Cursor{
+				ID:    i.ID,
+				Value: i.CreatedAt,
+			}
+		},
+	}
+	// InodeOrderFieldUpdatedAt orders Inode by updated_at.
+	InodeOrderFieldUpdatedAt = &InodeOrderField{
+		field: inode.FieldUpdatedAt,
+		toCursor: func(i *Inode) Cursor {
+			return Cursor{
+				ID:    i.ID,
+				Value: i.UpdatedAt,
+			}
+		},
+	}
 	// InodeOrderFieldName orders Inode by name.
 	InodeOrderFieldName = &InodeOrderField{
 		field: inode.FieldName,
@@ -1266,6 +1286,10 @@ var (
 func (f InodeOrderField) String() string {
 	var str string
 	switch f.field {
+	case inode.FieldCreatedAt:
+		str = "CREATED"
+	case inode.FieldUpdatedAt:
+		str = "UPDATED"
 	case inode.FieldName:
 		str = "NAME"
 	}
@@ -1284,6 +1308,10 @@ func (f *InodeOrderField) UnmarshalGQL(v interface{}) error {
 		return fmt.Errorf("InodeOrderField %T must be a string", v)
 	}
 	switch str {
+	case "CREATED":
+		*f = *InodeOrderFieldCreatedAt
+	case "UPDATED":
+		*f = *InodeOrderFieldUpdatedAt
 	case "NAME":
 		*f = *InodeOrderFieldName
 	default:

--- a/pkg/flow/ent/schema/inode.go
+++ b/pkg/flow/ent/schema/inode.go
@@ -22,8 +22,8 @@ type Inode struct {
 func (Inode) Fields() []ent.Field {
 	return []ent.Field{
 		field.UUID("id", uuid.UUID{}).Default(uuid.New).Immutable().StorageKey("oid"),
-		field.Time("created_at").Default(time.Now).Immutable(),
-		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),
+		field.Time("created_at").Default(time.Now).Immutable().Annotations(entgql.OrderField("CREATED")),
+		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now).Annotations(entgql.OrderField("UPDATED")),
 		field.String("name").Match(NameRegex).Optional().Annotations(entgql.OrderField("NAME")),
 		field.String("type").Immutable(),
 		field.Strings("attributes").Optional(),

--- a/pkg/flow/grpc-nodes.go
+++ b/pkg/flow/grpc-nodes.go
@@ -19,25 +19,34 @@ import (
 
 func directoryOrder(p *pagination) ent.InodePaginateOption {
 
-	field := ent.InodeOrderFieldName
-	direction := ent.OrderDirectionAsc
-
-	if p.order != nil {
-
-		if x := p.order.Field; x != "" && x == "NAME" {
-			field = ent.InodeOrderFieldName
-		}
-
-		if x := p.order.Direction; x != "" && x == "DESC" {
-			direction = ent.OrderDirectionDesc
-		}
-
+	order := ent.InodeOrder{
+		Direction: ent.OrderDirectionAsc,
+		Field:     ent.InodeOrderFieldName,
 	}
 
-	return ent.WithInodeOrder(&ent.InodeOrder{
-		Direction: direction,
-		Field:     field,
-	})
+	if p.order != nil {
+		switch p.order.GetField() {
+		case "UPDATED":
+			order.Field = ent.InodeOrderFieldUpdatedAt
+		case "CREATED":
+			order.Field = ent.InodeOrderFieldCreatedAt
+		case "NAME":
+			order.Field = ent.InodeOrderFieldName
+		default:
+			break
+		}
+
+		switch p.order.GetDirection() {
+		case "DESC":
+			order.Direction = ent.OrderDirectionDesc
+		case "ASC":
+			order.Direction = ent.OrderDirectionAsc
+		default:
+			break
+		}
+	}
+
+	return ent.WithInodeOrder(&order)
 
 }
 


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

Added the Name, Created, and Updated as supported fields to order by when getting directory nodes.

## Purpose

- [ ] Bug fix
- [X] New feature
- [ ] Other

## How was this tested? (if applicable)

Locally

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
