### PR TITLE
Fixes a crash that can happen when calling the DiscardHead api.

### DIFF
--- a/pkg/flow/grpc-workflow.go
+++ b/pkg/flow/grpc-workflow.go
@@ -478,6 +478,8 @@ func (flow *flow) DiscardHead(ctx context.Context, req *grpc.DiscardHeadRequest)
 	var rev *ent.Revision
 	var prevrev []*ent.Revision
 
+	rev = d.rev()
+
 	if revcount == 1 || refcount > 1 {
 		// already saved, or not discardable, gracefully back out
 		rollback(tx)


### PR DESCRIPTION
Signed-off-by: Alan Murtagh <alan.murtagh@direktiv.io>