### PR TITLE
Rm -p1 argument

### DIFF
--- a/.github/workflows/go-unittests.yml
+++ b/.github/workflows/go-unittests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-            go test $(go list ./... | egrep -v '(direktiv/pkg/flow/ent|direktiv/pkg/flow/grpc)') -coverprofile coverage.out -covermode count -p 1
+            go test $(go list ./... | egrep -v '(direktiv/pkg/flow/ent|direktiv/pkg/flow/grpc)') -coverprofile coverage.out -covermode count
             go tool cover -func coverage.out
 
       - name: Quality Gate - Test coverage shall be above threshold

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ UNITTEST_PACKAGES = $(shell echo ${TEST_PACKAGES} | sed 's/ /\n/g' | awk '{print
 
 .PHONY: unittest
 unittest: ## Runs all Go unit tests. Or, you can run a specific set of unit tests by defining TEST_PACKAGES relative to the root directory.
-	go test -p 1 -cover -timeout 60s ${UNITTEST_PACKAGES}
+	go test -cover -timeout 60s ${UNITTEST_PACKAGES}
 
 
 .PHONY: lint 


### PR DESCRIPTION
## Description

this PR removes the -p1 argument since its no longer needed.
It was used when we used the embedded postgres db inside the unit-tests 