### PR TITLE
References to replicaCount replaced with replicas

### DIFF
--- a/kubernetes/charts/direktiv/README.md
+++ b/kubernetes/charts/direktiv/README.md
@@ -68,7 +68,7 @@ $ helm install direktiv direktiv/direktiv
 | functions.netShape | string | `"10M"` | Egress/Ingress network limit for functions if supported by network |
 | functions.no_proxy | string | `""` | no_proxy injected as environment variable in functions |
 | functions.podCleaner | bool | `true` | Cleaning up tasks, Kubernetes < 1.20 does not clean finished tasks |
-| functions.replicaCount | int | `1` | number of controller replicas |
+| functions.replicas | int | `1` | number of controller replicas |
 | functions.runtime | string | `"default"` | runtime to use, e.g. gvisor on GCP |
 | functions.sidecar | string | `"direktiv/sidecar"` |  |
 | functions.tag | string | `""` |  |

--- a/kubernetes/charts/direktiv/templates/functions/functions-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/functions/functions-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "direktiv.labels" . | nindent 4 }}-functions
 spec:
-  replicas: {{ .Values.functions.replicaCount }}
+  replicas: {{ .Values.functions.replicas }}
   selector:
     matchLabels:
       {{- include "direktiv.selectorLabelsFunctions" . | nindent 6 }}

--- a/kubernetes/charts/direktiv/templates/ui/ui-deployment.yaml
+++ b/kubernetes/charts/direktiv/templates/ui/ui-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{ include "direktiv.labelsUI" . | nindent 4 }}-ui
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "direktiv.selectorLabelsUI" . | nindent 6 }}

--- a/kubernetes/charts/direktiv/values.yaml
+++ b/kubernetes/charts/direktiv/values.yaml
@@ -292,7 +292,7 @@ functions:
   timeout: 7200000
 
   # -- number of controller replicas
-  replicaCount: 1
+  replicas: 1
 
   # -- Egress/Ingress network limit for functions if supported by network
   netShape: "10M"


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

References to replicaCount replaced with replicas in helm charts

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
