### PR TITLE
API: tag can now be read from query or body in tag operations

### DIFF
--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -3194,7 +3194,11 @@ func (h *flowHandler) Tag(w http.ResponseWriter, r *http.Request) {
 	namespace := mux.Vars(r)["ns"]
 	path, ref := pathAndRef(r)
 
-	tag := r.URL.Query().Get("tag")
+	tag, err := readSingularFromQueryOrBody(r, "tag")
+	if err != nil {
+		respond(w, nil, err)
+		return
+	}
 
 	in := &grpc.TagRequest{
 		Namespace: namespace,
@@ -3235,7 +3239,11 @@ func (h *flowHandler) Retag(w http.ResponseWriter, r *http.Request) {
 	namespace := mux.Vars(r)["ns"]
 	path, ref := pathAndRef(r)
 
-	tag := r.URL.Query().Get("tag")
+	tag, err := readSingularFromQueryOrBody(r, "tag")
+	if err != nil {
+		respond(w, nil, err)
+		return
+	}
 
 	in := &grpc.RetagRequest{
 		Namespace: namespace,

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -655,62 +655,28 @@ func (s *Server) logMiddleware(h http.Handler) http.Handler {
 
 }
 
-//	readFromQueryOrBody : Reads keys passed in params from query and body
-//	and returns a map of those keys to corresponding read values.
-func readFromQueryOrBody(r *http.Request, keys []string) (map[string]string, error){
-	data := make(map[string]string)
-	in := make(map[string]string)
-	readOnce := false
-
-	for _, key := range keys{
-		value := r.URL.Query().Get(key)
-		if value == ""{
-
-			if !readOnce {
-				readOnce = true
-				err := unmarshalBody(r, &in)
-				if err == io.EOF {
-					return data, fmt.Errorf("%s is missing from query and body", key)
-				} else if err != nil {
-					return data, err
-				}
-			}
-
-			if val, ok := in[key]; ok {
-				data[key] = val
-			} else {
-				return data, fmt.Errorf("%s is missing from query and body", key)
-			}
-		} else {
-			data[key] = value
-		}
-	}
-
-	return data, nil
-}
-
 //	readSingularFromQueryOrBody : Reads a single key passed in params from 
 //	query and body and returns value of that key to corresponding read values.
-//
-//	Note: For reading multiple keys readFromQueryOrBody should be
-//  used to reduce body reads.
 func readSingularFromQueryOrBody(r *http.Request, key string) (string, error){
 	in := make(map[string]string)
 
 	value := r.URL.Query().Get(key)
-	if value == "" {
-		err := unmarshalBody(r, &in)
-		if err == io.EOF {
-			return "", fmt.Errorf("%s is missing from query and body", key)
-		} else if err != nil {
-			return "", err
+
+	err := unmarshalBody(r, &in)
+	if err == io.EOF && value == ""{
+		return "", fmt.Errorf("%s is missing from query and body", key)
+	} else if err != nil && err != io.EOF{
+		return "", err
+	}
+
+	if val, ok := in[key]; ok {
+		if value != "" {
+			return "", fmt.Errorf("%s exists in both query and body", key)
 		}
 
-		if val, ok := in[key]; ok {
-			return val, nil
-		} else {
-			return "", fmt.Errorf("%s is missing from query and body", key)
-		}
+		return val, nil
+	} else if value == "" {
+		return "", fmt.Errorf("%s is missing from query and body", key)
 	}
 
 	return value, nil


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

The tag and retag API operations now support reading `tag` from both query and body. Support for reading from body was added because the `tag` query was causing the API to be falsely flagged by some ad blockers.

Note: The query value of `tag` will be given priority if `tag` is in both query and body.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Tested locally.
