### PR TITLE
CLI Enhancements & Fixes

### DIFF
--- a/cmd/exec/main.go
+++ b/cmd/exec/main.go
@@ -144,13 +144,19 @@ var rootCmd = &cobra.Command{
 }
 
 var setCmd = &cobra.Command{
-	Use: "set ",
+	Use:   "set ",
+	Short: "Change remote node permissions to writable or readonly",
 }
 
 var setWritableCmd = &cobra.Command{
 	Use:   "writable WORKFLOW_PATH|DIR_PATH",
 	Short: "Sets local workflow or dir to writable in remote direktiv server.",
-	Args:  cobra.ExactArgs(1),
+	Long: `"Sets local workflow or dir to writable in remote direktiv server.
+
+EXAMPLE: 
+  set writable helloworld.yaml --addr http://192.168.1.1 --namespace admin
+`,
+	Args: cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		cmdPrepareWorkflow(args[0])
 	},
@@ -202,7 +208,11 @@ var setWritableCmd = &cobra.Command{
 var setReadonlyCmd = &cobra.Command{
 	Use:   "readonly WORKFLOW_PATH|DIR_PATH",
 	Short: "Sets local workflow or dir to readonly in remote direktiv server.",
-	Args:  cobra.ExactArgs(1),
+	Long: `Sets local workflow or dir to readonly in remote direktiv server.
+
+EXAMPLE: 
+  set readonly helloworld.yaml --addr http://192.168.1.1 --namespace admin`,
+	Args: cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		cmdPrepareWorkflow(args[0])
 	},

--- a/cmd/exec/operations.go
+++ b/cmd/exec/operations.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/direktiv/direktiv/pkg/util"
 )
