### PR TITLE
Move pub-sub code into a separate package

### DIFF
--- a/pkg/flow/cancel.go
+++ b/pkg/flow/cancel.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	derrors "github.com/direktiv/direktiv/pkg/flow/errors"
+	"github.com/direktiv/direktiv/pkg/flow/pubsub"
 	"github.com/direktiv/direktiv/pkg/flow/states"
 	"github.com/direktiv/direktiv/pkg/util"
 )
@@ -94,7 +95,7 @@ func (engine *engine) cancelInstance(id, code, message string, soft bool) {
 	go engine.runState(ctx, im, nil, err)
 }
 
-func (engine *engine) finishCancelWorkflow(req *PubsubUpdate) {
+func (engine *engine) finishCancelWorkflow(req *pubsub.PubsubUpdate) {
 	args := make([]interface{}, 0)
 
 	err := json.Unmarshal([]byte(req.Key), &args)
@@ -142,7 +143,7 @@ bad:
 func (engine *engine) cancelRunning(id string) {
 	im, err := engine.getInstanceMemory(context.Background(), id)
 	if err == nil {
-		engine.timers.deleteTimerByName(im.Controller(), engine.pubsub.hostname, id)
+		engine.timers.deleteTimerByName(im.Controller(), engine.pubsub.Hostname, id)
 	}
 
 	engine.cancellersLock.Lock()

--- a/pkg/flow/engine.go
+++ b/pkg/flow/engine.go
@@ -357,14 +357,14 @@ func (engine *engine) Transition(ctx context.Context, im *instanceMemory, nextSt
 	memory := im.MarshalMemory()
 	updater := im.getRuntimeUpdater()
 	updater = updater.SetFlow(flow).
-		SetController(engine.pubsub.hostname).
+		SetController(engine.pubsub.Hostname).
 		SetAttempts(attempt).
 		SetDeadline(deadline).
 		SetStateBeginTime(t).
 		SetData(data).
 		SetMemory(memory)
 	im.runtime.Flow = flow
-	im.runtime.Controller = engine.pubsub.hostname
+	im.runtime.Controller = engine.pubsub.Hostname
 	im.runtime.Attempts = attempt
 	im.runtime.Deadline = deadline
 	im.runtime.StateBeginTime = t

--- a/pkg/flow/events.go
+++ b/pkg/flow/events.go
@@ -20,6 +20,7 @@ import (
 	"github.com/direktiv/direktiv/pkg/flow/database"
 	"github.com/direktiv/direktiv/pkg/flow/ent"
 	derrors "github.com/direktiv/direktiv/pkg/flow/errors"
+	"github.com/direktiv/direktiv/pkg/flow/pubsub"
 
 	enteventsfilter "github.com/direktiv/direktiv/pkg/flow/ent/cloudeventfilters"
 	cevents "github.com/direktiv/direktiv/pkg/flow/ent/cloudevents"
@@ -941,9 +942,7 @@ func (events *events) BroadcastCloudevent(ctx context.Context, cached *database.
 	return nil
 }
 
-const pubsubUpdateEventDelays = "updateEventDelays"
-
-func (events *events) updateEventDelaysHandler(req *PubsubUpdate) {
+func (events *events) updateEventDelaysHandler(req *pubsub.PubsubUpdate) {
 	events.syncEventDelays()
 }
 
@@ -1138,7 +1137,7 @@ func (flow *flow) DeleteCloudEventFilter(ctx context.Context, in *grpc.DeleteClo
 
 	key := fmt.Sprintf("%s-%s", namespace, filterName)
 	eventFilterCache.delete(key)
-	flow.server.pubsub.publish(&PubsubUpdate{
+	flow.server.pubsub.Publish(&pubsub.PubsubUpdate{
 		Handler: deleteFilterCache,
 		Key:     key,
 	})
@@ -1151,7 +1150,7 @@ const (
 	deleteFilterCacheNamespace = "deleteFilterCacheNamespace"
 )
 
-func (flow *flow) deleteCache(req *PubsubUpdate) {
+func (flow *flow) deleteCache(req *pubsub.PubsubUpdate) {
 	flow.sugar.Debugf("deleting filter cache key: %v\n", req.Key)
 	eventFilterCache.delete(req.Key)
 }
@@ -1166,7 +1165,7 @@ func deleteCacheNamespaceSync(delkey string) {
 	})
 }
 
-func (flow *flow) deleteCacheNamespace(req *PubsubUpdate) {
+func (flow *flow) deleteCacheNamespace(req *pubsub.PubsubUpdate) {
 	flow.sugar.Debugf("deleting filter cache for namespace: %v\n", req.Key)
 	deleteCacheNamespaceSync(req.Key)
 }

--- a/pkg/flow/grpc-instances.go
+++ b/pkg/flow/grpc-instances.go
@@ -14,6 +14,7 @@ import (
 	entinst "github.com/direktiv/direktiv/pkg/flow/ent/instance"
 	entns "github.com/direktiv/direktiv/pkg/flow/ent/namespace"
 	"github.com/direktiv/direktiv/pkg/flow/grpc"
+	"github.com/direktiv/direktiv/pkg/flow/pubsub"
 	"github.com/direktiv/direktiv/pkg/util"
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -276,7 +277,7 @@ func (flow *flow) InstanceStream(req *grpc.InstanceRequest, srv grpc.Flow_Instan
 	phash := ""
 	nhash := ""
 
-	var sub *subscription
+	var sub *pubsub.Subscription
 
 resend:
 

--- a/pkg/flow/grpc-namespaces.go
+++ b/pkg/flow/grpc-namespaces.go
@@ -12,6 +12,7 @@ import (
 	entns "github.com/direktiv/direktiv/pkg/flow/ent/namespace"
 	derrors "github.com/direktiv/direktiv/pkg/flow/errors"
 	"github.com/direktiv/direktiv/pkg/flow/grpc"
+	"github.com/direktiv/direktiv/pkg/flow/pubsub"
 	"github.com/direktiv/direktiv/pkg/functions"
 	igrpc "github.com/direktiv/direktiv/pkg/functions/grpc"
 	"github.com/direktiv/direktiv/pkg/util"
@@ -339,7 +340,7 @@ func (flow *flow) DeleteNamespace(ctx context.Context, req *grpc.DeleteNamespace
 
 	// delete filter cache
 	deleteCacheNamespaceSync(cached.Namespace.Name)
-	flow.server.pubsub.publish(&PubsubUpdate{
+	flow.server.pubsub.Publish(&pubsub.PubsubUpdate{
 		Handler: deleteFilterCacheNamespace,
 		Key:     cached.Namespace.Name,
 	})

--- a/pkg/flow/routing.go
+++ b/pkg/flow/routing.go
@@ -18,6 +18,7 @@ import (
 	entirt "github.com/direktiv/direktiv/pkg/flow/ent/instanceruntime"
 	entwf "github.com/direktiv/direktiv/pkg/flow/ent/workflow"
 	derrors "github.com/direktiv/direktiv/pkg/flow/errors"
+	"github.com/direktiv/direktiv/pkg/flow/pubsub"
 	"github.com/direktiv/direktiv/pkg/model"
 	"github.com/direktiv/direktiv/pkg/util"
 	"github.com/google/uuid"
@@ -292,8 +293,8 @@ func (flow *flow) postCommitRouterConfiguration(id string, ms *muxStart) {
 	flow.pubsub.ConfigureRouterCron(id, ms.Cron, ms.Enabled)
 }
 
-func (flow *flow) configureRouterHandler(req *PubsubUpdate) {
-	msg := new(configureRouterMessage)
+func (flow *flow) configureRouterHandler(req *pubsub.PubsubUpdate) {
+	msg := new(pubsub.ConfigureRouterMessage)
 
 	err := json.Unmarshal([]byte(req.Key), msg)
 	if err != nil {

--- a/pkg/flow/syncer.go
+++ b/pkg/flow/syncer.go
@@ -87,7 +87,7 @@ func (syncer *syncer) scheduleTimeout(activityId string, oldController string, t
 
 	// cancel existing timeouts
 
-	syncer.timers.deleteTimerByName(oldController, syncer.pubsub.hostname, id)
+	syncer.timers.deleteTimerByName(oldController, syncer.pubsub.Hostname, id)
 
 	// schedule timeout
 
@@ -402,7 +402,7 @@ func (syncer *syncer) beginActivity(tx database.Transaction, args *newMirrorActi
 		EndAt:      time.Now(),
 		Mirror:     mirror.ID,
 		Namespace:  cached.Namespace.ID,
-		Controller: syncer.pubsub.hostname,
+		Controller: syncer.pubsub.Hostname,
 		Deadline:   deadline,
 	})
 	if err != nil {
@@ -518,7 +518,7 @@ func (syncer *syncer) fail(cached *database.CacheData, mirror *database.Mirror, 
 		return
 	}
 
-	act, err = act.Update().SetController(syncer.pubsub.hostname).SetEndAt(time.Now()).SetStatus(util.MirrorActivityStatusFailed).Save(ctx)
+	act, err = act.Update().SetController(syncer.pubsub.Hostname).SetEndAt(time.Now()).SetStatus(util.MirrorActivityStatusFailed).Save(ctx)
 	if err != nil {
 		syncer.sugar.Error(err)
 		return
@@ -561,7 +561,7 @@ func (syncer *syncer) success(cached *database.CacheData, mirror *database.Mirro
 		return errors.New("activity somehow already done")
 	}
 
-	act, err = act.Update().SetController(syncer.pubsub.hostname).SetEndAt(time.Now()).SetStatus(util.MirrorActivityStatusComplete).Save(ctx)
+	act, err = act.Update().SetController(syncer.pubsub.Hostname).SetEndAt(time.Now()).SetStatus(util.MirrorActivityStatusComplete).Save(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/flow/timeouts.go
+++ b/pkg/flow/timeouts.go
@@ -24,8 +24,8 @@ func (engine *engine) scheduleTimeout(im *instanceMemory, oldController string, 
 
 	// cancel existing timeouts
 
-	engine.timers.deleteTimerByName(oldController, engine.pubsub.hostname, oldId)
-	engine.timers.deleteTimerByName(oldController, engine.pubsub.hostname, id)
+	engine.timers.deleteTimerByName(oldController, engine.pubsub.Hostname, oldId)
+	engine.timers.deleteTimerByName(oldController, engine.pubsub.Hostname, id)
 
 	// schedule timeout
 


### PR DESCRIPTION
## Description

Moving the `pubsub.go` into a own package. 
This step is needed to refactor the logging into a own package.
And would help us to write unit tests for pub sub functionality.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [x] Other