### PR TITLE
Runs foreach logic in batches to help prevent engine overload.

### DIFF
--- a/pkg/flow/cancel.go
+++ b/pkg/flow/cancel.go
@@ -10,10 +10,10 @@ import (
 	"github.com/direktiv/direktiv/pkg/util"
 )
 
-func (engine *engine) Children(ctx context.Context, im *instanceMemory) ([]states.ChildInfo, error) {
+func (engine *engine) Children(ctx context.Context, im *instanceMemory) ([]*states.ChildInfo, error) {
 	var err error
 
-	var children []states.ChildInfo
+	var children []*states.ChildInfo
 	err = im.UnmarshalMemory(&children)
 	if err != nil {
 		return nil, err
@@ -32,6 +32,9 @@ func (engine *engine) LivingChildren(ctx context.Context, im *instanceMemory) []
 	}
 
 	for _, logic := range children {
+		if logic == nil {
+			continue
+		}
 		if logic.Complete {
 			continue
 		}

--- a/pkg/flow/states/action-helpers.go
+++ b/pkg/flow/states/action-helpers.go
@@ -15,7 +15,7 @@ import (
 )
 
 type actionRetryInfo struct {
-	Children []ChildInfo
+	Children []*ChildInfo
 	Idx      int
 }
 
@@ -85,7 +85,7 @@ func preprocessRetry(retry *model.RetryDefinition, attempt int, err error) (time
 	return d, nil
 }
 
-func scheduleRetry(ctx context.Context, instance Instance, children []ChildInfo, idx int, d time.Duration) error {
+func scheduleRetry(ctx context.Context, instance Instance, children []*ChildInfo, idx int, d time.Duration) error {
 	var err error
 
 	children[idx].Attempts++

--- a/pkg/flow/states/action.go
+++ b/pkg/flow/states/action.go
@@ -89,7 +89,7 @@ func (logic *actionLogic) Run(ctx context.Context, wakedata []byte) (*Transition
 
 	}
 
-	var children []ChildInfo
+	var children []*ChildInfo
 	err := logic.UnmarshalMemory(&children)
 	if err != nil {
 		return nil, derrors.NewInternalError(err)
@@ -188,7 +188,7 @@ func (logic *actionLogic) scheduleRetryAction(ctx context.Context, retry *action
 	return nil
 }
 
-func (logic *actionLogic) processActionResults(ctx context.Context, children []ChildInfo, results *actionResultPayload) (*Transition, error) {
+func (logic *actionLogic) processActionResults(ctx context.Context, children []*ChildInfo, results *actionResultPayload) (*Transition, error) {
 	var err error
 
 	sd := children[0]

--- a/pkg/flow/states/instance.go
+++ b/pkg/flow/states/instance.go
@@ -30,7 +30,7 @@ type Instance interface {
 	CreateChild(ctx context.Context, args CreateChildArgs) (Child, error)
 
 	Deadline(ctx context.Context) time.Time
-	LivingChildren(ctx context.Context) []ChildInfo
+	LivingChildren(ctx context.Context) []*ChildInfo
 }
 
 type Child interface {

--- a/pkg/flow/states/instance_test.go
+++ b/pkg/flow/states/instance_test.go
@@ -144,7 +144,7 @@ func (instance *testerInstance) ListenForEvents(ctx context.Context, events []*m
 	return nil
 }
 
-func (instance *testerInstance) LivingChildren(ctx context.Context) []ChildInfo {
+func (instance *testerInstance) LivingChildren(ctx context.Context) []*ChildInfo {
 	return nil
 }
 

--- a/pkg/flow/states/logic.go
+++ b/pkg/flow/states/logic.go
@@ -45,7 +45,7 @@ type Logic interface {
 	GetMemory() interface{}
 	Deadline(ctx context.Context) time.Time
 	Run(ctx context.Context, wakedata []byte) (*Transition, error)
-	LivingChildren(ctx context.Context) []ChildInfo
+	LivingChildren(ctx context.Context) []*ChildInfo
 }
 
 type Transition struct {

--- a/pkg/flow/states/parallel.go
+++ b/pkg/flow/states/parallel.go
@@ -79,7 +79,7 @@ func (logic *parallelLogic) Run(ctx context.Context, wakedata []byte) (*Transiti
 
 	}
 
-	var children []ChildInfo
+	var children []*ChildInfo
 	err := logic.UnmarshalMemory(&children)
 	if err != nil {
 		return nil, derrors.NewInternalError(err)
@@ -200,7 +200,7 @@ func (logic *parallelLogic) scheduleRetryAction(ctx context.Context, retry *acti
 	return nil
 }
 
-func (logic *parallelLogic) processActionResults(ctx context.Context, children []ChildInfo, results *actionResultPayload) (*Transition, error) {
+func (logic *parallelLogic) processActionResults(ctx context.Context, children []*ChildInfo, results *actionResultPayload) (*Transition, error) {
 	var err error
 
 	var found bool

--- a/pkg/flow/temporary.go
+++ b/pkg/flow/temporary.go
@@ -275,7 +275,7 @@ func (im *instanceMemory) Deadline(ctx context.Context) time.Time {
 	return time.Now().Add(states.DefaultShortDeadline)
 }
 
-func (im *instanceMemory) LivingChildren(ctx context.Context) []states.ChildInfo {
+func (im *instanceMemory) LivingChildren(ctx context.Context) []*states.ChildInfo {
 	return nil
 }
 


### PR DESCRIPTION
## Description

This tweaks the foreach state's logic to push through at most three child threads at a time. This should help prevent engine overload for large arrays. 

The number 3 is not currently configurable. Should it be? If not, do we want to leave it at 3?