+
+var ErrNotFound = errors.New("Resource was not found")
 
 func setRemoteWorkflowVariable(wfURL string, varName string, varPath string) error {
 	varData, err := safeLoadFile(varPath)
@@ -115,13 +118,8 @@ func recurseMkdirParent(path string) error {
 
 }
 
-func setWritable(path string) error {
-
-	dir, _ := filepath.Split(path)
-	dir = strings.TrimSuffix(dir, "/")
-
-	urlWorkflow = fmt.Sprintf("%s/tree/%s", urlPrefix, strings.TrimPrefix(path, "/"))
-	urlGetNode := fmt.Sprintf("%s", urlWorkflow)
+func getReadOnly(path string) (bool, string, error) {
+	urlGetNode := fmt.Sprintf("%s/tree/%s", urlPrefix, strings.TrimPrefix(path, "/"))
 
 	req, err := http.NewRequest(
 		http.MethodGet,
@@ -129,82 +127,108 @@ func setWritable(path string) error {
 		nil,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create request file: %v", err)
+		return false, "", fmt.Errorf("failed to create request file: %v", err)
 	}
 
 	addAuthHeaders(req)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to send request: %v", err)
+		return false, "", fmt.Errorf("failed to send request: %v", err)
 	}
 
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == http.StatusNotFound {
-			err = setWritable(dir)
+			return false, "", ErrNotFound
+		}
+
+		errBody, err := ioutil.ReadAll(resp.Body)
+		if err == nil {
+			return false, "", fmt.Errorf("failed to get node information, server responsed with %s\n------DUMPING ERROR BODY ------\n%s", resp.Status, string(errBody))
+		}
+
+		return false, "", fmt.Errorf("failed to get node information, server responsed with %s\n------DUMPING ERROR BODY ------\nCould read response body", resp.Status)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to read response: %v", err)
+	}
+
+	m := make(map[string]interface{})
+	err = json.Unmarshal(data, &m)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	x, exists := m["node"]
+	if !exists {
+		return false, "", fmt.Errorf("unexpected response: %v", string(data))
+	}
+
+	m2, ok := x.(map[string]interface{})
+	if !ok {
+		return false, "", fmt.Errorf("unexpected response: %v", string(data))
+	}
+
+	x, exists = m2["readOnly"]
+	if !exists {
+		return false, "", fmt.Errorf("unexpected response: %v", string(data))
+	}
+
+	ro, ok := x.(bool)
+	if !ok {
+		return false, "", fmt.Errorf("unexpected response: %v", string(data))
+	}
+
+	x, exists = m2["expandedType"]
+	if !exists {
+		return ro, "", fmt.Errorf("unexpected response: %v", string(data))
+	}
+
+	et, ok := x.(string)
+	if !ok {
+		return ro, "", fmt.Errorf("unexpected response: %v", string(data))
+	}
+
+	return ro, et, nil
+}
+
+func setWritable(path string, value bool) error {
+
+	dir, _ := filepath.Split(path)
+	dir = strings.TrimSuffix(dir, "/")
+
+	urlWorkflow = fmt.Sprintf("%s/tree/%s", urlPrefix, strings.TrimPrefix(path, "/"))
+
+	isReadOnly, nodeType, err := getReadOnly(path)
+	if err != nil {
+		if err == ErrNotFound {
+			err = setWritable(dir, value)
 			if err != nil {
 				return err
 			}
 			return nil
 		}
 
-		errBody, err := ioutil.ReadAll(resp.Body)
-		if err == nil {
-			return fmt.Errorf("failed to get node information, server responsed with %s\n------DUMPING ERROR BODY ------\n%s", resp.Status, string(errBody))
-		}
-
-		return fmt.Errorf("failed to get node information, server responsed with %s\n------DUMPING ERROR BODY ------\nCould read response body", resp.Status)
+		return err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %v", err)
-	}
-
-	m := make(map[string]interface{})
-	err = json.Unmarshal(data, &m)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal response: %v", err)
-	}
-
-	x, exists := m["node"]
-	if !exists {
-		return fmt.Errorf("unexpected response: %v", string(data))
-	}
-
-	m2, ok := x.(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("unexpected response: %v", string(data))
-	}
-
-	x, exists = m2["readOnly"]
-	if !exists {
-		return fmt.Errorf("unexpected response: %v", string(data))
-	}
-
-	ro, ok := x.(bool)
-	if !ok {
-		return fmt.Errorf("unexpected response: %v", string(data))
-	}
-
-	if ro == false {
+	if isReadOnly != value {
 		return nil
 	}
 
-	x, exists = m2["expandedType"]
-	if !exists {
-		return fmt.Errorf("unexpected response: %v", string(data))
-	}
-
-	et, ok := x.(string)
-	if !ok {
-		return fmt.Errorf("unexpected response: %v", string(data))
-	}
-
-	switch et {
+	switch nodeType {
 	case util.InodeTypeGit:
 
-		urlLockMirror := fmt.Sprintf("%s?op=lock-mirror", urlWorkflow)
+		var operation string
+		if value {
+			operation = "lock-mirror"
+		} else {
+			operation = "unlock-mirror"
+		}
+
+		urlLockMirror := fmt.Sprintf("%s?op=%s", urlWorkflow, operation)
 
 		req, err := http.NewRequest(
 			http.MethodPost,
@@ -233,7 +257,7 @@ func setWritable(path string) error {
 
 	default:
 
-		err = setWritable(dir)
+		err = setWritable(dir, value)
 		if err != nil {
 			return err
 		}
@@ -248,9 +272,21 @@ func updateRemoteWorkflow(path string, localPath string) error {
 
 	printlog("updating namespace: '%s' workflow: '%s'\n", getNamespace(), path)
 
-	err := setWritable(path)
+	isReadOnly, _, err := getReadOnly(path)
 	if err != nil {
-		log.Fatalf("Failed to make writable: %v", err)
+		log.Fatalf("Failed to get node : %v", err)
+	}
+
+	if isReadOnly {
+		var flagSuffix string
+		if config.profile != "" {
+			flagSuffix = " -P=\"" + config.profile + "\""
+		}
+		log.Fatalf(
+			"Cannot update node that is read only.\n"+
+				"To set node to writable use the set command\n"+
+				"Use the example below to set this path to writable:\n\n"+
+				"  direktiv-push set writable %s%s\n\n", cmdArgPath, flagSuffix)
 	}
 
 	err = recurseMkdirParent(path)

--- a/cmd/exec/operations.go
+++ b/cmd/exec/operations.go
@@ -412,3 +412,35 @@ func executeWorkflow(url string) (executeResponse, error) {
 	return instanceDetails, err
 
 }
+
+func pingNamespace() error {
+	urlGetNode := fmt.Sprintf("%s/tree/", urlPrefix)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		urlGetNode,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create request file: %v", err)
+	}
+
+	addAuthHeaders(req)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to ping namespace: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		errBody, err := ioutil.ReadAll(resp.Body)
+		if err == nil {
+			return fmt.Errorf("failed to ping namespace, server responsed with %s\n------DUMPING ERROR BODY ------\n%s", resp.Status, string(errBody))
+		}
+
+		return fmt.Errorf("failed to ping namespace, server responsed with %s\n------DUMPING ERROR BODY ------\nCould read response body", resp.Status)
+
+	}
+
+	return nil
+}

--- a/cmd/exec/operations.go
+++ b/cmd/exec/operations.go
@@ -14,7 +14,8 @@ import (
 	"github.com/direktiv/direktiv/pkg/util"
 )
 
-var ErrNotFound = errors.New("Resource was not found")
+var ErrNotFound = errors.New("resource was not found")
+var ErrNodeIsReadOnly = errors.New("resource is read-only")
 
 func setRemoteWorkflowVariable(wfURL string, varName string, varPath string) error {
 	varData, err := safeLoadFile(varPath)
@@ -294,15 +295,7 @@ func updateRemoteWorkflow(path string, localPath string) error {
 	}
 
 	if isReadOnly {
-		var flagSuffix string
-		if config.profile != "" {
-			flagSuffix = " -P=\"" + config.profile + "\""
-		}
-		log.Fatalf(
-			"Cannot update node that is read only.\n"+
-				"To set node to writable use the set command\n"+
-				"Use the example below to set this path to writable:\n\n"+
-				"  direktiv-push set writable %s%s\n\n", cmdArgPath, flagSuffix)
+		return ErrNodeIsReadOnly
 	}
 
 	err = recurseMkdirParent(path)


### PR DESCRIPTION
## Description

Fixes: https://github.com/direktiv/direktiv/issues/604 - Flag `--no-push` added to exec command
Fixes: https://github.com/direktiv/direktiv/issues/596 - Automatically setting nodes to writable on push removed and instead cli will error and report to user that node is readOnly. `set readonly` and `set writable` commands added to change permissions of remote nodes.

Additional Bug Fix: Checking the readOnly status of a node in a namespace that doesnt exist was causing a infinite loop. To prevent this the namespace is "pinged" in the root command pre-run now.