### PR TITLE
combine overwrite and search secrets handler

### DIFF
--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -1288,8 +1288,39 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//   '200':
 	r.HandleFunc("/namespaces/{ns}/eventfilter/{filter}", h.UpdateBroadcastCloudeventFilter).Name(RN_UpdateNamespaceEventFilter).Methods(http.MethodPatch)
 
+	// swagger:operation GET /api/namespaces/{namespace}/eventfilter CloudEventFilter listCloudeventFilter
+	// ---
+	// description: |
+	//   list all existing cloud event filter in target namespace
+	// summary: List existing cloudEventFilters
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// responses:
+	//   '200':
 	r.HandleFunc("/namespaces/{ns}/eventfilter", h.GetCloudeventFilterList).Name(RN_ListNamespaceEventFilters).Methods(http.MethodGet)
 
+	// swagger:operation GET /api/namespaces/{namespace}/eventfilter/{filtername} CloudEventFilter getCloudEventFilter
+	// ---
+	// description: |
+	//   Get specific cloud event filter by given name in target namespace
+	// summary: Get specific cloudEventFilter
+	// parameters:
+	// - in: path
+	//   name: namespace
+	//   type: string
+	//   required: true
+	//   description: 'target namespace'
+	// - in: path
+	//   name: filtername
+	//   type: string
+	//   required: true
+	//   description: 'target filtername'
+	// responses:
+	//   '200':
 	r.HandleFunc("/namespaces/{ns}/eventfilter/{filter}", h.GetCloudEventFilter).Name(RN_GetNamespaceEventFilter).Methods(http.MethodGet)
 
 	// swagger:operation GET /api/namespaces/{namespace}/tree/{workflow}?op=logs Logs getWorkflowLogs

--- a/pkg/api/flow.go
+++ b/pkg/api/flow.go
@@ -992,7 +992,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//       "$ref": '#/definitions/ErrorResponse'
 	r.HandleFunc("/namespaces/{ns}/secrets/{folder:.*[/]$}", h.CreateSecretsFolder).Name(RN_CreateSecretsFolder).Methods(http.MethodPut)
 
-	// swagger:operation POST /api/namespaces/{namespace}/secrets/{secret} Secrets overwriteAndSearchSecret
+	// swagger:operation PATCH /api/namespaces/{namespace}/secrets/{secret} Secrets overwriteAndSearchSecret
 	// ---
 	// description: |
 	//   Overwrite a namespace secret
