### PR TITLE
Fixed lock connection handling Closes #547

### DIFF
--- a/pkg/flow/locks.go
+++ b/pkg/flow/locks.go
@@ -55,39 +55,24 @@ func (locks *locks) Close() error {
 
 }
 
-func (locks *locks) tryLockDB(id uint64) (bool, *sql.Conn, error) {
-
-	var gotLock bool
-
-	conn, err := locks.db.Conn(context.Background())
-	if err != nil {
-		return false, nil, err
-	}
-
-	err = conn.QueryRowContext(context.Background(), "SELECT pg_try_advisory_lock($1)", int64(id)).Scan(&gotLock)
-	if err != nil {
-		return false, nil, err
-	}
-	if !gotLock {
-		err = conn.Close()
-		if err != nil {
-			fmt.Println("CLOSE LOCK CONN ERROR", err)
-		}
-	}
-
-	return gotLock, conn, nil
-
-}
-
 func (locks *locks) lockDB(id uint64, wait int) (*sql.Conn, error) {
 
-	var err error
+	var (
+		err  error
+		conn *sql.Conn
+	)
+
+	defer func() {
+		if err != nil && conn != nil {
+			conn.Close()
+		}
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(),
 		time.Duration(wait)*time.Second)
 	defer cancel()
 
-	conn, err := locks.db.Conn(ctx)
+	conn, err = locks.db.Conn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -107,22 +92,23 @@ func (locks *locks) lockDB(id uint64, wait int) (*sql.Conn, error) {
 
 }
 
-func (locks *locks) unlockDB(id uint64, conn *sql.Conn) error {
+func (locks *locks) unlockDB(id uint64, conn *sql.Conn) (err error) {
 
-	_, err := conn.ExecContext(context.Background(),
+	defer func() {
+		err = conn.Close()
+		if err != nil {
+			err = fmt.Errorf("can not close database connection %d: %v", id, err)
+		}
+	}()
+
+	_, err = conn.ExecContext(context.Background(),
 		"SELECT pg_advisory_unlock($1)", int64(id))
 
 	if err != nil {
-		return fmt.Errorf("can not unlock lock %d: %v", id, err)
+		err = fmt.Errorf("can not unlock lock %d: %v", id, err)
 	}
 
-	err = conn.Close()
-
-	if err != nil {
-		return fmt.Errorf("can not close database connection %d: %v", id, err)
-	}
-
-	return nil
+	return err
 
 }
 

--- a/pkg/flow/syncer.go
+++ b/pkg/flow/syncer.go
@@ -492,6 +492,10 @@ func (syncer *syncer) execute(am *activityMemory) {
 		if err != nil {
 			return
 		}
+
+		// in case of cron
+		syncer.server.syncerCronPollerMirror(am.mir)
+
 	case util.MirrorActivityTypeCronSync:
 		err = syncer.hardSync(ctx, am)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Jens Gerke <jens.gerke@direktiv.io>

## Description

Lock functionality does not return the connection to the connection pool if acquiring the lock fails after getting the connection from the pool.