### PR TITLE
logging fix for action lodging string interpolation

### DIFF
--- a/pkg/flow/grpc-internal.go
+++ b/pkg/flow/grpc-internal.go
@@ -108,7 +108,7 @@ func (internal *internal) ActionLog(ctx context.Context, req *grpc.ActionLogRequ
 	}
 
 	for _, msg := range req.GetMsg() {
-		internal.logToInstance(ctx, t, d.in, msg)
+		internal.logToInstanceRaw(ctx, t, d.in, msg)
 	}
 
 	var resp emptypb.Empty

--- a/pkg/flow/logs.go
+++ b/pkg/flow/logs.go
@@ -124,11 +124,17 @@ func (srv *server) logToWorkflow(ctx context.Context, t time.Time, d *wfData, ms
 
 }
 
+// log To instance with string interpolation
 func (srv *server) logToInstance(ctx context.Context, t time.Time, in *ent.Instance, msg string, a ...interface{}) {
 
-	logc := srv.db.LogMsg
-
 	msg = fmt.Sprintf(msg, a...)
+
+	srv.logToInstanceRaw(ctx, t, in, msg)
+}
+
+// log To instance with raw string
+func (srv *server) logToInstanceRaw(ctx context.Context, t time.Time, in *ent.Instance, msg string) {
+	logc := srv.db.LogMsg
 
 	util.Trace(ctx, msg)
 
@@ -146,7 +152,6 @@ func (srv *server) logToInstance(ctx context.Context, t time.Time, in *ent.Insta
 	srv.sugar.Infow(msg, "trace", tid, "namespace", ns.Name, "namespace-id", ns.ID.String(), "workflow-id", wf.ID.String(), "workflow", GetInodePath(in.As), "instance", in.ID.String())
 
 	srv.pubsub.NotifyInstanceLogs(in)
-
 }
 
 func (engine *engine) UserLog(ctx context.Context, im *instanceMemory, msg string, a ...interface{}) {


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

If you log a special character from a workflow to the side car and that log message has a special Sprintf character, the interal logger will attempt the resolve this special character with no additional.

The internal ActionLog has been updated to use a new function `logToInstanceRaw` which prints the string as is.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
