### PR TITLE
AS WORKFLOW query filter added to instance filter

### DIFF
--- a/pkg/flow/grpc-instances.go
+++ b/pkg/flow/grpc-instances.go
@@ -380,6 +380,8 @@ func instancesFilter(p *pagination) ent.InstancePaginateOption {
 			}
 
 			switch ftype {
+			case "WORKFLOW":
+				return query.Where(entinst.AsHasPrefix(filter + ":")), nil
 			case "CONTAINS":
 				return query.Where(entinst.AsContains(filter)), nil
 			}


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description
Added filter.type=WORKFLOW to instances filtering

Example query:
filter.field=AS&filter.type=WORKFLOW&filter.val={$WORKFLOW_NODE}

## Purpose

- [X] Bug fix
- [X] New feature
- [ ] Other
