### PR TITLE
738 install k3s instructions in readme is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ scripts/dev.yaml
 scripts/api/api.md
 scripts/api/swagger.json
 scripts/dev.yaml
+.idea

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,7 @@
 **Install k3s**
 
 ```
-curl -sfL https://get.k3s.io | sh -s - --disable traefik --write-kubeconfig-mode=644 --kube-apiserver-arg feature-gates=TTLAfterFinished=true
+curl -sfL https://get.k3s.io | sh -s - --disable traefik --write-kubeconfig-mode=644
 ```
 
 **Change ~/.bashrc for code completion**

--- a/scripts/resetAll.sh
+++ b/scripts/resetAll.sh
@@ -38,7 +38,7 @@ helm install linkerd-control-plane \
   linkerd/linkerd-control-plane --wait
 
 if [ ! -d "$dir/direktiv-charts" ]; then
-  git clone git@github.com:direktiv/direktiv-charts.git $dir/direktiv-charts
+  git clone https://github.com/direktiv/direktiv-charts.git $dir/direktiv-charts
 fi
 
 cd $dir/direktiv-charts/charts/knative-instance && helm dependency update $dir/direktiv-charts/charts/knative-instance


### PR DESCRIPTION
## Description
K8s feature-gates 'TTLAfterFinished'  flag was removed [see this](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/).

 This PR removes 'TTLAfterFinished' usage in the k3s installation instruction.