### PR TITLE
workaround golangci-lint issue.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.0
       - name: Get the version tag

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.0
       - name: Set env

--- a/.github/workflows/go-licenses.yml
+++ b/.github/workflows/go-licenses.yml
@@ -16,7 +16,7 @@ jobs:
     name: licenses-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.0
       - uses: actions/checkout@v3

--- a/.github/workflows/go-unittests.yml
+++ b/.github/workflows/go-unittests.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-unittests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.0
       - uses: actions/checkout@v3

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -16,7 +16,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.0
           version: v1.52

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,22 @@ linters:
     - cyclop
     - godox # must fix
 
+
+    # Workarround to fix issue https://github.com/golangci/golangci-lint/issues/3711
+    # This workarround is mentioned here https://github.com/golangci/golangci-lint/issues/3086#issuecomment-1475232706
+    # under "current list".
+    # TODO: watch for new golangci-lint version to fix this issue.
+    - bodyclose # must fix
+    - contextcheck
+    - nilerr
+    - rowserrcheck
+    - unparam
+    - noctx
+    - sqlclosecheck
+    - tparallel
+    - wastedassign
+
+
   presets:
     - bugs
     - comment


### PR DESCRIPTION
## Description

This PR workaround golangci-lint [panic: cannot convert *t0 (M) to PM) issue](https://github.com/golangci/golangci-lint/issues/3711)