### PR TITLE
Changes start-event struct field from 'filters' to 'context' to make …

### DIFF
--- a/pkg/flow/db-events.go
+++ b/pkg/flow/db-events.go
@@ -192,7 +192,7 @@ func (events *events) processWorkflowEvents(ctx context.Context, evc *ent.Events
 			em := make(map[string]interface{})
 			em[eventTypeString] = e.Type
 
-			for kf, vf := range e.Filters {
+			for kf, vf := range e.Context {
 				em[fmt.Sprintf("%s%s", filterPrefix, strings.ToLower(kf))] = vf
 			}
 			ev = append(ev, em)

--- a/pkg/model/start-common.go
+++ b/pkg/model/start-common.go
@@ -24,7 +24,7 @@ func (o *Workflow) GetStartDefinition() StartDefinition {
 // FIXME: Going to be renamed later
 type StartEventDefinition struct {
 	Type    string                 `yaml:"type"`
-	Filters map[string]interface{} `yaml:"filters,omitempty"`
+	Context map[string]interface{} `yaml:"context,omitempty"`
 }
 
 func (o *StartEventDefinition) Validate() error {

--- a/specification/workflow-yaml/starts.md
+++ b/specification/workflow-yaml/starts.md
@@ -88,7 +88,7 @@ The StartEventDefinition is a structure shared by various start definitions invo
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | `type` | Identifies which CloudEvents events can trigger the workflow by requiring an exact match to the event's own `type` context value. | string | yes | 
-| `filters` | Optional key-value pairs to further restrict what events can trigger the workflow. For each pair, incoming CloudEvents context values will be checked for a match. All pairs must find a match for the event to be accepted. The "keys" are strings that match exactly to specific context keys, but the "values" can be "glob" patterns allowing them to match a range of possible context values. | object | no |
+| `context` | Optional key-value pairs to further restrict what events can trigger the workflow. For each pair, incoming CloudEvents context values will be checked for a match. All pairs must find a match for the event to be accepted. The "keys" are strings that match exactly to specific context keys, but the "values" can be "glob" patterns allowing them to match a range of possible context values. | object | no |
 
 The input data of an event-triggered workflow is a JSON representation of all the received events stored under keys matching the events' respective type. For example, this CloudEvents event will result in the following input data in a workflow triggered by a single event:
 


### PR DESCRIPTION
…it consistent with the event states.

Signed-off-by: Alan Murtagh <alan.murtagh@direktiv.io>