### PR TITLE
New filtering options for instances list.

### DIFF
--- a/pkg/flow/grpc-instances.go
+++ b/pkg/flow/grpc-instances.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entinst "github.com/direktiv/direktiv/pkg/flow/ent/instance"
@@ -375,19 +376,37 @@ func instancesFilter(p *pagination) ent.InstancePaginateOption {
 		case "AS":
 
 			ftype := p.filter.Type
-			if ftype == "" {
-				return query, nil
-			}
 
 			switch ftype {
 			case "WORKFLOW":
 				return query.Where(entinst.AsHasPrefix(filter + ":")), nil
+			case "":
+				fallthrough
 			case "CONTAINS":
 				return query.Where(entinst.AsContains(filter)), nil
+			default:
+				return nil, fmt.Errorf("unexpected filter type")
 			}
-		}
 
-		return query, nil
+		case "STATUS":
+
+			ftype := p.filter.Type
+
+			switch ftype {
+			case "MATCH":
+				return query.Where(entinst.StatusEQ(filter)), nil
+			case "":
+				fallthrough
+			case "CONTAINS":
+				return query.Where(entinst.StatusContains(filter)), nil
+			default:
+				return nil, fmt.Errorf("unexpected filter type")
+			}
+
+		default:
+			return nil, fmt.Errorf("bad filter field")
+
+		}
 
 	})
 

--- a/pkg/flow/grpc-instances.go
+++ b/pkg/flow/grpc-instances.go
@@ -372,7 +372,7 @@ func instancesFilter(p *pagination) ent.InstancePaginateOption {
 		}
 
 		switch field {
-		case "WORKFLOW":
+		case "AS":
 
 			ftype := p.filter.Type
 			if ftype == "" {
@@ -380,7 +380,7 @@ func instancesFilter(p *pagination) ent.InstancePaginateOption {
 			}
 
 			switch ftype {
-			case "AS":
+			case "WORKFLOW":
 				return query.Where(entinst.AsHasPrefix(filter + ":")), nil
 			case "CONTAINS":
 				return query.Where(entinst.AsContains(filter)), nil

--- a/pkg/flow/grpc-instances.go
+++ b/pkg/flow/grpc-instances.go
@@ -372,7 +372,7 @@ func instancesFilter(p *pagination) ent.InstancePaginateOption {
 		}
 
 		switch field {
-		case "AS":
+		case "WORKFLOW":
 
 			ftype := p.filter.Type
 			if ftype == "" {
@@ -380,7 +380,7 @@ func instancesFilter(p *pagination) ent.InstancePaginateOption {
 			}
 
 			switch ftype {
-			case "WORKFLOW":
+			case "AS":
 				return query.Where(entinst.AsHasPrefix(filter + ":")), nil
 			case "CONTAINS":
 				return query.Where(entinst.AsContains(filter)), nil


### PR DESCRIPTION
## Description

Adds new options for filtering on the instance status list. 

You can filter on either `AS` or `STATUS`. 

`AS` refers to the `as` field, which is the string used to invoke/call the workflow. `AS` can have filter types `WORKFLOW` or `CONTAINS`. The latter is a simple string match, while the former attempts to match the prefix only so that the specific tag/ref/revision used (if any) is irrelevant. 

`STATUS` refers to the `status` field. `STATUS` can have filter types `MATCHES` or `CONTAINS`. Both are basic string matches, though the former must be an exact match. 

This issue is slightly related to #400.