### PR TITLE
Pin reinstall script to helm-charts develop branch

### DIFF
--- a/scripts/reinstall-dev-stack.sh
+++ b/scripts/reinstall-dev-stack.sh
@@ -18,7 +18,7 @@ helm repo add direktiv https://chart.direktiv.io
 
 if [ ! -d "$dir/direktiv-charts" ]; then
   git clone https://github.com/direktiv/direktiv-charts.git $dir/direktiv-charts;
-  git -C $dir/direktiv-charts checkout temp-remove-secrets;
+  git -C $dir/direktiv-charts checkout develop;
 fi
 
 cd $dir/direktiv-charts/charts/knative-instance && helm dependency update $dir/direktiv-charts/charts/knative-instance


### PR DESCRIPTION
## Description

Removes the need that we always have to remember to update the branch-name used in the current helm-chart branch.
Instead we should just apply our newest patches to the develop branch in the helm-chart repo so that i will be used by our reinstall-script 