### PR TITLE
request get secrets from not exist folder return error

### DIFF
--- a/pkg/secrets/server.go
+++ b/pkg/secrets/server.go
@@ -12,6 +12,8 @@ import (
 	"github.com/direktiv/direktiv/pkg/util"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -174,6 +176,11 @@ func (s *Server) GetSecrets(ctx context.Context, in *secretsgrpc.GetSecretsReque
 
 	names, err := s.handler.GetSecrets(in.GetNamespace(), in.GetName())
 	if err != nil {
+		return &resp, err
+	}
+
+	if len(names) == 0 {
+		err = status.Error(codes.NotFound, fmt.Sprintf("folder %s not exists", in.GetName()))
 		return &resp, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Fxrdf <faissal.farid@direktiv.io>

## Description

return error when requesting get secrets inside non existing folder
Please describe the aim of the pull request and the changes made in the commits.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
