### PR TITLE
Puts all user-facing logs into a queue so that main-logic can continu…

### DIFF
--- a/pkg/flow/logs.go
+++ b/pkg/flow/logs.go
@@ -14,73 +14,190 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func (srv *server) logToServer(ctx context.Context, t time.Time, msg string, a ...interface{}) {
+type logMessage struct {
+	ctx context.Context
+	t   time.Time
+	msg string
+	ns  *ent.Namespace
+	wf  *wfData
+	in  *ent.Instance
+}
+
+func (srv *server) startLogWorkers(n int) {
+	srv.logWorkersWG.Add(n)
+	for i := 0; i < n; i++ {
+		go srv.logWorker()
+	}
+}
+
+func (srv *server) logWorker() {
+
+	defer srv.logWorkersWG.Done()
+
+	for {
+
+		l, more := <-srv.logQueue
+		if !more {
+			return
+		}
+
+		if l.in != nil {
+			srv.workerLogToInstance(l)
+		} else if l.wf != nil {
+			srv.workerLogToWorkflow(l)
+		} else if l.ns != nil {
+			srv.workerLogToNamespace(l)
+		} else {
+			srv.workerLogToServer(l)
+		}
+
+	}
+
+}
+
+func (srv *server) closeLogWorkers() {
+	close(srv.logQueue)
+	srv.logWorkersWG.Wait()
+}
+
+func (srv *server) workerLogToServer(l *logMessage) {
 
 	logc := srv.db.LogMsg
 
-	msg = fmt.Sprintf(msg, a...)
+	util.Trace(l.ctx, l.msg)
 
-	util.Trace(ctx, msg)
-
-	_, err := logc.Create().SetMsg(msg).SetT(t).Save(ctx)
+	_, err := logc.Create().SetMsg(l.msg).SetT(l.t).Save(context.Background())
 	if err != nil {
 		srv.sugar.Error(err)
 		return
 	}
 
-	span := trace.SpanFromContext(ctx)
+	span := trace.SpanFromContext(l.ctx)
 	tid := span.SpanContext().TraceID()
 
-	srv.sugar.Infow(msg, "trace", tid)
+	srv.sugar.Infow(l.msg, "trace", tid)
 
 	srv.pubsub.NotifyServerLogs()
 
 }
 
-func (srv *server) logToNamespace(ctx context.Context, t time.Time, ns *ent.Namespace, msg string, a ...interface{}) {
+func (srv *server) workerLogToNamespace(l *logMessage) {
 
 	logc := srv.db.LogMsg
 
-	msg = fmt.Sprintf(msg, a...)
+	util.Trace(l.ctx, l.msg)
 
-	util.Trace(ctx, msg)
-
-	_, err := logc.Create().SetMsg(msg).SetNamespace(ns).SetT(t).Save(ctx)
+	_, err := logc.Create().SetMsg(l.msg).SetNamespace(l.ns).SetT(l.t).Save(context.Background())
 	if err != nil {
 		srv.sugar.Error(err)
 		return
 	}
 
-	span := trace.SpanFromContext(ctx)
+	span := trace.SpanFromContext(l.ctx)
 	tid := span.SpanContext().TraceID()
 
-	srv.sugar.Infow(msg, "trace", tid, "namespace", ns.Name, "namespace-id", ns.ID.String())
+	srv.sugar.Infow(l.msg, "trace", tid, "namespace", l.ns.Name, "namespace-id", l.ns.ID.String())
 
-	srv.pubsub.NotifyNamespaceLogs(ns)
+	srv.pubsub.NotifyNamespaceLogs(l.ns)
+
+}
+
+func (srv *server) workerLogToWorkflow(l *logMessage) {
+
+	logc := srv.db.LogMsg
+
+	util.Trace(l.ctx, l.msg)
+
+	_, err := logc.Create().SetMsg(l.msg).SetWorkflow(l.wf.wf).SetT(l.t).Save(context.Background())
+	if err != nil {
+		srv.sugar.Error(err)
+		return
+	}
+
+	span := trace.SpanFromContext(l.ctx)
+	tid := span.SpanContext().TraceID()
+
+	ns := l.wf.wf.Edges.Namespace
+	srv.sugar.Infow(l.msg, "trace", tid, "namespace", ns.Name, "namespace-id", ns.ID.String(), "workflow-id", l.wf.wf.ID.String(), "workflow", GetInodePath(l.wf.path))
+
+	srv.pubsub.NotifyWorkflowLogs(l.wf.wf)
+
+}
+
+func (srv *server) workerLogToInstance(l *logMessage) {
+
+	logc := srv.db.LogMsg
+
+	util.Trace(l.ctx, l.msg)
+
+	_, err := logc.Create().SetMsg(l.msg).SetInstance(l.in).SetT(l.t).Save(context.Background())
+	if err != nil {
+		srv.sugar.Error(err)
+		return
+	}
+
+	span := trace.SpanFromContext(l.ctx)
+	tid := span.SpanContext().TraceID()
+
+	nsid := ""
+	nsname := ""
+	if l.in.Edges.Namespace != nil {
+		nsid = l.in.Edges.Namespace.ID.String()
+		nsname = l.in.Edges.Namespace.Name
+	}
+
+	wfid := ""
+	if l.in.Edges.Workflow != nil {
+		wfid = l.in.Edges.Workflow.ID.String()
+	}
+
+	srv.sugar.Infow(l.msg, "trace", tid, "namespace", nsname, "namespace-id", nsid, "workflow-id", wfid, "workflow", GetInodePath(l.in.As), "instance", l.in.ID.String())
+
+	srv.pubsub.NotifyInstanceLogs(l.in)
+
+}
+
+func (srv *server) logToServer(ctx context.Context, t time.Time, msg string, a ...interface{}) {
+
+	defer func() {
+		_ = recover()
+	}()
+
+	srv.logQueue <- &logMessage{
+		ctx: ctx,
+		t:   t,
+		msg: fmt.Sprintf(msg, a...),
+	}
+
+}
+
+func (srv *server) logToNamespace(ctx context.Context, t time.Time, ns *ent.Namespace, msg string, a ...interface{}) {
+
+	defer func() {
+		_ = recover()
+	}()
+
+	srv.logQueue <- &logMessage{
+		ctx: ctx,
+		t:   t,
+		msg: fmt.Sprintf(msg, a...),
+		ns:  ns,
+	}
 
 }
 
 func (srv *server) logToWorkflow(ctx context.Context, t time.Time, d *wfData, msg string, a ...interface{}) {
 
-	logc := srv.db.LogMsg
+	defer func() {
+		_ = recover()
+	}()
 
-	msg = fmt.Sprintf(msg, a...)
-
-	util.Trace(ctx, msg)
-
-	_, err := logc.Create().SetMsg(msg).SetWorkflow(d.wf).SetT(t).Save(ctx)
-	if err != nil {
-		srv.sugar.Error(err)
-		return
+	srv.logQueue <- &logMessage{
+		ctx: ctx,
+		t:   t,
+		msg: fmt.Sprintf(msg, a...),
+		wf:  d,
 	}
-
-	span := trace.SpanFromContext(ctx)
-	tid := span.SpanContext().TraceID()
-
-	ns := d.wf.Edges.Namespace
-	srv.sugar.Infow(msg, "trace", tid, "namespace", ns.Name, "namespace-id", ns.ID.String(), "workflow-id", d.wf.ID.String(), "workflow", GetInodePath(d.path))
-
-	srv.pubsub.NotifyWorkflowLogs(d.wf)
 
 }
 
@@ -90,38 +207,23 @@ func (srv *server) logToInstance(ctx context.Context, t time.Time, in *ent.Insta
 	msg = fmt.Sprintf(msg, a...)
 
 	srv.logToInstanceRaw(ctx, t, in, msg)
+
 }
 
 // log To instance with raw string
 func (srv *server) logToInstanceRaw(ctx context.Context, t time.Time, in *ent.Instance, msg string) {
-	logc := srv.db.LogMsg
 
-	util.Trace(ctx, msg)
+	defer func() {
+		_ = recover()
+	}()
 
-	_, err := logc.Create().SetMsg(msg).SetInstance(in).SetT(t).Save(ctx)
-	if err != nil {
-		srv.sugar.Error(err)
-		return
+	srv.logQueue <- &logMessage{
+		ctx: ctx,
+		t:   t,
+		msg: msg,
+		in:  in,
 	}
 
-	span := trace.SpanFromContext(ctx)
-	tid := span.SpanContext().TraceID()
-
-	nsid := ""
-	nsname := ""
-	if in.Edges.Namespace != nil {
-		nsid = in.Edges.Namespace.ID.String()
-		nsname = in.Edges.Namespace.Name
-	}
-
-	wfid := ""
-	if in.Edges.Workflow != nil {
-		wfid = in.Edges.Workflow.ID.String()
-	}
-
-	srv.sugar.Infow(msg, "trace", tid, "namespace", nsname, "namespace-id", nsid, "workflow-id", wfid, "workflow", GetInodePath(in.As), "instance", in.ID.String())
-
-	srv.pubsub.NotifyInstanceLogs(in)
 }
 
 func (engine *engine) UserLog(ctx context.Context, im *instanceMemory, msg string, a ...interface{}) {


### PR DESCRIPTION
…e without waiting for the database operation to complete.

Relating to #688 

This should result in a minor improvement in instance execution time. 

Signed-off-by: Alan Murtagh <alan.murtagh@direktiv.io>