### PR TITLE
Revision suffix removed from workflow service paths

### DIFF
--- a/pkg/functions/kube.go
+++ b/pkg/functions/kube.go
@@ -1000,7 +1000,7 @@ func metaSpec(net string, min, max int, nsID, nsName, wfID, path, name, scope st
 	metaSpec.Labels[ServiceHeaderName] = SanitizeLabel(name)
 	if len(wfID) > 0 {
 		metaSpec.Labels[ServiceHeaderWorkflowID] = SanitizeLabel(wfID)
-		metaSpec.Labels[ServiceHeaderPath] = SanitizeLabel(path)
+		metaSpec.Labels[ServiceHeaderPath] = trimRevisionSuffix(SanitizeLabel(path))
 		metaSpec.Labels[ServiceHeaderRevision] = SanitizeLabel(hash)
 	}
 
@@ -1028,6 +1028,14 @@ func SanitizeLabel(s string) string {
 	return s
 }
 
+func trimRevisionSuffix(s string) string {
+	if i := strings.LastIndex(s, ":"); i > 0 {
+		s = s[:i]
+	}
+
+	return s
+}
+
 func meta(svn, name, nsID, nsName, wfID, path string, scale, size int, scope, hash string) metav1.ObjectMeta {
 
 	meta := metav1.ObjectMeta{
@@ -1042,7 +1050,7 @@ func meta(svn, name, nsID, nsName, wfID, path string, scale, size int, scope, ha
 	meta.Labels[ServiceHeaderName] = SanitizeLabel(name)
 	if len(wfID) > 0 {
 		meta.Labels[ServiceHeaderWorkflowID] = SanitizeLabel(wfID)
-		meta.Labels[ServiceHeaderPath] = SanitizeLabel(path)
+		meta.Labels[ServiceHeaderPath] = trimRevisionSuffix(SanitizeLabel(path))
 		meta.Labels[ServiceHeaderRevision] = SanitizeLabel(hash)
 	}
 

--- a/pkg/functions/pod.go
+++ b/pkg/functions/pod.go
@@ -288,7 +288,7 @@ func (is *functionsServer) CreateFunctionsPod(ctx context.Context,
 
 	labels[ServiceHeaderName] = info.GetName()
 	labels[ServiceHeaderWorkflowID] = info.GetWorkflow()
-	labels[ServiceHeaderPath] = SanitizeLabel(info.GetPath())
+	labels[ServiceHeaderPath] = trimRevisionSuffix(SanitizeLabel(info.GetPath()))
 	labels[ServiceHeaderRevision] = SanitizeLabel(hash)
 	labels[ServiceHeaderNamespaceID] = info.GetNamespace()
 	labels[ServiceHeaderNamespaceName] = info.GetNamespaceName()


### PR DESCRIPTION
## Description

If you execute a workflow with a ref=REVISION_UUID and the workflow service hasn't spun up yet it will try to create a Kubernetes service with a label `"direktiv.io/path=WF_NAME:REVISION_UUID`. The `:` character is illegal in kube labels so this service will fail and the instance will also fail. 

This pr trims the `REVISION_UUID` from the path in the services. I've had a look at the flow and functions code and don't think it will cause any problems anywhere else. I've also done some testing locally and it all seems to work. 

It's a small change, but I'm making this a pr incase there some side-effect you know of that I'm forgetting about.

I also did think about sanitizing the label instead of just trimming it, but I feel like this just adds confusion. Example scenario:

1. Create a revision named `dog`
2. Execute rev dog
3. You now have a svc with `direktiv.io/path=WF_NAME:dog`
4. Create new revision `cat`, change input, but dont change function
5. Executing rev cat will now use the same svc as dog which still has `direktiv.io/path=WF_NAME:dog`

## Purpose

- [X] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Local cluster
- Created 4 revisions
- Executed individually (works)
- Tested routing (works)
