### PR TITLE
Sidecar can accept empty variables of type tar and tar.gz, Increased max GRPC size

### DIFF
--- a/pkg/util/grpc-util.go
+++ b/pkg/util/grpc-util.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const maxSize = 33554432
+const maxSize = 134217728
 
 // GetEndpointTLS creates a grpc client
 func GetEndpointTLS(service string) (*grpc.ClientConn, error) {


### PR DESCRIPTION
Signed-off-by: Jens Gerke <jens.gerke@direktiv.io>

