### PR TITLE
Tweaks the foreach state so that the array-generating query must now …

### DIFF
--- a/pkg/flow/errors.go
+++ b/pkg/flow/errors.go
@@ -21,6 +21,7 @@ var (
 	ErrCodeJQBadQuery             = "direktiv.jq.badCommand"
 	ErrCodeJQNotObject            = "direktiv.jq.notObject"
 	ErrCodeAllBranchesFailed      = "direktiv.parallel.allFailed"
+	ErrCodeNotArray               = "direktiv.foreach.badArray"
 	ErrCodeFailedSchemaValidation = "direktiv.schema.failed"
 )
 

--- a/pkg/flow/state-foreach.go
+++ b/pkg/flow/state-foreach.go
@@ -161,10 +161,15 @@ func (sl *foreachStateLogic) do(ctx context.Context, engine *engine, im *instanc
 
 func (sl *foreachStateLogic) doAll(ctx context.Context, engine *engine, im *instanceMemory) (err error) {
 
-	var array []interface{}
-	array, err = jq(im.data, sl.state.Array)
+	x, err := jqOne(im.data, sl.state.Array)
 	if err != nil {
 		return
+	}
+
+	var array []interface{}
+	array, ok := x.([]interface{})
+	if !ok {
+		return NewCatchableError(ErrCodeNotArray, "jq produced non-array output")
 	}
 
 	engine.logToInstance(ctx, time.Now(), im.in, "Generated %d objects to loop over.", len(array))


### PR DESCRIPTION
…generate one result, which is an array. As opposed to multiple results of any kind, which were treated like elements in an array.

Signed-off-by: Alan Murtagh <alan.murtagh@direktiv.io>