### PR TITLE
revisions trimmed from prometheus metrics temporarily

### DIFF
--- a/pkg/flow/metrics.go
+++ b/pkg/flow/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/direktiv/direktiv/pkg/flow/grpc"
@@ -320,6 +321,11 @@ func (engine *engine) metricsCompleteInstance(ctx context.Context, im *instanceM
 	t := im.StateBeginTime()
 	namespace := ns.Name
 	workflow := GetInodePath(im.in.As)
+
+	// Trim workflow revision until revisions are fully implemented.
+	if divider := strings.LastIndex(workflow, ":"); divider > 0 {
+		workflow = workflow[0:divider]
+	}
 
 	now := time.Now()
 	empty := time.Time{}


### PR DESCRIPTION
Signed-off-by: Jon Alfaro <jon.alfaro@vorteil.io>

## Description

Prometheus counters currently do not have a field for workflow revisions. Because of this I've removed the revision ref from the driektiv_workflow prometheus key. This is a temporary fix and should be added back in when revision ref has been split and is stored in new counter key. I'll make an issue to track this