### PR TITLE
fix build on windows platform

### DIFF
--- a/cmd/secrets/entry.go
+++ b/cmd/secrets/entry.go
@@ -21,7 +21,7 @@ func RunApplication() {
 
 	go func() {
 		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
+		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM, syscall.Signal(0xA))
 		<-sig
 		srv.Stop()
 		<-sig

--- a/cmd/sidecar/signal.go
+++ b/cmd/sidecar/signal.go
@@ -3,9 +3,8 @@ package sidecar
 import (
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 // SignalListener controls the signals for a sidecar.
@@ -18,7 +17,7 @@ type SignalListener struct {
 func (sl *SignalListener) Start() {
 	sl.signals = make(chan os.Signal, 2)
 	sl.stopper = make(chan *time.Time, 1)
-	signal.Notify(sl.signals, os.Interrupt, unix.SIGTERM)
+	signal.Notify(sl.signals, os.Interrupt, syscall.SIGTERM)
 
 	log.Debug("Listening for signals.")
 


### PR DESCRIPTION
## Description

if build direktiv.exe on windows platform, it will occur build error
```
# github.com/direktiv/direktiv/cmd/secrets
cmd\secrets\entry.go:24:63: undefined: syscall.SIGUSR1
# github.com/direktiv/direktiv/cmd/sidecar
cmd\sidecar\signal.go:21:47: undefined: unix.SIGTERM
```
## Purpose

- [X] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

go build -o direktiv.exe -tags osusergo,netgo  cmd/direktiv/main.go

## Test Platform Details (if applicable)

**Operating system:** Windows 10

## Checklist
- [X] PR is signed