@@ -1028,7 +1028,7 @@ func (h *flowHandler) initRoutes(r *mux.Router) {
 	//     description: secret not found
 	//     schema:
 	//       "$ref": '#/definitions/ErrorResponse'
-	r.HandleFunc("/namespaces/{ns}/secrets/{secret:.*[^/]$}", h.OverwriteSecret).Name(RN_OverwriteSecret).Methods(http.MethodPost)
+	r.HandleFunc("/namespaces/{ns}/secrets/{secret:.*[^/]$}", h.OverwriteSecret).Name(RN_OverwriteSecret).Methods(http.MethodPatch)
 
 	// swagger:operation GET /api/namespaces/{namespace}/instances/{instance} Instances getInstance
 	// ---

--- a/scripts/api/api.md
+++ b/scripts/api/api.md
@@ -51,6 +51,8 @@ Direktiv Documentation can be found at https://docs.direktiv.io/
 |---------|---------|--------|---------|
 | PUT | /api/namespaces/{namespace}/eventfilter/{filtername} | [create cloudevent filter](#create-cloudevent-filter) | Creates new cloudEventFilter |
 | DELETE | /api/namespaces/{namespace}/broadcast/{filtername} | [delete cloudevent filter](#delete-cloudevent-filter) | Delete existing cloudEventFilter |
+| GET | /api/namespaces/{namespace}/eventfilter/{filtername} | [get cloud event filter](#get-cloud-event-filter) | Get specific cloudEventFilter |
+| GET | /api/namespaces/{namespace}/eventfilter | [list cloudevent filter](#list-cloudevent-filter) | List existing cloudEventFilters |
 | PATCH | /api/namespaces/{namespace}/eventfilter/{filtername} | [update cloudevent filter](#update-cloudevent-filter) | Update existing cloudEventFilter |
   
 
@@ -195,10 +197,9 @@ Direktiv Documentation can be found at https://docs.direktiv.io/
 | PUT | /api/namespaces/{namespace}/secrets/{secret} | [create secret](#create-secret) | Create a Namespace Secret |
 | DELETE | /api/namespaces/{namespace}/secrets/{folder} | [delete folder](#delete-folder) | Delete a Namespace Folder |
 | DELETE | /api/namespaces/{namespace}/secrets/{secret} | [delete secret](#delete-secret) | Delete a Namespace Secret |
-| GET | /api/namespaces/{namespace}/secrets | [get secrets](#get-secrets) | Get List of Namespace Secrets |
+| GET | /api/namespaces/{namespace}/secrets | [get secrets](#get-secrets) | Get List of Namespace Secrets or Search for Namespace Secrets by given name |
 | GET | /api/namespaces/{namespace}/secrets/{folder} | [get secrets inside folder](#get-secrets-inside-folder) | Get List of Namespace nodes inside Folder |
-| PATCH | /api/namespaces/{namespace}/secrets/{secret} | [overwrite and search secret](#overwrite-and-search-secret) | Overwrite a Namespace Secret or Search for a Secret by given Name. Set op query param for search function like /api/namespaces/{namespace}/secrets/{name}?op=name |
-| GET | /api/namespaces/search/{namespace}/secrets/{name} | [search secret](#search-secret) | Get List of Namespace nodes contains name |
+| PATCH | /api/namespaces/{namespace}/secrets/{secret} | [overwrite and search secret](#overwrite-and-search-secret) | Overwrite a Namespace Secret |
   
 
 
@@ -1276,6 +1277,36 @@ an error has occurred
 
 [ErrorResponse](#error-response)
 
+### <span id="get-cloud-event-filter"></span> Get specific cloudEventFilter (*getCloudEventFilter*)
+
+```
+GET /api/namespaces/{namespace}/eventfilter/{filtername}
+```
+
+Get specific cloud event filter by given name in target namespace
+
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| filtername | `path` | string | `string` |  | ✓ |  | target filtername |
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+
+#### All responses
+
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#get-cloud-event-filter-200) | OK |  |  | [schema](#get-cloud-event-filter-200-schema) |
+
+#### Responses
+
+
+##### <span id="get-cloud-event-filter-200"></span> 200
+Status: OK
+
+###### <span id="get-cloud-event-filter-200-schema"></span> Schema
+
 ### <span id="get-event-history"></span> Get events history. (*getEventHistory*)
 
 ```
@@ -1814,13 +1845,13 @@ Status: OK
 
 ###### <span id="get-registries-200-schema"></span> Schema
 
-### <span id="get-secrets"></span> Get List of Namespace Secrets (*getSecrets*)
+### <span id="get-secrets"></span> Get List of Namespace Secrets or Search for Namespace Secrets by given name (*getSecrets*)
 
 ```
 GET /api/namespaces/{namespace}/secrets
 ```
 
-Gets the list of namespace secrets.
+Gets the list of namespace secrets. Also can use for search by setting query param op=search
 
 
 #### Parameters
@@ -2203,6 +2234,35 @@ Status: Internal Server Error
 
 
 
+### <span id="list-cloudevent-filter"></span> List existing cloudEventFilters (*listCloudeventFilter*)
+
+```
+GET /api/namespaces/{namespace}/eventfilter
+```
+
+list all existing cloud event filter in target namespace
+
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+
+#### All responses
+
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#list-cloudevent-filter-200) | OK |  |  | [schema](#list-cloudevent-filter-200-schema) |
+
+#### Responses
+
+
+##### <span id="list-cloudevent-filter-200"></span> 200
+Status: OK
+
+###### <span id="list-cloudevent-filter-200-schema"></span> Schema
+
 ### <span id="list-namespace-service-revision-pods"></span> Get Namespace Service Revision Pods List (*listNamespaceServiceRevisionPods*)
 
 ```
@@ -2449,13 +2509,13 @@ Status: OK
 
 ###### <span id="namespace-metrics-successful-200-schema"></span> Schema
 
-### <span id="overwrite-and-search-secret"></span> Overwrite a Namespace Secret or Search for a Secret by given Name. Set op query param for search function like /api/namespaces/{namespace}/secrets/{name}?op=name (*overwriteAndSearchSecret*)
+### <span id="overwrite-and-search-secret"></span> Overwrite a Namespace Secret (*overwriteAndSearchSecret*)
 
 ```
 PATCH /api/namespaces/{namespace}/secrets/{secret}
 ```
 
-Overwrite a namespace secret, or search for a search secret which contains by given name
+Overwrite a namespace secret
 
 
 #### Consumes
@@ -2467,7 +2527,7 @@ Overwrite a namespace secret, or search for a search secret which contains by gi
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 | secret | `path` | string | `string` |  | ✓ |  | target secret |
-| Secret Payload | `body` | string | `string` | | ✓ | | Payload that contains secret data, when using search functions its not necessary |
+| Secret Payload | `body` | string | `string` | | ✓ | | Payload that contains secret data |
 
 #### All responses
 
@@ -2555,50 +2615,6 @@ Replay a cloud event to a namespace.
 Status: OK
 
 ###### <span id="replay-cloudevent-200-schema"></span> Schema
-
-### <span id="search-secret"></span> Get List of Namespace nodes contains name (*searchSecret*)
-
-```
-GET /api/namespaces/search/{namespace}/secrets/{name}
-```
-
-secrets and folders which including given name.
-
-
-#### Parameters
-
-| Name | Source | Type | Go type | Separator | Required | Default | Description |
-|------|--------|------|---------|-----------| :------: |---------|-------------|
-| name | `path` | string | `string` |  | ✓ |  | target name |
-| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
-
-#### All responses
-
-| Code | Status | Description | Has headers | Schema |
-|------|--------|-------------|:-----------:|--------|
-| [200](#search-secret-200) | OK | successfully got namespace nodes |  | [schema](#search-secret-200-schema) |
-| [default](#search-secret-default) | | an error has occurred |  | [schema](#search-secret-default-schema) |
-
-#### Responses
-
-
-##### <span id="search-secret-200"></span> 200 - successfully got namespace nodes
-Status: OK
-
-###### <span id="search-secret-200-schema"></span> Schema
-   
-  
-
-[OkBody](#ok-body)
-
-##### <span id="search-secret-default"></span> Default Response
-an error has occurred
-
-###### <span id="search-secret-default-schema"></span> Schema
-
-  
-
-[ErrorResponse](#error-response)
 
 ### <span id="server-logs"></span> Get Direktiv Server Logs (*serverLogs*)
 

--- a/scripts/api/api.md
+++ b/scripts/api/api.md
@@ -45,6 +45,16 @@ Direktiv Documentation can be found at https://docs.direktiv.io/
 
 ## All endpoints
 
+###  cloud_event_filter
+
+| Method  | URI     | Name   | Summary |
+|---------|---------|--------|---------|
+| PUT | /api/namespaces/{namespace}/eventfilter/{filtername} | [create cloudevent filter](#create-cloudevent-filter) | Creates new cloudEventFilter |
+| DELETE | /api/namespaces/{namespace}/broadcast/{filtername} | [delete cloudevent filter](#delete-cloudevent-filter) | Delete existing cloudEventFilter |
+| PATCH | /api/namespaces/{namespace}/eventfilter/{filtername} | [update cloudevent filter](#update-cloudevent-filter) | Update existing cloudEventFilter |
+  
+
+
 ###  directory
 
 | Method  | URI     | Name   | Summary |
@@ -152,6 +162,7 @@ Direktiv Documentation can be found at https://docs.direktiv.io/
 | Method  | URI     | Name   | Summary |
 |---------|---------|--------|---------|
 | POST | /api/namespaces/{namespace}/broadcast | [broadcast cloudevent](#broadcast-cloudevent) | Broadcast Cloud Event |
+| POST | /api/namespaces/{namespace}/broadcast/{filtername} | [broadcast cloudevent filter](#broadcast-cloudevent-filter) | Filter given cloud event and broadcast it |
 | POST | /api/jq | [jq playground](#jq-playground) | JQ Playground api to test jq queries |
 | POST | /api/namespaces/{namespace}/events/{event}/replay | [replay cloudevent](#replay-cloudevent) | Replay Cloud Event |
 | GET | /api/version | [version](#version) | Returns version information for servers in the cluster. |
@@ -186,7 +197,7 @@ Direktiv Documentation can be found at https://docs.direktiv.io/
 | DELETE | /api/namespaces/{namespace}/secrets/{secret} | [delete secret](#delete-secret) | Delete a Namespace Secret |
 | GET | /api/namespaces/{namespace}/secrets | [get secrets](#get-secrets) | Get List of Namespace Secrets |
 | GET | /api/namespaces/{namespace}/secrets/{folder} | [get secrets inside folder](#get-secrets-inside-folder) | Get List of Namespace nodes inside Folder |
-| PUT | /api/namespaces/overwrite/{namespace}/secrets/{secret} | [overwrite secret](#overwrite-secret) | Overwrite a Namespace Secret |
+| PATCH | /api/namespaces/{namespace}/secrets/{secret} | [overwrite and search secret](#overwrite-and-search-secret) | Overwrite a Namespace Secret or Search for a Secret by given Name. Set op query param for search function like /api/namespaces/{namespace}/secrets/{name}?op=name |
 | GET | /api/namespaces/search/{namespace}/secrets/{name} | [search secret](#search-secret) | Get List of Namespace nodes contains name |
   
 
@@ -344,6 +355,39 @@ Status: OK
 
 ###### <span id="broadcast-cloudevent-200-schema"></span> Schema
 
+### <span id="broadcast-cloudevent-filter"></span> Filter given cloud event and broadcast it (*broadcastCloudeventFilter*)
+
+```
+POST /api/namespaces/{namespace}/broadcast/{filtername}
+```
+
+Filter cloud event by given filtername and broadcast to a namespace.
+Cloud events posted to this api will filter cloud event by given filtername and be picked up by any workflows listening to the same event type on the namescape.
+The body of this request should follow the cloud event core specification defined at https://github.com/cloudevents/spec .
+
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| filtername | `path` | string | `string` |  | ✓ |  | target filtername |
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| cloudevent | `body` | [interface{}](#interface) | `interface{}` | | ✓ | | Cloud Event request to be sent. |
+
+#### All responses
+
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#broadcast-cloudevent-filter-200) | OK |  |  | [schema](#broadcast-cloudevent-filter-200-schema) |
+
+#### Responses
+
+
+##### <span id="broadcast-cloudevent-filter-200"></span> 200
+Status: OK
+
+###### <span id="broadcast-cloudevent-filter-200-schema"></span> Schema
+
 ### <span id="cancel-instance"></span> Cancel a Pending Instance (*cancelInstance*)
 
 ```
@@ -373,6 +417,38 @@ Cancel a currently pending instance.
 Status: OK
 
 ###### <span id="cancel-instance-200-schema"></span> Schema
+
+### <span id="create-cloudevent-filter"></span> Creates new cloudEventFilter (*createCloudeventFilter*)
+
+```
+PUT /api/namespaces/{namespace}/eventfilter/{filtername}
+```
+
+Creates new cloud event filter in target namespace
+The body of this request should be a compilable javascript code without function header.
+
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| filtername | `path` | string | `string` |  | ✓ |  | new filtername |
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| script | `body` | [interface{}](#interface) | `interface{}` | | ✓ | | compilable javascript code. |
+
+#### All responses
+
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#create-cloudevent-filter-200) | OK |  |  | [schema](#create-cloudevent-filter-200-schema) |
+
+#### Responses
+
+
+##### <span id="create-cloudevent-filter-200"></span> 200
+Status: OK
+
+###### <span id="create-cloudevent-filter-200-schema"></span> Schema
 
 ### <span id="create-directory"></span> Create a Directory (*createDirectory*)
 
@@ -709,6 +785,36 @@ an error has occurred
   
 
 [ErrorResponse](#error-response)
+
+### <span id="delete-cloudevent-filter"></span> Delete existing cloudEventFilter (*deleteCloudeventFilter*)
+
+```
+DELETE /api/namespaces/{namespace}/broadcast/{filtername}
+```
+
+Delete existing cloud event filter in target namespace
+
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| filtername | `path` | string | `string` |  | ✓ |  | target filtername |
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+
+#### All responses
+
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#delete-cloudevent-filter-200) | OK |  |  | [schema](#delete-cloudevent-filter-200-schema) |
+
+#### Responses
+
+
+##### <span id="delete-cloudevent-filter-200"></span> 200
+Status: OK
+
+###### <span id="delete-cloudevent-filter-200-schema"></span> Schema
 
 ### <span id="delete-folder"></span> Delete a Namespace Folder (*deleteFolder*)
 
@@ -2343,13 +2449,13 @@ Status: OK
 
 ###### <span id="namespace-metrics-successful-200-schema"></span> Schema
 
-### <span id="overwrite-secret"></span> Overwrite a Namespace Secret (*overwriteSecret*)
+### <span id="overwrite-and-search-secret"></span> Overwrite a Namespace Secret or Search for a Secret by given Name. Set op query param for search function like /api/namespaces/{namespace}/secrets/{name}?op=name (*overwriteAndSearchSecret*)
 
 ```
-PUT /api/namespaces/overwrite/{namespace}/secrets/{secret}
+PATCH /api/namespaces/{namespace}/secrets/{secret}
 ```
 
-Overwrite a namespace secret.
+Overwrite a namespace secret, or search for a search secret which contains by given name
 
 
 #### Consumes
@@ -2361,31 +2467,31 @@ Overwrite a namespace secret.
 |------|--------|------|---------|-----------| :------: |---------|-------------|
 | namespace | `path` | string | `string` |  | ✓ |  | target namespace |
 | secret | `path` | string | `string` |  | ✓ |  | target secret |
-| Secret Payload | `body` | string | `string` | | ✓ | | Payload that contains secret data. |
+| Secret Payload | `body` | string | `string` | | ✓ | | Payload that contains secret data, when using search functions its not necessary |
 
 #### All responses
 
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
-| [200](#overwrite-secret-200) | OK | namespace has been successfully overwritten |  | [schema](#overwrite-secret-200-schema) |
-| [default](#overwrite-secret-default) | | secret not found |  | [schema](#overwrite-secret-default-schema) |
+| [200](#overwrite-and-search-secret-200) | OK | namespace has been successfully overwritten |  | [schema](#overwrite-and-search-secret-200-schema) |
+| [default](#overwrite-and-search-secret-default) | | secret not found |  | [schema](#overwrite-and-search-secret-default-schema) |
 
 #### Responses
 
 
-##### <span id="overwrite-secret-200"></span> 200 - namespace has been successfully overwritten
+##### <span id="overwrite-and-search-secret-200"></span> 200 - namespace has been successfully overwritten
 Status: OK
 
-###### <span id="overwrite-secret-200-schema"></span> Schema
+###### <span id="overwrite-and-search-secret-200-schema"></span> Schema
    
   
 
 [OkBody](#ok-body)
 
-##### <span id="overwrite-secret-default"></span> Default Response
+##### <span id="overwrite-and-search-secret-default"></span> Default Response
 secret not found
 
-###### <span id="overwrite-secret-default-schema"></span> Schema
+###### <span id="overwrite-and-search-secret-default-schema"></span> Schema
 
   
 
@@ -2852,6 +2958,37 @@ Status: OK
 
 
 
+### <span id="update-cloudevent-filter"></span> Update existing cloudEventFilter (*updateCloudeventFilter*)
+
+```
+PATCH /api/namespaces/{namespace}/eventfilter/{filtername}
+```
+
+Update existing cloud event filter in target namespace
+
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| filtername | `path` | string | `string` |  | ✓ |  | target filtername |
+| namespace | `path` | string | `string` |  | ✓ |  | target namespace |
+| script | `body` | [interface{}](#interface) | `interface{}` | | ✓ | | compilable javascript code. |
+
+#### All responses
+
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#update-cloudevent-filter-200) | OK |  |  | [schema](#update-cloudevent-filter-200-schema) |
+
+#### Responses
+
+
+##### <span id="update-cloudevent-filter-200"></span> 200
+Status: OK
+
+###### <span id="update-cloudevent-filter-200-schema"></span> Schema
+
 ### <span id="update-namespace-service"></span> Create Namespace Service Revision (*updateNamespaceService*)
 
 ```
@@ -3189,73 +3326,10 @@ Status: OK
 
 ## Models
 
-### <span id="create-namespace-service-body"></span> CreateNamespaceServiceBody
-
-
-> CreateNamespaceServiceBody create namespace service body
-
-**Example**
-```
-{"cmd":"","image":"direktiv/request:v12","minScale":"1","name":"fast-request","size":"small"}
-```
-  
-
-
-
-[interface{}](#interface)
-
-### <span id="create-registry-body"></span> CreateRegistryBody
-
-
-> CreateRegistryBody create registry body
-
-**Example**
-```
-{"data":"admin:8QwFLg%D$qg*","reg":"https://prod.customreg.io"}
-```
-  
-
-
-
-[interface{}](#interface)
-
-### <span id="delete-registry-body"></span> DeleteRegistryBody
-
-
-> DeleteRegistryBody delete registry body
-
-**Example**
-```
-{"data":"admin:8QwFLg%D$qg*","reg":"https://prod.customreg.io"}
-```
-  
-
-
-
-[interface{}](#interface)
-
 ### <span id="error-response"></span> ErrorResponse
 
 
-> ErrorResponse error response
   
-
-
-
-[interface{}](#interface)
-
-### <span id="jq-playground-body"></span> JqPlaygroundBody
-
-
-> JqPlaygroundBody jq playground body
-
-**Example**
-```
-{"data":"eyJhIjogMSwgImIiOiAyLCAiYyI6IDQsICJkIjogN30=","query":"map(select(. \u003e= 2))"}
-```
-  
-
-
 
 [interface{}](#interface)
 
@@ -3269,95 +3343,10 @@ Status: OK
 
 [interface{}](#interface)
 
-### <span id="set-namespace-config-body"></span> SetNamespaceConfigBody
-
-
-> SetNamespaceConfigBody set namespace config body
-
-**Example**
-```
-{"broadcast":{"directory.create":false,"directory.delete":false,"instance.failed":false,"instance.started":false,"instance.success":false,"instance.variable.create":false,"instance.variable.delete":false,"instance.variable.update":false,"namespace.variable.create":false,"namespace.variable.delete":false,"namespace.variable.update":false,"workflow.create":false,"workflow.delete":false,"workflow.update":false,"workflow.variable.create":false,"workflow.variable.delete":false,"workflow.variable.update":false}}
-```
-  
-
-
-
-[interface{}](#interface)
-
-### <span id="set-workflow-cloud-event-logs-body"></span> SetWorkflowCloudEventLogsBody
-
-
-> SetWorkflowCloudEventLogsBody set workflow cloud event logs body
-
-**Example**
-```
-{"logger":"mylog"}
-```
-  
-
-
-
-[interface{}](#interface)
-
-### <span id="test-registry-body"></span> TestRegistryBody
-
-
-> TestRegistryBody test registry body
-
-**Example**
-```
-{"token":"8QwFLg%D$qg*","url":"https://prod.customreg.io","username":"admin"}
-```
-  
-
-
-
-[interface{}](#interface)
-
-### <span id="toggle-workflow-body"></span> ToggleWorkflowBody
-
-
-> ToggleWorkflowBody toggle workflow body
-
-**Example**
-```
-{"live":false}
-```
-  
-
-
-
-[interface{}](#interface)
-
-### <span id="update-namespace-service-body"></span> UpdateNamespaceServiceBody
-
-
-> UpdateNamespaceServiceBody update namespace service body
-
-**Example**
-```
-{"cmd":"","image":"direktiv/request:v10","minScale":"1","size":"small"}
-```
-  
-
-
-
-[interface{}](#interface)
-
-### <span id="update-service-request"></span> UpdateServiceRequest
-
-
-> UpdateServiceRequest UpdateServiceRequest UpdateServiceRequest update service request
-  
-
-
-
-[interface{}](#interface)
-
 ### <span id="update-service-request"></span> updateServiceRequest
 
 
-> UpdateServiceRequest UpdateServiceRequest update service request
+> UpdateServiceRequest update service request
   
 
 

--- a/scripts/api/swagger.json
+++ b/scripts/api/swagger.json
@@ -1001,59 +1001,6 @@
         }
       }
     },
-    "/api/namespaces/overwrite/{namespace}/secrets/{secret}": {
-      "put": {
-        "description": "Overwrite a namespace secret.\n",
-        "consumes": [
-          "text/plain"
-        ],
-        "tags": [
-          "Secrets"
-        ],
-        "summary": "Overwrite a Namespace Secret",
-        "operationId": "overwriteSecret",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "target namespace",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "target secret",
-            "name": "secret",
-            "in": "path",
-            "required": true
-          },
-          {
-            "description": "Payload that contains secret data.",
-            "name": "Secret Payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "7F8E7B0124ACB2BD20B383DE0756C7C0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "namespace has been successfully overwritten",
-            "schema": {
-              "$ref": "#/definitions/OkBody"
-            }
-          },
-          "default": {
-            "description": "secret not found",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          }
-        }
-      }
-    },
     "/api/namespaces/search/{namespace}/secrets/{name}": {
       "get": {
         "description": "secrets and folders which including given name.\n",
@@ -1197,6 +1144,75 @@
         }
       }
     },
+    "/api/namespaces/{namespace}/broadcast/{filtername}": {
+      "post": {
+        "description": "Filter cloud event by given filtername and broadcast to a namespace.\nCloud events posted to this api will filter cloud event by given filtername and be picked up by any workflows listening to the same event type on the namescape.\nThe body of this request should follow the cloud event core specification defined at https://github.com/cloudevents/spec .\n",
+        "tags": [
+          "Other"
+        ],
+        "summary": "Filter given cloud event and broadcast it",
+        "operationId": "broadcastCloudeventFilter",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target filtername",
+            "name": "filtername",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Cloud Event request to be sent.",
+            "name": "cloudevent",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete existing cloud event filter in target namespace\n",
+        "tags": [
+          "CloudEventFilter"
+        ],
+        "summary": "Delete existing cloudEventFilter",
+        "operationId": "deleteCloudeventFilter",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target filtername",
+            "name": "filtername",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/api/namespaces/{namespace}/config": {
       "get": {
         "description": "Gets a namespace config.\n",
@@ -1298,6 +1314,84 @@
         "responses": {
           "200": {
             "description": "successfully got event listeners"
+          }
+        }
+      }
+    },
+    "/api/namespaces/{namespace}/eventfilter/{filtername}": {
+      "put": {
+        "description": "Creates new cloud event filter in target namespace\nThe body of this request should be a compilable javascript code without function header.\n",
+        "tags": [
+          "CloudEventFilter"
+        ],
+        "summary": "Creates new cloudEventFilter",
+        "operationId": "createCloudeventFilter",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "new filtername",
+            "name": "filtername",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "compilable javascript code.",
+            "name": "script",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "patch": {
+        "description": "Update existing cloud event filter in target namespace\n",
+        "tags": [
+          "CloudEventFilter"
+        ],
+        "summary": "Update existing cloudEventFilter",
+        "operationId": "updateCloudeventFilter",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target filtername",
+            "name": "filtername",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "compilable javascript code.",
+            "name": "script",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
           }
         }
       }
@@ -2182,6 +2276,57 @@
         "responses": {
           "200": {
             "description": "namespace secret has been successfully deleted",
+            "schema": {
+              "$ref": "#/definitions/OkBody"
+            }
+          },
+          "default": {
+            "description": "secret not found",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Overwrite a namespace secret, or search for a search secret which contains by given name\n",
+        "consumes": [
+          "text/plain"
+        ],
+        "tags": [
+          "Secrets"
+        ],
+        "summary": "Overwrite a Namespace Secret or Search for a Secret by given Name. Set op query param for search function like /api/namespaces/{namespace}/secrets/{name}?op=name",
+        "operationId": "overwriteAndSearchSecret",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target secret",
+            "name": "secret",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Payload that contains secret data, when using search functions its not necessary",
+            "name": "Secret Payload",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "7F8E7B0124ACB2BD20B383DE0756C7C0"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "namespace has been successfully overwritten",
             "schema": {
               "$ref": "#/definitions/OkBody"
             }
@@ -3249,59 +3394,17 @@
     }
   },
   "definitions": {
-    "CreateNamespaceServiceBody": {
-      "description": "CreateNamespaceServiceBody create namespace service body\nExample: {\"cmd\":\"\",\"image\":\"direktiv/request:v12\",\"minScale\":\"1\",\"name\":\"fast-request\",\"size\":\"small\"}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/namespace_services"
-    },
-    "CreateRegistryBody": {
-      "description": "CreateRegistryBody create registry body\nExample: {\"data\":\"admin:8QwFLg%D$qg*\",\"reg\":\"https://prod.customreg.io\"}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/registries"
-    },
-    "DeleteRegistryBody": {
-      "description": "DeleteRegistryBody delete registry body\nExample: {\"data\":\"admin:8QwFLg%D$qg*\",\"reg\":\"https://prod.customreg.io\"}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/registries"
-    },
     "ErrorResponse": {
-      "description": "ErrorResponse error response",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/models"
-    },
-    "JqPlaygroundBody": {
-      "description": "JqPlaygroundBody jq playground body\nExample: {\"data\":\"eyJhIjogMSwgImIiOiAyLCAiYyI6IDQsICJkIjogN30=\",\"query\":\"map(select(. \\u003e= 2))\"}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/other"
+      "x-go-package": "github.com/direktiv/direktiv/pkg/api"
     },
     "OkBody": {
       "description": "OkBody is an arbitrary placeholder response that represents an ok response body",
       "x-go-package": "github.com/direktiv/direktiv/pkg/api"
     },
-    "SetNamespaceConfigBody": {
-      "description": "SetNamespaceConfigBody set namespace config body\nExample: {\"broadcast\":{\"directory.create\":false,\"directory.delete\":false,\"instance.failed\":false,\"instance.started\":false,\"instance.success\":false,\"instance.variable.create\":false,\"instance.variable.delete\":false,\"instance.variable.update\":false,\"namespace.variable.create\":false,\"namespace.variable.delete\":false,\"namespace.variable.update\":false,\"workflow.create\":false,\"workflow.delete\":false,\"workflow.update\":false,\"workflow.variable.create\":false,\"workflow.variable.delete\":false,\"workflow.variable.update\":false}}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/namespaces"
-    },
-    "SetWorkflowCloudEventLogsBody": {
-      "description": "SetWorkflowCloudEventLogsBody set workflow cloud event logs body\nExample: {\"logger\":\"mylog\"}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/workflows"
-    },
-    "TestRegistryBody": {
-      "description": "TestRegistryBody test registry body\nExample: {\"token\":\"8QwFLg%D$qg*\",\"url\":\"https://prod.customreg.io\",\"username\":\"admin\"}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/operations"
-    },
-    "ToggleWorkflowBody": {
-      "description": "ToggleWorkflowBody toggle workflow body\nExample: {\"live\":false}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/workflows"
-    },
-    "UpdateNamespaceServiceBody": {
-      "description": "UpdateNamespaceServiceBody update namespace service body\nExample: {\"cmd\":\"\",\"image\":\"direktiv/request:v10\",\"minScale\":\"1\",\"size\":\"small\"}",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/client/namespace_services"
-    },
     "UpdateServiceRequest": {
-      "description": "UpdateServiceRequest UpdateServiceRequest update service request",
+      "description": "UpdateServiceRequest update service request",
       "x-go-name": "updateServiceRequest",
       "x-go-package": "github.com/direktiv/direktiv/pkg/api"
-    },
-    "updateServiceRequest": {
-      "description": "UpdateServiceRequest UpdateServiceRequest UpdateServiceRequest update service request",
-      "x-go-name": "UpdateServiceRequest",
-      "x-go-package": "github.com/direktiv/direktiv/pkg/api/models"
     }
   },
   "securityDefinitions": {

--- a/scripts/api/swagger.json
+++ b/scripts/api/swagger.json
@@ -1001,46 +1001,6 @@
         }
       }
     },
-    "/api/namespaces/search/{namespace}/secrets/{name}": {
-      "get": {
-        "description": "secrets and folders which including given name.\n",
-        "tags": [
-          "Secrets"
-        ],
-        "summary": "Get List of Namespace nodes contains name",
-        "operationId": "searchSecret",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "target namespace",
-            "name": "namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "target name",
-            "name": "name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successfully got namespace nodes",
-            "schema": {
-              "$ref": "#/definitions/OkBody"
-            }
-          },
-          "default": {
-            "description": "an error has occurred",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          }
-        }
-      }
-    },
     "/api/namespaces/{namespace}": {
       "put": {
         "description": "Creates a new namespace.\n",
@@ -1318,7 +1278,60 @@
         }
       }
     },
+    "/api/namespaces/{namespace}/eventfilter": {
+      "get": {
+        "description": "list all existing cloud event filter in target namespace\n",
+        "tags": [
+          "CloudEventFilter"
+        ],
+        "summary": "List existing cloudEventFilters",
+        "operationId": "listCloudeventFilter",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/api/namespaces/{namespace}/eventfilter/{filtername}": {
+      "get": {
+        "description": "Get specific cloud event filter by given name in target namespace\n",
+        "tags": [
+          "CloudEventFilter"
+        ],
+        "summary": "Get specific cloudEventFilter",
+        "operationId": "getCloudEventFilter",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target namespace",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "target filtername",
+            "name": "filtername",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
       "put": {
         "description": "Creates new cloud event filter in target namespace\nThe body of this request should be a compilable javascript code without function header.\n",
         "tags": [
@@ -2051,11 +2064,11 @@
     },
     "/api/namespaces/{namespace}/secrets": {
       "get": {
-        "description": "Gets the list of namespace secrets.\n",
+        "description": "Gets the list of namespace secrets. Also can use for search by setting query param op=search\n",
         "tags": [
           "Secrets"
         ],
-        "summary": "Get List of Namespace Secrets",
+        "summary": "Get List of Namespace Secrets or Search for Namespace Secrets by given name",
         "operationId": "getSecrets",
         "parameters": [
           {
@@ -2289,14 +2302,14 @@
         }
       },
       "patch": {
-        "description": "Overwrite a namespace secret, or search for a search secret which contains by given name\n",
+        "description": "Overwrite a namespace secret\n",
         "consumes": [
           "text/plain"
         ],
         "tags": [
           "Secrets"
         ],
-        "summary": "Overwrite a Namespace Secret or Search for a Secret by given Name. Set op query param for search function like /api/namespaces/{namespace}/secrets/{name}?op=name",
+        "summary": "Overwrite a Namespace Secret",
         "operationId": "overwriteAndSearchSecret",
         "parameters": [
           {
@@ -2314,7 +2327,7 @@
             "required": true
           },
           {
-            "description": "Payload that contains secret data, when using search functions its not necessary",
+            "description": "Payload that contains secret data",
             "name": "Secret Payload",
             "in": "body",
             "required": true,


### PR DESCRIPTION
Signed-off-by: Fxrdf <faissal.farid@direktiv.io>

## Description

jens comments for this PR: 
- Search and overwrite should be args 
/namespaces/{ns}/secrets/{secret:.*[^/]$}?op=search&term=whatever
The functions sharing the same path and and 'op' parameter defines what it does.

op=set (default if it is not set)
op=search&term=whattosearch
op=update

My changes: 
combined both handler search and overwrite. Still not good solution in my opinion, because it's mixing patch and get...
 By default, know it's an overwrite when adding query param op like ?op=search it will use the search function

Please describe the aim of the pull request and the changes made in the commits.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
