### PR TITLE
Set helm AppVersion to full tag (without cutting leading 'v').

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -23,11 +23,11 @@ jobs:
           v="${version:1}"
           echo "packaging helm for $v"
           helm dependency update kubernetes/charts/direktiv/
-          helm package --app-version=$v --version=$v kubernetes/charts/direktiv/
+          helm package --app-version=$version --version=$v kubernetes/charts/direktiv/
           helm dependency update kubernetes/charts/knative
-          helm package --app-version=$v --version=$v kubernetes/charts/knative/
+          helm package --app-version=$version --version=$v kubernetes/charts/knative/
           git clone https://github.com/CrunchyData/postgres-operator-examples.git
-          helm package --app-version=$v --version=$v postgres-operator-examples/helm/install/
+          helm package --app-version=$version --version=$v postgres-operator-examples/helm/install/
           wget https://${{ secrets.GCP_BUCKET }}.storage.googleapis.com/index.yaml
           echo "do helm index thing"
           helm repo index ./ --merge ./index.yaml


### PR DESCRIPTION
The AppVersion is being used for the default tags of each image in the Direktiv helm charts. Currently this is being set to the tag, minus the leading 'v' character.

This change tells the github action to not remove the v from the AppVersion value.