### PR TITLE
prepare betterlogger to replace the old solution

### DIFF
--- a/pkg/flow/engine.go
+++ b/pkg/flow/engine.go
@@ -586,7 +586,7 @@ func (engine *engine) transformState(ctx context.Context, im *instanceMemory, tr
 		return nil
 	}
 
-	engine.logger.Debug(ctx, im.GetInstanceID(), im.GetAttributes(), "Transforming state data.")
+	engine.logger.Debugf(ctx, im.GetInstanceID(), im.GetAttributes(), "Transforming state data.")
 
 	x, err := jqObject(im.data, transition.Transform)
 	if err != nil {

--- a/pkg/flow/server.go
+++ b/pkg/flow/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/direktiv/direktiv/pkg/flow/database/entwrapper"
 	"github.com/direktiv/direktiv/pkg/flow/database/recipient"
 	"github.com/direktiv/direktiv/pkg/flow/grpc"
+	"github.com/direktiv/direktiv/pkg/flow/internallogger"
 	"github.com/direktiv/direktiv/pkg/flow/pubsub"
 	"github.com/direktiv/direktiv/pkg/metrics"
 	"github.com/direktiv/direktiv/pkg/refactor/core"
@@ -70,10 +71,11 @@ type server struct {
 	vars     *vars
 	actions  *actions
 
-	metrics  *metrics.Client
-	logger   logengine.BetterLogger
-	edb      *entwrapper.Database // TODO: remove
-	database *database.CachedDatabase
+	metrics    *metrics.Client
+	logger     *internallogger.Logger // TODO: remove
+	loggerBeta logengine.BetterLogger
+	edb        *entwrapper.Database // TODO: remove
+	database   *database.CachedDatabase
 }
 
 func Run(ctx context.Context, logger *zap.SugaredLogger, conf *util.Config) error {
@@ -104,6 +106,7 @@ func newServer(logger *zap.SugaredLogger, conf *util.Config) (*server, error) {
 		return nil, err
 	}
 
+	srv.logger = internallogger.InitLogger()
 	srv.initJQ()
 
 	return srv, nil
@@ -196,6 +199,7 @@ func (srv *server) start(ctx context.Context) error {
 		return err
 	}
 	defer srv.cleanup(srv.pubsub.Close)
+	srv.logger.StartLogWorkers(1, srv.edb, srv.pubsub, srv.sugar)
 
 	srv.sugar.Debug("Initializing timers.")
 
@@ -263,15 +267,11 @@ func (srv *server) start(ctx context.Context) error {
 	logger, logworker, closelogworker := logengine.NewCachedLogger(1024,
 		store.Logs().Append,
 		func(objectID uuid.UUID, objectType string) {
-			re, ok := recipient.Convert(objectType)
-			if !ok {
-				panic("invalid recipient type")
-			}
-			srv.pubsub.NotifyLogs(objectID, re)
+			srv.pubsub.NotifyLogs(objectID, recipient.RecipientType(objectType))
 		},
 		srv.sugar.Errorf,
 	)
-	srv.logger = logengine.ChainedBetterLogger{
+	srv.loggerBeta = logengine.ChainedBetterLogger{
 		logengine.SugarBetterLogger{
 			Sugar: srv.sugar,
 			AddTraceFrom: func(ctx context.Context, toTags map[string]string) map[string]string {
@@ -411,6 +411,7 @@ func (srv *server) start(ctx context.Context) error {
 
 	wg.Wait()
 
+	srv.logger.CloseLogWorkers()
 	closelogworker()
 
 	if err != nil {

--- a/pkg/flow/server.go
+++ b/pkg/flow/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/direktiv/direktiv/pkg/flow/database/entwrapper"
 	"github.com/direktiv/direktiv/pkg/flow/database/recipient"
 	"github.com/direktiv/direktiv/pkg/flow/grpc"
-	"github.com/direktiv/direktiv/pkg/flow/internallogger"
 	"github.com/direktiv/direktiv/pkg/flow/pubsub"
 	"github.com/direktiv/direktiv/pkg/metrics"
 	"github.com/direktiv/direktiv/pkg/refactor/core"
@@ -71,11 +70,10 @@ type server struct {
 	vars     *vars
 	actions  *actions
 
-	metrics    *metrics.Client
-	logger     *internallogger.Logger // TODO: remove
-	loggerBeta logengine.BetterLogger
-	edb        *entwrapper.Database // TODO: remove
-	database   *database.CachedDatabase
+	metrics  *metrics.Client
+	logger   logengine.BetterLogger
+	edb      *entwrapper.Database // TODO: remove
+	database *database.CachedDatabase
 }
 
 func Run(ctx context.Context, logger *zap.SugaredLogger, conf *util.Config) error {
@@ -106,7 +104,6 @@ func newServer(logger *zap.SugaredLogger, conf *util.Config) (*server, error) {
 		return nil, err
 	}
 
-	srv.logger = internallogger.InitLogger()
 	srv.initJQ()
 
 	return srv, nil
@@ -199,7 +196,6 @@ func (srv *server) start(ctx context.Context) error {
 		return err
 	}
 	defer srv.cleanup(srv.pubsub.Close)
-	srv.logger.StartLogWorkers(1, srv.edb, srv.pubsub, srv.sugar)
 
 	srv.sugar.Debug("Initializing timers.")
 
@@ -267,17 +263,21 @@ func (srv *server) start(ctx context.Context) error {
 	logger, logworker, closelogworker := logengine.NewCachedLogger(1024,
 		store.Logs().Append,
 		func(objectID uuid.UUID, objectType string) {
-			srv.pubsub.NotifyLogs(objectID, recipient.RecipientType(objectType))
+			re, ok := recipient.Convert(objectType)
+			if !ok {
+				panic("invalid recipient type")
+			}
+			srv.pubsub.NotifyLogs(objectID, re)
 		},
 		srv.sugar.Errorf,
 	)
-	srv.loggerBeta = logengine.ChainedBetterLogger{
+	srv.logger = logengine.ChainedBetterLogger{
 		logengine.SugarBetterLogger{
 			Sugar: srv.sugar,
-			AddTraceFrom: func(ctx context.Context, toTags map[string]interface{}) map[string]interface{} {
+			AddTraceFrom: func(ctx context.Context, toTags map[string]string) map[string]string {
 				span := trace.SpanFromContext(ctx)
 				tid := span.SpanContext().TraceID()
-				toTags["trace"] = tid
+				toTags["trace"] = tid.String()
 				return toTags
 			},
 		},
@@ -411,7 +411,6 @@ func (srv *server) start(ctx context.Context) error {
 
 	wg.Wait()
 
-	srv.logger.CloseLogWorkers()
 	closelogworker()
 
 	if err != nil {

--- a/pkg/flow/temporary.go
+++ b/pkg/flow/temporary.go
@@ -137,7 +137,7 @@ func (im *instanceMemory) Log(ctx context.Context, level log.Level, a string, x 
 	case log.Error:
 		im.engine.logger.Errorf(ctx, im.GetInstanceID(), im.GetAttributes(), a, x...)
 	case log.Panic:
-		im.engine.logger.Panicf(ctx, im.GetInstanceID(), im.GetAttributes(), a, x...)
+		im.engine.logger.Errorf(ctx, im.GetInstanceID(), im.GetAttributes(), a, x...)
 	}
 }
 

--- a/pkg/refactor/logengine/logger.go
+++ b/pkg/refactor/logengine/logger.go
@@ -5,46 +5,47 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/direktiv/direktiv/pkg/flow/internallogger"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
 type BetterLogger interface {
-	Debugf(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{})
-	Infof(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{})
-	Errorf(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{})
+	Debugf(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{})
+	Infof(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{})
+	Errorf(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{})
 }
 
 type SugarBetterLogger struct {
 	Sugar        *zap.SugaredLogger
-	AddTraceFrom func(ctx context.Context, toTags map[string]interface{}) map[string]interface{}
+	AddTraceFrom func(ctx context.Context, toTags map[string]string) map[string]string
 }
 
-func (s SugarBetterLogger) Debugf(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (s SugarBetterLogger) Debugf(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	_ = ctx
 	msg = fmt.Sprintf(msg, a...)
 	tags = s.AddTraceFrom(ctx, tags)
-	tags["sender"] = recipientID
+	tags["sender"] = recipientID.String()
 	s.log(Debug, tags, msg)
 }
 
-func (s SugarBetterLogger) Infof(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (s SugarBetterLogger) Infof(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	_ = ctx
 	msg = fmt.Sprintf(msg, a...)
 	tags = s.AddTraceFrom(ctx, tags)
-	tags["sender"] = recipientID
+	tags["sender"] = recipientID.String()
 	s.log(Info, tags, msg)
 }
 
-func (s SugarBetterLogger) Errorf(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (s SugarBetterLogger) Errorf(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	_ = ctx
 	msg = fmt.Sprintf(msg, a...)
 	tags = s.AddTraceFrom(ctx, tags)
-	tags["sender"] = recipientID
+	tags["sender"] = recipientID.String()
 	s.log(Error, tags, msg)
 }
 
-func (s SugarBetterLogger) log(level LogLevel, tags map[string]interface{}, msg string) {
+func (s SugarBetterLogger) log(level LogLevel, tags map[string]string, msg string) {
 	logToSuggar := s.Sugar.Debugw
 	switch level {
 	case Debug:
@@ -65,19 +66,19 @@ func (s SugarBetterLogger) log(level LogLevel, tags map[string]interface{}, msg 
 
 type ChainedBetterLogger []BetterLogger
 
-func (loggers ChainedBetterLogger) Debugf(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (loggers ChainedBetterLogger) Debugf(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	for i := range loggers {
 		loggers[i].Debugf(ctx, recipientID, tags, msg, a...)
 	}
 }
 
-func (loggers ChainedBetterLogger) Infof(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (loggers ChainedBetterLogger) Infof(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	for i := range loggers {
 		loggers[i].Infof(ctx, recipientID, tags, msg, a...)
 	}
 }
 
-func (loggers ChainedBetterLogger) Errorf(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (loggers ChainedBetterLogger) Errorf(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	for i := range loggers {
 		loggers[i].Errorf(ctx, recipientID, tags, msg, a...)
 	}
@@ -91,12 +92,12 @@ type CachedSQLLogStore struct {
 }
 
 type logMessage struct {
-	recipientID    uuid.UUID
-	reciepientType string
-	time           time.Time
-	tags           map[string]interface{}
-	msg            string
-	level          LogLevel
+	recipientID   uuid.UUID
+	recipientType string
+	time          time.Time
+	tags          map[string]string
+	msg           string
+	level         LogLevel
 }
 
 func (cls *CachedSQLLogStore) logWorker() {
@@ -105,11 +106,36 @@ func (cls *CachedSQLLogStore) logWorker() {
 		if !more {
 			return
 		}
-		err := cls.storeAdd(context.Background(), l.time, l.level, l.msg, l.tags)
+		if v, ok := l.tags["callpath"]; ok {
+			if l.tags["callpath"] == "/" {
+				l.tags["root-instance-id"] = l.tags["instance-id"]
+			}
+			l.tags["callpath"] = internallogger.AppendInstanceID(v, l.tags["instance-id"])
+			res, err := internallogger.GetRootinstanceID(v)
+			if err != nil {
+				l.tags["root-instance-id"] = l.tags["instance-id"]
+			} else {
+				l.tags["root-instance-id"] = res
+			}
+		}
+		attributes := make(map[string]string)
+		attributes["recipientType"] = "sender_type"
+		attributes["root-instance-id"] = "root_instance_id"
+		attributes["callpath"] = "log_instance_call_path"
+		for k, v := range attributes {
+			if e, ok := l.tags[k]; ok {
+				l.tags[v] = e
+			}
+		}
+		convertedTags := make(map[string]interface{})
+		for k, v := range l.tags {
+			convertedTags[k] = v
+		}
+		err := cls.storeAdd(context.Background(), l.time, l.level, l.msg, convertedTags)
 		if err != nil {
 			cls.logError("cachedSQLLogStore error storing logs, %v", err)
 		}
-		cls.callback(l.recipientID, l.reciepientType)
+		cls.callback(l.recipientID, l.recipientType)
 	}
 }
 
@@ -128,48 +154,48 @@ func (cls *CachedSQLLogStore) closeLogWorkers() {
 	close(cls.logQueue)
 }
 
-func (cls *CachedSQLLogStore) Debugf(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (cls *CachedSQLLogStore) Debugf(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	_ = ctx
 	select {
 	case cls.logQueue <- &logMessage{
-		time:           time.Now(),
-		recipientID:    recipientID,
-		tags:           tags,
-		msg:            fmt.Sprintf(msg, a...),
-		reciepientType: fmt.Sprintf("%v", tags["sender_type"]),
-		level:          Debug,
+		time:          time.Now(),
+		recipientID:   recipientID,
+		tags:          tags,
+		msg:           fmt.Sprintf(msg, a...),
+		recipientType: fmt.Sprintf("%v", tags["recipientType"]),
+		level:         Debug,
 	}:
 	default:
 		cls.logError("!! Log-buffer is/was full.")
 	}
 }
 
-func (cls *CachedSQLLogStore) Errorf(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (cls *CachedSQLLogStore) Errorf(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	_ = ctx
 	select {
 	case cls.logQueue <- &logMessage{
-		time:           time.Now(),
-		recipientID:    recipientID,
-		tags:           tags,
-		msg:            fmt.Sprintf(msg, a...),
-		reciepientType: fmt.Sprintf("%v", tags["sender_type"]),
-		level:          Error,
+		time:          time.Now(),
+		recipientID:   recipientID,
+		tags:          tags,
+		msg:           fmt.Sprintf(msg, a...),
+		recipientType: fmt.Sprintf("%v", tags["recipientType"]),
+		level:         Error,
 	}:
 	default:
 		cls.logError("!! Log-buffer is/was full.")
 	}
 }
 
-func (cls *CachedSQLLogStore) Infof(ctx context.Context, recipientID uuid.UUID, tags map[string]interface{}, msg string, a ...interface{}) {
+func (cls *CachedSQLLogStore) Infof(ctx context.Context, recipientID uuid.UUID, tags map[string]string, msg string, a ...interface{}) {
 	_ = ctx
 	select {
 	case cls.logQueue <- &logMessage{
-		time:           time.Now(),
-		recipientID:    recipientID,
-		tags:           tags,
-		msg:            fmt.Sprintf(msg, a...),
-		reciepientType: fmt.Sprintf("%v", tags["sender_type"]),
-		level:          Info,
+		time:          time.Now(),
+		recipientID:   recipientID,
+		tags:          tags,
+		msg:           fmt.Sprintf(msg, a...),
+		recipientType: fmt.Sprintf("%v", tags["recipientType"]),
+		level:         Info,
 	}:
 	default:
 		cls.logError("!! Log-buffer is/was full.")


### PR DESCRIPTION
## Description
this PR prepares the new logger to replace the old internal logger.
- change the type of the tags from map[string]interface{} to map[string]string
- Add the mapping from the user-facing tag keys to the new db-column names from the PR https://github.com/direktiv/direktiv/pull/937
- fix one line in engine.go so that it will work with the new logger