### PR TITLE
Refactor atob into own package

### DIFF
--- a/pkg/flow/actions.go
+++ b/pkg/flow/actions.go
@@ -236,7 +236,7 @@ func (actions *actions) NamespaceRegistries(ctx context.Context, req *grpc.Names
 	resp.Registries = new(grpc.Registries)
 	resp.Registries.PageInfo = new(grpc.PageInfo)
 
-	err = bytedata.Atob(cx, &resp.Registries)
+	err = bytedata.ConvertDataForOutput(cx, &resp.Registries)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ resend:
 	resp.Registries = new(grpc.Registries)
 	resp.Registries.PageInfo = new(grpc.PageInfo)
 
-	err = bytedata.Atob(cx, &resp.Registries)
+	err = bytedata.ConvertDataForOutput(cx, &resp.Registries)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/actions.go
+++ b/pkg/flow/actions.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 	"time"
 
-	libgrpc "google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
-	"google.golang.org/protobuf/types/known/emptypb"
-
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/grpc"
 	igrpc "github.com/direktiv/direktiv/pkg/functions/grpc"
 	"github.com/direktiv/direktiv/pkg/util"
+	libgrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type actions struct {
@@ -236,7 +236,7 @@ func (actions *actions) NamespaceRegistries(ctx context.Context, req *grpc.Names
 	resp.Registries = new(grpc.Registries)
 	resp.Registries.PageInfo = new(grpc.PageInfo)
 
-	err = atob(cx, &resp.Registries)
+	err = bytedata.Atob(cx, &resp.Registries)
 	if err != nil {
 		return nil, err
 	}
@@ -293,12 +293,12 @@ resend:
 	resp.Registries = new(grpc.Registries)
 	resp.Registries.PageInfo = new(grpc.PageInfo)
 
-	err = atob(cx, &resp.Registries)
+	err = bytedata.Atob(cx, &resp.Registries)
 	if err != nil {
 		return err
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/engine.go
+++ b/pkg/flow/engine.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	derrors "github.com/direktiv/direktiv/pkg/flow/errors"
 	"github.com/direktiv/direktiv/pkg/flow/grpc"
@@ -110,7 +111,7 @@ func (engine *engine) NewInstance(ctx context.Context, args *newInstanceArgs) (*
 		as += ":" + args.Ref
 	}
 
-	data := marshalInstanceInputData(args.Input)
+	data := bytedata.MarshalInstanceInputData(args.Input)
 
 	clients := engine.edb.Clients(tctx)
 

--- a/pkg/flow/events.go
+++ b/pkg/flow/events.go
@@ -464,7 +464,7 @@ func (flow *flow) EventListeners(ctx context.Context, req *grpc.EventListenersRe
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +569,7 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/events.go
+++ b/pkg/flow/events.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dop251/goja"
 
 	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	derrors "github.com/direktiv/direktiv/pkg/flow/errors"
@@ -463,7 +464,7 @@ func (flow *flow) EventListeners(ctx context.Context, req *grpc.EventListenersRe
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -568,7 +569,7 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}
@@ -638,7 +639,7 @@ resend:
 
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -841,7 +842,7 @@ resend:
 
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/functions.go
+++ b/pkg/flow/functions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/functions"
 	"github.com/direktiv/direktiv/pkg/model"
@@ -87,7 +88,7 @@ func (flow *flow) functionsHeartbeat() {
 						FunctionDefinition: def,
 					}
 
-					csum := checksum(tuple)
+					csum := bytedata.Checksum(tuple)
 
 					if _, exists := checksums[csum]; !exists {
 						checksums[csum] = true
@@ -114,7 +115,7 @@ func (flow *flow) flushHeartbeatTuples(tuples []*functions.HeartbeatTuple) {
 		return
 	}
 
-	msg := marshal(tuples)
+	msg := bytedata.Marshal(tuples)
 
 	if len(msg) > heartbeatMessageLimit {
 

--- a/pkg/flow/grpc-inode-annotations.go
+++ b/pkg/flow/grpc-inode-annotations.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entnote "github.com/direktiv/direktiv/pkg/flow/ent/annotation"
@@ -148,7 +149,7 @@ func (flow *flow) NodeAnnotations(ctx context.Context, req *grpc.NodeAnnotations
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = atob(results, &resp.Annotations.Results)
+	err = bytedata.Atob(results, &resp.Annotations.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -187,12 +188,12 @@ resend:
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = atob(results, &resp.Annotations.Results)
+	err = bytedata.Atob(results, &resp.Annotations.Results)
 	if err != nil {
 		return err
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/grpc-inode-annotations.go
+++ b/pkg/flow/grpc-inode-annotations.go
@@ -149,7 +149,7 @@ func (flow *flow) NodeAnnotations(ctx context.Context, req *grpc.NodeAnnotations
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Annotations.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Annotations.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ resend:
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Annotations.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Annotations.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-instance-annotations.go
+++ b/pkg/flow/grpc-instance-annotations.go
@@ -150,7 +150,7 @@ func (flow *flow) InstanceAnnotations(ctx context.Context, req *grpc.InstanceAnn
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Annotations.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Annotations.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ resend:
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Annotations.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Annotations.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-instance-annotations.go
+++ b/pkg/flow/grpc-instance-annotations.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entnote "github.com/direktiv/direktiv/pkg/flow/ent/annotation"
@@ -149,7 +150,7 @@ func (flow *flow) InstanceAnnotations(ctx context.Context, req *grpc.InstanceAnn
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = atob(results, &resp.Annotations.Results)
+	err = bytedata.Atob(results, &resp.Annotations.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -188,12 +189,12 @@ resend:
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = atob(results, &resp.Annotations.Results)
+	err = bytedata.Atob(results, &resp.Annotations.Results)
 	if err != nil {
 		return err
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/grpc-instance-variables.go
+++ b/pkg/flow/grpc-instance-variables.go
@@ -346,7 +346,7 @@ func (flow *flow) InstanceVariables(ctx context.Context, req *grpc.InstanceVaria
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Variables.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Variables.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +404,7 @@ resend:
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Variables.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Variables.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-instance-variables.go
+++ b/pkg/flow/grpc-instance-variables.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entinst "github.com/direktiv/direktiv/pkg/flow/ent/instance"
@@ -132,7 +133,7 @@ func (internal *internal) InstanceVariableParcels(req *grpc.VariableInternalRequ
 		vdata = new(database.VarData)
 		t := time.Now()
 		vdata.Data = make([]byte, 0)
-		hash, err := computeHash(vdata.Data)
+		hash, err := bytedata.ComputeHash(vdata.Data)
 		if err != nil {
 			internal.sugar.Error(err)
 		}
@@ -218,7 +219,7 @@ func (internal *internal) ThreadVariableParcels(req *grpc.VariableInternalReques
 		vdata = new(database.VarData)
 		t := time.Now()
 		vdata.Data = make([]byte, 0)
-		hash, err := computeHash(vdata.Data)
+		hash, err := bytedata.ComputeHash(vdata.Data)
 		if err != nil {
 			internal.sugar.Error(err)
 		}
@@ -345,7 +346,7 @@ func (flow *flow) InstanceVariables(ctx context.Context, req *grpc.InstanceVaria
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = atob(results, &resp.Variables.Results)
+	err = bytedata.Atob(results, &resp.Variables.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +404,7 @@ resend:
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = atob(results, &resp.Variables.Results)
+	err = bytedata.Atob(results, &resp.Variables.Results)
 	if err != nil {
 		return err
 	}
@@ -426,7 +427,7 @@ resend:
 
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/grpc-instances.go
+++ b/pkg/flow/grpc-instances.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entinst "github.com/direktiv/direktiv/pkg/flow/ent/instance"
@@ -78,7 +79,7 @@ func (flow *flow) InstanceInput(ctx context.Context, req *grpc.InstanceInputRequ
 
 	var resp grpc.InstanceInputResponse
 
-	err = atob(cached.Instance, &resp.Instance)
+	err = bytedata.Atob(cached.Instance, &resp.Instance)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +90,7 @@ func (flow *flow) InstanceInput(ctx context.Context, req *grpc.InstanceInputRequ
 		return nil, err
 	}
 	delete(m, "private")
-	input := marshal(m)
+	input := bytedata.Marshal(m)
 
 	resp.Data = []byte(input)
 	resp.Namespace = cached.Namespace.Name
@@ -107,7 +108,7 @@ func (flow *flow) InstanceOutput(ctx context.Context, req *grpc.InstanceOutputRe
 
 	var resp grpc.InstanceOutputResponse
 
-	err = atob(cached.Instance, &resp.Instance)
+	err = bytedata.Atob(cached.Instance, &resp.Instance)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (flow *flow) InstanceOutput(ctx context.Context, req *grpc.InstanceOutputRe
 		return nil, err
 	}
 	delete(m, "private")
-	output := marshal(m)
+	output := bytedata.Marshal(m)
 
 	resp.Data = []byte(output)
 	resp.Namespace = cached.Namespace.Name
@@ -136,7 +137,7 @@ func (flow *flow) InstanceMetadata(ctx context.Context, req *grpc.InstanceMetada
 
 	var resp grpc.InstanceMetadataResponse
 
-	err = atob(cached.Instance, &resp.Instance)
+	err = bytedata.Atob(cached.Instance, &resp.Instance)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +172,7 @@ func (flow *flow) Instances(ctx context.Context, req *grpc.InstancesRequest) (*g
 	resp.Instances = new(grpc.Instances)
 	resp.Instances.PageInfo = pi
 
-	err = atob(results, &resp.Instances.Results)
+	err = bytedata.Atob(results, &resp.Instances.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -212,12 +213,12 @@ resend:
 	resp.Instances = new(grpc.Instances)
 	resp.Instances.PageInfo = pi
 
-	err = atob(results, &resp.Instances.Results)
+	err = bytedata.Atob(results, &resp.Instances.Results)
 	if err != nil {
 		return err
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -244,7 +245,7 @@ func (flow *flow) Instance(ctx context.Context, req *grpc.InstanceRequest) (*grp
 
 	var resp grpc.InstanceResponse
 
-	err = atob(cached.Instance, &resp.Instance)
+	err = bytedata.Atob(cached.Instance, &resp.Instance)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +293,7 @@ resend:
 
 	resp := new(grpc.InstanceResponse)
 
-	err = atob(cached.Instance, &resp.Instance)
+	err = bytedata.Atob(cached.Instance, &resp.Instance)
 	if err != nil {
 		return err
 	}
@@ -311,7 +312,7 @@ resend:
 	}
 	resp.Workflow = rwf
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -512,7 +513,7 @@ resend:
 
 	resp := new(grpc.AwaitWorkflowResponse)
 
-	err = atob(cached.Instance, &resp.Instance)
+	err = bytedata.Atob(cached.Instance, &resp.Instance)
 	if err != nil {
 		return err
 	}
@@ -533,7 +534,7 @@ resend:
 		resp.Data = []byte(runtime.Output)
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/grpc-instances.go
+++ b/pkg/flow/grpc-instances.go
@@ -79,7 +79,7 @@ func (flow *flow) InstanceInput(ctx context.Context, req *grpc.InstanceInputRequ
 
 	var resp grpc.InstanceInputResponse
 
-	err = bytedata.Atob(cached.Instance, &resp.Instance)
+	err = bytedata.ConvertDataForOutput(cached.Instance, &resp.Instance)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (flow *flow) InstanceOutput(ctx context.Context, req *grpc.InstanceOutputRe
 
 	var resp grpc.InstanceOutputResponse
 
-	err = bytedata.Atob(cached.Instance, &resp.Instance)
+	err = bytedata.ConvertDataForOutput(cached.Instance, &resp.Instance)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (flow *flow) InstanceMetadata(ctx context.Context, req *grpc.InstanceMetada
 
 	var resp grpc.InstanceMetadataResponse
 
-	err = bytedata.Atob(cached.Instance, &resp.Instance)
+	err = bytedata.ConvertDataForOutput(cached.Instance, &resp.Instance)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (flow *flow) Instances(ctx context.Context, req *grpc.InstancesRequest) (*g
 	resp.Instances = new(grpc.Instances)
 	resp.Instances.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Instances.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Instances.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ resend:
 	resp.Instances = new(grpc.Instances)
 	resp.Instances.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Instances.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Instances.Results)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func (flow *flow) Instance(ctx context.Context, req *grpc.InstanceRequest) (*grp
 
 	var resp grpc.InstanceResponse
 
-	err = bytedata.Atob(cached.Instance, &resp.Instance)
+	err = bytedata.ConvertDataForOutput(cached.Instance, &resp.Instance)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ resend:
 
 	resp := new(grpc.InstanceResponse)
 
-	err = bytedata.Atob(cached.Instance, &resp.Instance)
+	err = bytedata.ConvertDataForOutput(cached.Instance, &resp.Instance)
 	if err != nil {
 		return err
 	}
@@ -513,7 +513,7 @@ resend:
 
 	resp := new(grpc.AwaitWorkflowResponse)
 
-	err = bytedata.Atob(cached.Instance, &resp.Instance)
+	err = bytedata.ConvertDataForOutput(cached.Instance, &resp.Instance)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-logs.go
+++ b/pkg/flow/grpc-logs.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"context"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entinst "github.com/direktiv/direktiv/pkg/flow/ent/instance"
@@ -38,7 +39,7 @@ func (flow *flow) ServerLogs(ctx context.Context, req *grpc.ServerLogsRequest) (
 	resp := new(grpc.ServerLogsResponse)
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +71,7 @@ resend:
 	resp := new(grpc.ServerLogsResponse)
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}
@@ -119,7 +120,7 @@ func (flow *flow) NamespaceLogs(ctx context.Context, req *grpc.NamespaceLogsRequ
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}
@@ -219,7 +220,7 @@ func (flow *flow) WorkflowLogs(ctx context.Context, req *grpc.WorkflowLogsReques
 	resp.Path = cached.Path()
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ resend:
 	resp.Path = cached.Path()
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}
@@ -318,7 +319,7 @@ func (flow *flow) InstanceLogs(ctx context.Context, req *grpc.InstanceLogsReques
 	resp.Instance = cached.Instance.ID.String()
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +358,7 @@ resend:
 	resp.Instance = cached.Instance.ID.String()
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-logs.go
+++ b/pkg/flow/grpc-logs.go
@@ -39,7 +39,7 @@ func (flow *flow) ServerLogs(ctx context.Context, req *grpc.ServerLogsRequest) (
 	resp := new(grpc.ServerLogsResponse)
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ resend:
 	resp := new(grpc.ServerLogsResponse)
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (flow *flow) NamespaceLogs(ctx context.Context, req *grpc.NamespaceLogsRequ
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (flow *flow) WorkflowLogs(ctx context.Context, req *grpc.WorkflowLogsReques
 	resp.Path = cached.Path()
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +271,7 @@ resend:
 	resp.Path = cached.Path()
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}
@@ -319,7 +319,7 @@ func (flow *flow) InstanceLogs(ctx context.Context, req *grpc.InstanceLogsReques
 	resp.Instance = cached.Instance.ID.String()
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ resend:
 	resp.Instance = cached.Instance.ID.String()
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-mirror.go
+++ b/pkg/flow/grpc-mirror.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	derrors "github.com/direktiv/direktiv/pkg/flow/errors"
@@ -94,7 +95,7 @@ respond:
 
 	var resp grpc.CreateNamespaceResponse
 
-	err = atob(ns, &resp.Namespace)
+	err = bytedata.Atob(ns, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (flow *flow) CreateDirectoryMirror(ctx context.Context, req *grpc.CreateDir
 
 	var resp grpc.CreateDirectoryResponse
 
-	err = atob(ino, &resp.Node)
+	err = bytedata.Atob(ino, &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -616,12 +617,12 @@ func (flow *flow) MirrorInfo(ctx context.Context, req *grpc.MirrorInfoRequest) (
 	resp.Activities = new(grpc.MirrorActivities)
 	resp.Activities.PageInfo = pi
 
-	err = atob(results, &resp.Activities.Results)
+	err = bytedata.Atob(results, &resp.Activities.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = atob(mirror, &resp.Info)
+	err = bytedata.Atob(mirror, &resp.Info)
 	if err != nil {
 		return nil, err
 	}
@@ -689,12 +690,12 @@ resend:
 	resp.Activities = new(grpc.MirrorActivities)
 	resp.Activities.PageInfo = pi
 
-	err = atob(results, &resp.Activities.Results)
+	err = bytedata.Atob(results, &resp.Activities.Results)
 	if err != nil {
 		return err
 	}
 
-	err = atob(mirror, &resp.Info)
+	err = bytedata.Atob(mirror, &resp.Info)
 	if err != nil {
 		return err
 	}
@@ -706,7 +707,7 @@ resend:
 		resp.Info.PrivateKey = "-"
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -773,7 +774,7 @@ func (flow *flow) MirrorActivityLogs(ctx context.Context, req *grpc.MirrorActivi
 	resp.Activity = activity.ID.String()
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -812,7 +813,7 @@ resend:
 	resp.Activity = activity.ID.String()
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-mirror.go
+++ b/pkg/flow/grpc-mirror.go
@@ -95,7 +95,7 @@ respond:
 
 	var resp grpc.CreateNamespaceResponse
 
-	err = bytedata.Atob(ns, &resp.Namespace)
+	err = bytedata.ConvertDataForOutput(ns, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (flow *flow) CreateDirectoryMirror(ctx context.Context, req *grpc.CreateDir
 
 	var resp grpc.CreateDirectoryResponse
 
-	err = bytedata.Atob(ino, &resp.Node)
+	err = bytedata.ConvertDataForOutput(ino, &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -617,12 +617,12 @@ func (flow *flow) MirrorInfo(ctx context.Context, req *grpc.MirrorInfoRequest) (
 	resp.Activities = new(grpc.MirrorActivities)
 	resp.Activities.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Activities.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Activities.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = bytedata.Atob(mirror, &resp.Info)
+	err = bytedata.ConvertDataForOutput(mirror, &resp.Info)
 	if err != nil {
 		return nil, err
 	}
@@ -690,12 +690,12 @@ resend:
 	resp.Activities = new(grpc.MirrorActivities)
 	resp.Activities.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Activities.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Activities.Results)
 	if err != nil {
 		return err
 	}
 
-	err = bytedata.Atob(mirror, &resp.Info)
+	err = bytedata.ConvertDataForOutput(mirror, &resp.Info)
 	if err != nil {
 		return err
 	}
@@ -774,7 +774,7 @@ func (flow *flow) MirrorActivityLogs(ctx context.Context, req *grpc.MirrorActivi
 	resp.Activity = activity.ID.String()
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -813,7 +813,7 @@ resend:
 	resp.Activity = activity.ID.String()
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-namespace-annotations.go
+++ b/pkg/flow/grpc-namespace-annotations.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/database/entwrapper"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
@@ -168,7 +169,7 @@ func (flow *flow) NamespaceAnnotations(ctx context.Context, req *grpc.NamespaceA
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = atob(results, &resp.Annotations.Results)
+	err = bytedata.Atob(results, &resp.Annotations.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -209,12 +210,12 @@ resend:
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = atob(results, &resp.Annotations.Results)
+	err = bytedata.Atob(results, &resp.Annotations.Results)
 	if err != nil {
 		return err
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -324,7 +325,7 @@ func (x *entInstanceAnnotationQuerier) QueryAnnotations() *ent.AnnotationQuery {
 }
 
 func (flow *flow) SetAnnotation(ctx context.Context, q annotationQuerier, key string, mimetype string, data []byte) (*ent.Annotation, bool, error) {
-	hash, err := computeHash(data)
+	hash, err := bytedata.ComputeHash(data)
 	if err != nil {
 		flow.sugar.Error(err)
 	}

--- a/pkg/flow/grpc-namespace-annotations.go
+++ b/pkg/flow/grpc-namespace-annotations.go
@@ -169,7 +169,7 @@ func (flow *flow) NamespaceAnnotations(ctx context.Context, req *grpc.NamespaceA
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Annotations.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Annotations.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ resend:
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Annotations.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Annotations.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-namespace-variables.go
+++ b/pkg/flow/grpc-namespace-variables.go
@@ -251,7 +251,7 @@ func (flow *flow) NamespaceVariables(ctx context.Context, req *grpc.NamespaceVar
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Variables.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Variables.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ resend:
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Variables.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Variables.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-namespace-variables.go
+++ b/pkg/flow/grpc-namespace-variables.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entns "github.com/direktiv/direktiv/pkg/flow/ent/namespace"
@@ -99,7 +100,7 @@ func (internal *internal) NamespaceVariableParcels(req *grpc.VariableInternalReq
 		vdata = new(database.VarData)
 		t := time.Now()
 		vdata.Data = make([]byte, 0)
-		hash, err := computeHash(vdata.Data)
+		hash, err := bytedata.ComputeHash(vdata.Data)
 		if err != nil {
 			internal.sugar.Error(err)
 		}
@@ -250,7 +251,7 @@ func (flow *flow) NamespaceVariables(ctx context.Context, req *grpc.NamespaceVar
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = atob(results, &resp.Variables.Results)
+	err = bytedata.Atob(results, &resp.Variables.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +310,7 @@ resend:
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = atob(results, &resp.Variables.Results)
+	err = bytedata.Atob(results, &resp.Variables.Results)
 	if err != nil {
 		return err
 	}
@@ -332,7 +333,7 @@ resend:
 
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/grpc-namespaces.go
+++ b/pkg/flow/grpc-namespaces.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entino "github.com/direktiv/direktiv/pkg/flow/ent/inode"
@@ -52,7 +53,7 @@ func (flow *flow) ResolveNamespaceUID(ctx context.Context, req *grpc.ResolveName
 
 	var resp grpc.NamespaceResponse
 
-	err = atob(cached.Namespace, &resp.Namespace)
+	err = bytedata.Atob(cached.Namespace, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +129,7 @@ func (flow *flow) Namespace(ctx context.Context, req *grpc.NamespaceRequest) (*g
 
 	var resp grpc.NamespaceResponse
 
-	err = atob(cached.Namespace, &resp.Namespace)
+	err = bytedata.Atob(cached.Namespace, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func (flow *flow) Namespaces(ctx context.Context, req *grpc.NamespacesRequest) (
 	resp := new(grpc.NamespacesResponse)
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -185,12 +186,12 @@ resend:
 	resp := new(grpc.NamespacesResponse)
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -269,7 +270,7 @@ respond:
 
 	var resp grpc.CreateNamespaceResponse
 
-	err = atob(cached.Namespace, &resp.Namespace)
+	err = bytedata.Atob(cached.Namespace, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +385,7 @@ func (flow *flow) RenameNamespace(ctx context.Context, req *grpc.RenameNamespace
 
 	var resp grpc.RenameNamespaceResponse
 
-	err = atob(cached.Namespace, &resp.Namespace)
+	err = bytedata.Atob(cached.Namespace, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-namespaces.go
+++ b/pkg/flow/grpc-namespaces.go
@@ -53,7 +53,7 @@ func (flow *flow) ResolveNamespaceUID(ctx context.Context, req *grpc.ResolveName
 
 	var resp grpc.NamespaceResponse
 
-	err = bytedata.Atob(cached.Namespace, &resp.Namespace)
+	err = bytedata.ConvertDataForOutput(cached.Namespace, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (flow *flow) Namespace(ctx context.Context, req *grpc.NamespaceRequest) (*g
 
 	var resp grpc.NamespaceResponse
 
-	err = bytedata.Atob(cached.Namespace, &resp.Namespace)
+	err = bytedata.ConvertDataForOutput(cached.Namespace, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (flow *flow) Namespaces(ctx context.Context, req *grpc.NamespacesRequest) (
 	resp := new(grpc.NamespacesResponse)
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ resend:
 	resp := new(grpc.NamespacesResponse)
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ respond:
 
 	var resp grpc.CreateNamespaceResponse
 
-	err = bytedata.Atob(cached.Namespace, &resp.Namespace)
+	err = bytedata.ConvertDataForOutput(cached.Namespace, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +385,7 @@ func (flow *flow) RenameNamespace(ctx context.Context, req *grpc.RenameNamespace
 
 	var resp grpc.RenameNamespaceResponse
 
-	err = bytedata.Atob(cached.Namespace, &resp.Namespace)
+	err = bytedata.ConvertDataForOutput(cached.Namespace, &resp.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-nodes.go
+++ b/pkg/flow/grpc-nodes.go
@@ -83,7 +83,7 @@ func (flow *flow) Node(ctx context.Context, req *grpc.NodeRequest) (*grpc.NodeRe
 		return nil, err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		flow.sugar.Debugf("gRPC %s handler failed to traverse to marshal response: %v", this(), err)
 		return nil, err
@@ -126,12 +126,12 @@ func (flow *flow) Directory(ctx context.Context, req *grpc.DirectoryRequest) (*g
 	resp.Children = new(grpc.DirectoryChildren)
 	resp.Children.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Children.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Children.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -192,12 +192,12 @@ resend:
 	resp.Children = new(grpc.DirectoryChildren)
 	resp.Children.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Children.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Children.Results)
 	if err != nil {
 		return err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (flow *flow) CreateDirectory(ctx context.Context, req *grpc.CreateDirectory
 
 	var resp grpc.CreateDirectoryResponse
 
-	err = bytedata.Atob(ino, &resp.Node)
+	err = bytedata.ConvertDataForOutput(ino, &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +527,7 @@ func (flow *flow) RenameNode(ctx context.Context, req *grpc.RenameNodeRequest) (
 
 	var resp grpc.RenameNodeResponse
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-nodes.go
+++ b/pkg/flow/grpc-nodes.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entino "github.com/direktiv/direktiv/pkg/flow/ent/inode"
@@ -82,7 +83,7 @@ func (flow *flow) Node(ctx context.Context, req *grpc.NodeRequest) (*grpc.NodeRe
 		return nil, err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		flow.sugar.Debugf("gRPC %s handler failed to traverse to marshal response: %v", this(), err)
 		return nil, err
@@ -125,12 +126,12 @@ func (flow *flow) Directory(ctx context.Context, req *grpc.DirectoryRequest) (*g
 	resp.Children = new(grpc.DirectoryChildren)
 	resp.Children.PageInfo = pi
 
-	err = atob(results, &resp.Children.Results)
+	err = bytedata.Atob(results, &resp.Children.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -191,12 +192,12 @@ resend:
 	resp.Children = new(grpc.DirectoryChildren)
 	resp.Children.PageInfo = pi
 
-	err = atob(results, &resp.Children.Results)
+	err = bytedata.Atob(results, &resp.Children.Results)
 	if err != nil {
 		return err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -219,7 +220,7 @@ resend:
 
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -319,7 +320,7 @@ func (flow *flow) CreateDirectory(ctx context.Context, req *grpc.CreateDirectory
 
 	var resp grpc.CreateDirectoryResponse
 
-	err = atob(ino, &resp.Node)
+	err = bytedata.Atob(ino, &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +527,7 @@ func (flow *flow) RenameNode(ctx context.Context, req *grpc.RenameNodeRequest) (
 
 	var resp grpc.RenameNodeResponse
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-refs.go
+++ b/pkg/flow/grpc-refs.go
@@ -7,6 +7,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entref "github.com/direktiv/direktiv/pkg/flow/ent/ref"
@@ -70,12 +71,12 @@ func (flow *flow) Tags(ctx context.Context, req *grpc.TagsRequest) (*grpc.TagsRe
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +117,12 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -129,7 +130,7 @@ resend:
 	resp.Node.Path = cached.Path()
 	resp.Node.Parent = cached.Dir()
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -167,12 +168,12 @@ func (flow *flow) Refs(ctx context.Context, req *grpc.RefsRequest) (*grpc.RefsRe
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -213,12 +214,12 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -226,7 +227,7 @@ resend:
 	resp.Node.Path = cached.Path()
 	resp.Node.Parent = cached.Dir()
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/grpc-refs.go
+++ b/pkg/flow/grpc-refs.go
@@ -71,12 +71,12 @@ func (flow *flow) Tags(ctx context.Context, req *grpc.TagsRequest) (*grpc.TagsRe
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -117,12 +117,12 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -168,12 +168,12 @@ func (flow *flow) Refs(ctx context.Context, req *grpc.RefsRequest) (*grpc.RefsRe
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -214,12 +214,12 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-revisions.go
+++ b/pkg/flow/grpc-revisions.go
@@ -7,6 +7,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entref "github.com/direktiv/direktiv/pkg/flow/ent/ref"
 	entrev "github.com/direktiv/direktiv/pkg/flow/ent/revision"
@@ -35,12 +36,12 @@ func (flow *flow) Revisions(ctx context.Context, req *grpc.RevisionsRequest) (*g
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -81,12 +82,12 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = atob(results, &resp.Results)
+	err = bytedata.Atob(results, &resp.Results)
 	if err != nil {
 		return err
 	}
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -94,7 +95,7 @@ resend:
 	resp.Node.Path = cached.Path()
 	resp.Node.Parent = cached.Dir()
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/grpc-revisions.go
+++ b/pkg/flow/grpc-revisions.go
@@ -36,12 +36,12 @@ func (flow *flow) Revisions(ctx context.Context, req *grpc.RevisionsRequest) (*g
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -82,12 +82,12 @@ resend:
 	resp.Namespace = cached.Namespace.Name
 	resp.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Results)
 	if err != nil {
 		return err
 	}
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-routing.go
+++ b/pkg/flow/grpc-routing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entmux "github.com/direktiv/direktiv/pkg/flow/ent/route"
@@ -21,7 +22,7 @@ func (flow *flow) Router(ctx context.Context, req *grpc.RouterRequest) (*grpc.Ro
 
 	var resp grpc.RouterResponse
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +32,7 @@ func (flow *flow) Router(ctx context.Context, req *grpc.RouterRequest) (*grpc.Ro
 	resp.Node.Path = cached.Path()
 	resp.Live = cached.Workflow.Live
 
-	err = atob(cached.Workflow.Routes, &resp.Routes)
+	err = bytedata.Atob(cached.Workflow.Routes, &resp.Routes)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +64,7 @@ resend:
 
 	resp := new(grpc.RouterResponse)
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -73,7 +74,7 @@ resend:
 	resp.Node.Path = cached.Path()
 	resp.Live = cached.Workflow.Live
 
-	err = atob(cached.Workflow.Routes, &resp.Routes)
+	err = bytedata.Atob(cached.Workflow.Routes, &resp.Routes)
 	if err != nil {
 		return err
 	}
@@ -83,7 +84,7 @@ resend:
 		resp.Routes[i].Ref = route.Ref.Name
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -171,7 +172,7 @@ func (flow *flow) EditRouter(ctx context.Context, req *grpc.EditRouterRequest) (
 
 	var resp grpc.EditRouterResponse
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +182,7 @@ func (flow *flow) EditRouter(ctx context.Context, req *grpc.EditRouterRequest) (
 	resp.Node.Path = cached.Path()
 	resp.Live = req.GetLive()
 
-	err = atob(routes, &resp.Routes)
+	err = bytedata.Atob(routes, &resp.Routes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-routing.go
+++ b/pkg/flow/grpc-routing.go
@@ -22,7 +22,7 @@ func (flow *flow) Router(ctx context.Context, req *grpc.RouterRequest) (*grpc.Ro
 
 	var resp grpc.RouterResponse
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (flow *flow) Router(ctx context.Context, req *grpc.RouterRequest) (*grpc.Ro
 	resp.Node.Path = cached.Path()
 	resp.Live = cached.Workflow.Live
 
-	err = bytedata.Atob(cached.Workflow.Routes, &resp.Routes)
+	err = bytedata.ConvertDataForOutput(cached.Workflow.Routes, &resp.Routes)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ resend:
 
 	resp := new(grpc.RouterResponse)
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ resend:
 	resp.Node.Path = cached.Path()
 	resp.Live = cached.Workflow.Live
 
-	err = bytedata.Atob(cached.Workflow.Routes, &resp.Routes)
+	err = bytedata.ConvertDataForOutput(cached.Workflow.Routes, &resp.Routes)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (flow *flow) EditRouter(ctx context.Context, req *grpc.EditRouterRequest) (
 
 	var resp grpc.EditRouterResponse
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (flow *flow) EditRouter(ctx context.Context, req *grpc.EditRouterRequest) (
 	resp.Node.Path = cached.Path()
 	resp.Live = req.GetLive()
 
-	err = bytedata.Atob(routes, &resp.Routes)
+	err = bytedata.ConvertDataForOutput(routes, &resp.Routes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-secrets.go
+++ b/pkg/flow/grpc-secrets.go
@@ -56,7 +56,7 @@ func (flow *flow) Secrets(ctx context.Context, req *grpc.SecretsRequest) (*grpc.
 	resp.Secrets = new(grpc.Secrets)
 	resp.Secrets.PageInfo = new(grpc.PageInfo)
 
-	err = bytedata.Atob(cx, &resp.Secrets)
+	err = bytedata.ConvertDataForOutput(cx, &resp.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ resend:
 	resp.Secrets = new(grpc.Secrets)
 	resp.Secrets.PageInfo = new(grpc.PageInfo)
 
-	err = bytedata.Atob(cx, &resp.Secrets)
+	err = bytedata.ConvertDataForOutput(cx, &resp.Secrets)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func (flow *flow) SearchSecret(ctx context.Context, req *grpc.SearchSecretReques
 	resp.Secrets = new(grpc.Secrets)
 	resp.Secrets.PageInfo = new(grpc.PageInfo)
 
-	err = bytedata.Atob(cx, &resp.Secrets)
+	err = bytedata.ConvertDataForOutput(cx, &resp.Secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-secrets.go
+++ b/pkg/flow/grpc-secrets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/grpc"
 	secretsgrpc "github.com/direktiv/direktiv/pkg/secrets/grpc"
@@ -55,7 +56,7 @@ func (flow *flow) Secrets(ctx context.Context, req *grpc.SecretsRequest) (*grpc.
 	resp.Secrets = new(grpc.Secrets)
 	resp.Secrets.PageInfo = new(grpc.PageInfo)
 
-	err = atob(cx, &resp.Secrets)
+	err = bytedata.Atob(cx, &resp.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -117,12 +118,12 @@ resend:
 	resp.Secrets = new(grpc.Secrets)
 	resp.Secrets.PageInfo = new(grpc.PageInfo)
 
-	err = atob(cx, &resp.Secrets)
+	err = bytedata.Atob(cx, &resp.Secrets)
 	if err != nil {
 		return err
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -184,7 +185,7 @@ func (flow *flow) SearchSecret(ctx context.Context, req *grpc.SearchSecretReques
 	resp.Secrets = new(grpc.Secrets)
 	resp.Secrets.PageInfo = new(grpc.PageInfo)
 
-	err = atob(cx, &resp.Secrets)
+	err = bytedata.Atob(cx, &resp.Secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-workflow-annotations.go
+++ b/pkg/flow/grpc-workflow-annotations.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	entnote "github.com/direktiv/direktiv/pkg/flow/ent/annotation"
@@ -142,7 +143,7 @@ func (flow *flow) WorkflowAnnotations(ctx context.Context, req *grpc.WorkflowAnn
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = atob(results, &resp.Annotations.Results)
+	err = bytedata.Atob(results, &resp.Annotations.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -181,12 +182,12 @@ resend:
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = atob(results, &resp.Annotations.Results)
+	err = bytedata.Atob(results, &resp.Annotations.Results)
 	if err != nil {
 		return err
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {

--- a/pkg/flow/grpc-workflow-annotations.go
+++ b/pkg/flow/grpc-workflow-annotations.go
@@ -143,7 +143,7 @@ func (flow *flow) WorkflowAnnotations(ctx context.Context, req *grpc.WorkflowAnn
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Annotations.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Annotations.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ resend:
 	resp.Annotations = new(grpc.Annotations)
 	resp.Annotations.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Annotations.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Annotations.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-workflow-variables.go
+++ b/pkg/flow/grpc-workflow-variables.go
@@ -238,7 +238,7 @@ func (flow *flow) WorkflowVariables(ctx context.Context, req *grpc.WorkflowVaria
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Variables.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Variables.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ resend:
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = bytedata.Atob(results, &resp.Variables.Results)
+	err = bytedata.ConvertDataForOutput(results, &resp.Variables.Results)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/grpc-workflow-variables.go
+++ b/pkg/flow/grpc-workflow-variables.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/database/entwrapper"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
@@ -103,7 +104,7 @@ func (internal *internal) WorkflowVariableParcels(req *grpc.VariableInternalRequ
 		vdata = new(database.VarData)
 		t := time.Now()
 		vdata.Data = make([]byte, 0)
-		hash, err := computeHash(vdata.Data)
+		hash, err := bytedata.ComputeHash(vdata.Data)
 		if err != nil {
 			internal.sugar.Error(err)
 		}
@@ -237,7 +238,7 @@ func (flow *flow) WorkflowVariables(ctx context.Context, req *grpc.WorkflowVaria
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = atob(results, &resp.Variables.Results)
+	err = bytedata.Atob(results, &resp.Variables.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +296,7 @@ resend:
 	resp.Variables = new(grpc.Variables)
 	resp.Variables.PageInfo = pi
 
-	err = atob(results, &resp.Variables.Results)
+	err = bytedata.Atob(results, &resp.Variables.Results)
 	if err != nil {
 		return err
 	}
@@ -318,7 +319,7 @@ resend:
 
 	}
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -367,7 +368,7 @@ func (x *entInstanceVarQuerier) QueryVars() *ent.VarRefQuery {
 }
 
 func (flow *flow) SetVariable(ctx context.Context, q varQuerier, key string, data []byte, vMimeType string, thread bool) (*ent.VarData, bool, error) {
-	hash, err := computeHash(data)
+	hash, err := bytedata.ComputeHash(data)
 	if err != nil {
 		flow.sugar.Error(err)
 	}

--- a/pkg/flow/grpc-workflow.go
+++ b/pkg/flow/grpc-workflow.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	entref "github.com/direktiv/direktiv/pkg/flow/ent/ref"
 	entrev "github.com/direktiv/direktiv/pkg/flow/ent/revision"
@@ -92,7 +93,7 @@ func (flow *flow) ResolveWorkflowUID(ctx context.Context, req *grpc.ResolveWorkf
 
 	var resp grpc.WorkflowResponse
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,7 @@ func (flow *flow) Workflow(ctx context.Context, req *grpc.WorkflowRequest) (*grp
 
 	var resp grpc.WorkflowResponse
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +135,7 @@ func (flow *flow) Workflow(ctx context.Context, req *grpc.WorkflowRequest) (*grp
 	resp.EventLogging = cached.Workflow.LogToEvents
 	resp.Oid = cached.Workflow.ID.String()
 
-	err = atob(cached.Revision, &resp.Revision)
+	err = bytedata.Atob(cached.Revision, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ resend:
 
 	resp := new(grpc.WorkflowResponse)
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -178,14 +179,14 @@ resend:
 	resp.Oid = cached.Workflow.ID.String()
 	resp.EventLogging = cached.Workflow.LogToEvents
 
-	err = atob(cached.Revision, &resp.Revision)
+	err = bytedata.Atob(cached.Revision, &resp.Revision)
 	if err != nil {
 		return err
 	}
 
 	resp.Revision.Name = cached.Revision.ID.String()
 
-	nhash = checksum(resp)
+	nhash = bytedata.Checksum(resp)
 	if nhash != phash {
 		err = srv.Send(resp)
 		if err != nil {
@@ -221,7 +222,7 @@ func (flow *flow) createWorkflow(ctx context.Context, args *createWorkflowArgs) 
 		return nil, nil, errors.New("cannot write into read-only directory")
 	}
 
-	hash, err := computeHash(args.data)
+	hash, err := bytedata.ComputeHash(args.data)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -291,7 +292,7 @@ func (flow *flow) CreateWorkflow(ctx context.Context, req *grpc.CreateWorkflowRe
 
 	data := req.GetSource()
 
-	hash, err := computeHash(data)
+	hash, err := bytedata.ComputeHash(data)
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +404,7 @@ func (flow *flow) CreateWorkflow(ctx context.Context, req *grpc.CreateWorkflowRe
 
 	var resp grpc.CreateWorkflowResponse
 
-	err = atob(ino, &resp.Node)
+	err = bytedata.Atob(ino, &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +417,7 @@ func (flow *flow) CreateWorkflow(ctx context.Context, req *grpc.CreateWorkflowRe
 	resp.Node.Parent = dir
 	resp.Node.Path = path
 
-	err = atob(rev, &resp.Revision)
+	err = bytedata.Atob(rev, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -449,7 +450,7 @@ type updateWorkflowArgs struct {
 func (flow *flow) updateWorkflow(ctx context.Context, args *updateWorkflowArgs) (*database.Revision, error) {
 	data := args.data
 
-	hash, err := computeHash(data)
+	hash, err := bytedata.ComputeHash(data)
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +584,7 @@ func (flow *flow) UpdateWorkflow(ctx context.Context, req *grpc.UpdateWorkflowRe
 
 	var resp grpc.UpdateWorkflowResponse
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +597,7 @@ func (flow *flow) UpdateWorkflow(ctx context.Context, req *grpc.UpdateWorkflowRe
 	resp.Node.Parent = cached.Dir()
 	resp.Node.Path = cached.Path()
 
-	err = atob(rev, &resp.Revision)
+	err = bytedata.Atob(rev, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +640,7 @@ func (flow *flow) SaveHead(ctx context.Context, req *grpc.SaveHeadRequest) (*grp
 
 	if len(metadata) != 0 {
 		obj := make(map[string]interface{})
-		err := unmarshal(string(metadata), &obj)
+		err := bytedata.Unmarshal(string(metadata), &obj)
 		if err != nil {
 			return nil, err
 		}
@@ -669,7 +670,7 @@ respond:
 
 	var resp grpc.SaveHeadResponse
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -682,7 +683,7 @@ respond:
 	resp.Node.Parent = cached.Dir()
 	resp.Node.Path = cached.Path()
 
-	err = atob(cached.Revision, &resp.Revision)
+	err = bytedata.Atob(cached.Revision, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -750,7 +751,7 @@ respond:
 
 	var resp grpc.DiscardHeadResponse
 
-	err = atob(cached.Inode(), &resp.Node)
+	err = bytedata.Atob(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +764,7 @@ respond:
 	resp.Node.Parent = cached.Dir()
 	resp.Node.Path = cached.Path()
 
-	err = atob(cached.Revision, &resp.Revision)
+	err = bytedata.Atob(cached.Revision, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/grpc-workflow.go
+++ b/pkg/flow/grpc-workflow.go
@@ -642,7 +642,7 @@ func (flow *flow) SaveHead(ctx context.Context, req *grpc.SaveHeadRequest) (*grp
 	if len(metadata) != 0 {
 		obj := make(map[string]interface{})
 
-		err := json.Unmarshal([]byte(metadata), &obj)
+		err := json.Unmarshal(metadata, &obj)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/flow/grpc-workflow.go
+++ b/pkg/flow/grpc-workflow.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"time"
@@ -93,7 +94,7 @@ func (flow *flow) ResolveWorkflowUID(ctx context.Context, req *grpc.ResolveWorkf
 
 	var resp grpc.WorkflowResponse
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +121,7 @@ func (flow *flow) Workflow(ctx context.Context, req *grpc.WorkflowRequest) (*grp
 
 	var resp grpc.WorkflowResponse
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +136,7 @@ func (flow *flow) Workflow(ctx context.Context, req *grpc.WorkflowRequest) (*grp
 	resp.EventLogging = cached.Workflow.LogToEvents
 	resp.Oid = cached.Workflow.ID.String()
 
-	err = bytedata.Atob(cached.Revision, &resp.Revision)
+	err = bytedata.ConvertDataForOutput(cached.Revision, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +165,7 @@ resend:
 
 	resp := new(grpc.WorkflowResponse)
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return err
 	}
@@ -179,7 +180,7 @@ resend:
 	resp.Oid = cached.Workflow.ID.String()
 	resp.EventLogging = cached.Workflow.LogToEvents
 
-	err = bytedata.Atob(cached.Revision, &resp.Revision)
+	err = bytedata.ConvertDataForOutput(cached.Revision, &resp.Revision)
 	if err != nil {
 		return err
 	}
@@ -404,7 +405,7 @@ func (flow *flow) CreateWorkflow(ctx context.Context, req *grpc.CreateWorkflowRe
 
 	var resp grpc.CreateWorkflowResponse
 
-	err = bytedata.Atob(ino, &resp.Node)
+	err = bytedata.ConvertDataForOutput(ino, &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +418,7 @@ func (flow *flow) CreateWorkflow(ctx context.Context, req *grpc.CreateWorkflowRe
 	resp.Node.Parent = dir
 	resp.Node.Path = path
 
-	err = bytedata.Atob(rev, &resp.Revision)
+	err = bytedata.ConvertDataForOutput(rev, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +585,7 @@ func (flow *flow) UpdateWorkflow(ctx context.Context, req *grpc.UpdateWorkflowRe
 
 	var resp grpc.UpdateWorkflowResponse
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +598,7 @@ func (flow *flow) UpdateWorkflow(ctx context.Context, req *grpc.UpdateWorkflowRe
 	resp.Node.Parent = cached.Dir()
 	resp.Node.Path = cached.Path()
 
-	err = bytedata.Atob(rev, &resp.Revision)
+	err = bytedata.ConvertDataForOutput(rev, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -640,7 +641,8 @@ func (flow *flow) SaveHead(ctx context.Context, req *grpc.SaveHeadRequest) (*grp
 
 	if len(metadata) != 0 {
 		obj := make(map[string]interface{})
-		err := bytedata.Unmarshal(string(metadata), &obj)
+
+		err := json.Unmarshal([]byte(metadata), &obj)
 		if err != nil {
 			return nil, err
 		}
@@ -670,7 +672,7 @@ respond:
 
 	var resp grpc.SaveHeadResponse
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -683,7 +685,7 @@ respond:
 	resp.Node.Parent = cached.Dir()
 	resp.Node.Path = cached.Path()
 
-	err = bytedata.Atob(cached.Revision, &resp.Revision)
+	err = bytedata.ConvertDataForOutput(cached.Revision, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -751,7 +753,7 @@ respond:
 
 	var resp grpc.DiscardHeadResponse
 
-	err = bytedata.Atob(cached.Inode(), &resp.Node)
+	err = bytedata.ConvertDataForOutput(cached.Inode(), &resp.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +766,7 @@ respond:
 	resp.Node.Parent = cached.Dir()
 	resp.Node.Path = cached.Path()
 
-	err = bytedata.Atob(cached.Revision, &resp.Revision)
+	err = bytedata.ConvertDataForOutput(cached.Revision, &resp.Revision)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flow/jq.go
+++ b/pkg/flow/jq.go
@@ -1,0 +1,51 @@
+package flow
+
+import (
+	derrors "github.com/direktiv/direktiv/pkg/flow/errors"
+	"github.com/direktiv/direktiv/pkg/jqer"
+)
+
+func (srv *server) initJQ() {
+	jqer.StringQueryRequiresWrappings = true
+	jqer.TrimWhitespaceOnQueryStrings = true
+
+	jqer.SearchInStrings = true
+	jqer.WrappingBegin = "jq"
+	jqer.WrappingIncrement = "("
+	jqer.WrappingDecrement = ")"
+}
+
+func jq(input interface{}, command interface{}) ([]interface{}, error) {
+	out, err := jqer.Evaluate(input, command)
+	if err != nil {
+		return nil, derrors.NewCatchableError(ErrCodeJQBadQuery, "failed to evaluate jq/js: %v", err)
+	}
+	return out, nil
+}
+
+func jqOne(input interface{}, command interface{}) (interface{}, error) {
+	output, err := jq(input, command)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output) != 1 {
+		return nil, derrors.NewCatchableError(ErrCodeJQNotObject, "the `jq` or `js` command produced multiple outputs")
+	}
+
+	return output[0], nil
+}
+
+func jqObject(input interface{}, command interface{}) (map[string]interface{}, error) {
+	x, err := jqOne(input, command)
+	if err != nil {
+		return nil, err
+	}
+
+	m, ok := x.(map[string]interface{})
+	if !ok {
+		return nil, derrors.NewCatchableError(ErrCodeJQNotObject, "the `jq` or `js` command produced a non-object output")
+	}
+
+	return m, nil
+}

--- a/pkg/flow/pubsub.go
+++ b/pkg/flow/pubsub.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -821,7 +822,7 @@ func (pubsub *pubsub) ConfigureRouterCron(id, cron string, enabled bool) {
 		Enabled: enabled,
 	}
 
-	key := marshal(msg)
+	key := bytedata.Marshal(msg)
 
 	pubsub.publish(&PubsubUpdate{
 		Handler: pubsubConfigureRouterFunction,

--- a/pkg/flow/routing.go
+++ b/pkg/flow/routing.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"os"
@@ -294,7 +295,7 @@ func (flow *flow) postCommitRouterConfiguration(id string, ms *muxStart) {
 func (flow *flow) configureRouterHandler(req *PubsubUpdate) {
 	msg := new(configureRouterMessage)
 
-	err := bytedata.Unmarshal(req.Key, msg)
+	err := json.Unmarshal([]byte(req.Key), msg)
 	if err != nil {
 		flow.sugar.Error(err)
 		return

--- a/pkg/flow/routing.go
+++ b/pkg/flow/routing.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	entinst "github.com/direktiv/direktiv/pkg/flow/ent/instance"
 	entirt "github.com/direktiv/direktiv/pkg/flow/ent/instanceruntime"
@@ -61,7 +62,7 @@ func (ms *muxStart) Hash() string {
 		ms.Type = model.StartTypeDefault.String()
 	}
 
-	return checksum(ms)
+	return bytedata.Checksum(ms)
 }
 
 func (srv *server) validateRouter(ctx context.Context, cached *database.CacheData) (*muxStart, error, error) {
@@ -293,7 +294,7 @@ func (flow *flow) postCommitRouterConfiguration(id string, ms *muxStart) {
 func (flow *flow) configureRouterHandler(req *PubsubUpdate) {
 	msg := new(configureRouterMessage)
 
-	err := unmarshal(req.Key, msg)
+	err := bytedata.Unmarshal(req.Key, msg)
 	if err != nil {
 		flow.sugar.Error(err)
 		return

--- a/pkg/flow/trace.go
+++ b/pkg/flow/trace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/direktiv/direktiv/pkg/flow/bytedata"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -88,7 +89,7 @@ func traceFullAddWorkflowInstance(ctx context.Context, im *instanceMemory) (cont
 	traceAddWorkflowInstance(ctx, im)
 
 	x := dbTrace(ctx)
-	s := marshal(x)
+	s := bytedata.Marshal(x)
 
 	updater := im.getRuntimeUpdater()
 	updater = updater.SetInstanceContext(s)
@@ -124,7 +125,7 @@ func traceStateGenericBegin(ctx context.Context, im *instanceMemory) (context.Co
 	var span trace.Span
 
 	carrier := new(Carrier)
-	err := unmarshal(im.runtime.InstanceContext, carrier)
+	err := bytedata.Unmarshal(im.runtime.InstanceContext, carrier)
 	if err != nil {
 		return ctx, nil, err
 	}
@@ -134,7 +135,7 @@ func traceStateGenericBegin(ctx context.Context, im *instanceMemory) (context.Co
 	ctx, span = tr.Start(ctx, im.logic.GetType().String(), trace.WithSpanKind(trace.SpanKindInternal))
 
 	x := dbTrace(ctx)
-	s := marshal(x)
+	s := bytedata.Marshal(x)
 
 	updater := im.getRuntimeUpdater()
 	updater = updater.SetStateContext(s)
@@ -155,7 +156,7 @@ func traceStateGenericLogicThread(ctx context.Context, im *instanceMemory) (cont
 	var span trace.Span
 
 	carrier := new(Carrier)
-	err := unmarshal(im.runtime.StateContext, carrier)
+	err := bytedata.Unmarshal(im.runtime.StateContext, carrier)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/flow/trace.go
+++ b/pkg/flow/trace.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/direktiv/direktiv/pkg/flow/bytedata"
@@ -125,7 +126,8 @@ func traceStateGenericBegin(ctx context.Context, im *instanceMemory) (context.Co
 	var span trace.Span
 
 	carrier := new(Carrier)
-	err := bytedata.Unmarshal(im.runtime.InstanceContext, carrier)
+
+	err := json.Unmarshal([]byte(im.runtime.InstanceContext), carrier)
 	if err != nil {
 		return ctx, nil, err
 	}
@@ -156,7 +158,7 @@ func traceStateGenericLogicThread(ctx context.Context, im *instanceMemory) (cont
 	var span trace.Span
 
 	carrier := new(Carrier)
-	err := bytedata.Unmarshal(im.runtime.StateContext, carrier)
+	err := json.Unmarshal([]byte(im.runtime.StateContext), carrier)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
In order to decouple the architecture as a frist step we could move most of the methods from data.go file into a own pkg. This step would be also necessary to decouple our logging system from the server/flow pkg.
 
Signed-off-by: Alexander Ertli <alexander.ertli@direktiv.io>