### PR TITLE
allow retrigger events which id field includes slashes

### DIFF
--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -1502,7 +1502,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	// responses:
 	//   '200':
 	//     "description": "successfully replayed cloud event"
-	r.HandleFunc("/namespaces/{ns}/events/{event}/replay", h.ReplayEvent).Name(RN_NamespaceEvent).Methods(http.MethodPost)
+	r.HandleFunc("/namespaces/{ns}/events/{event:.*}/replay", h.ReplayEvent).Name(RN_NamespaceEvent).Methods(http.MethodPost)
 
 	// swagger:operation POST /api/namespaces/{namespace}/tree/{workflow}?op=set-workflow-event-logging Workflows setWorkflowCloudEventLogs
 	// ---


### PR DESCRIPTION
Signed-off-by: Fxrdf <faissal.farid@direktiv.io>

## Description

extend replayEvent http handler to allow slashes for types
## Purpose

- [x] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)
per insomnia

Broadcast an event which his ID field include slashes and replay it 
## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
