### PR TITLE
Bug 575

### DIFF
--- a/pkg/functions/lock.go
+++ b/pkg/functions/lock.go
@@ -57,30 +57,6 @@ func (locks *locks) Close() error {
 
 }
 
-func (locks *locks) tryLockDB(id uint64) (bool, *sql.Conn, error) {
-
-	var gotLock bool
-
-	conn, err := locks.db.Conn(context.Background())
-	if err != nil {
-		return false, nil, err
-	}
-
-	err = conn.QueryRowContext(context.Background(), "SELECT pg_try_advisory_lock($1)", int64(id)).Scan(&gotLock)
-	if err != nil {
-		return false, nil, err
-	}
-	if !gotLock {
-		err = conn.Close()
-		if err != nil {
-			fmt.Println("CLOSE LOCK CONN ERROR", err)
-		}
-	}
-
-	return gotLock, conn, nil
-
-}
-
 func (locks *locks) lockDB(id uint64, wait int) (*sql.Conn, error) {
 
 	var err error

--- a/specification/workflow-yaml/action.md
+++ b/specification/workflow-yaml/action.md
@@ -22,5 +22,5 @@ The `action` state is the simplest and most common way to call a function or inv
 | `transition` | Identifies which state to transition to next, referring to the next state's unique `id`. If undefined, this state terminates the workflow. | string | no |
 | `catch` | Defines behaviour for handling of catchable errors.  | [[]ErrorCatchDefinition](./errors.md) | no |
 | `timeout` | ISO8601 duration string to set a non-default timeout. | string | no | 
-| `aync` | If set to `true`, the workflow execution will continue without waiting for the action to return.  | boolean | no | 
+| `async` | If set to `true`, the workflow execution will continue without waiting for the action to return.  | boolean | no | 
 | `action` | Defines the action to perform. | [ActionDefinition](./actions.md) | yes |


### PR DESCRIPTION
## Description

Cancel request are blocking without a timeout. This can lead to long lasting locks in the flow engine. This makes the cancel call to the pod async and adds a timeout to the request. 