### PR TITLE
Fix sanitize-path breaks the backend

### DIFF
--- a/pkg/refactor/filestore/path.go
+++ b/pkg/refactor/filestore/path.go
@@ -1,25 +1,24 @@
 package filestore
 
 import (
-	"errors"
+	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
-
-	"github.com/direktiv/direktiv/pkg/util"
 )
 
-var pathRegexExp = util.URIRegex
+var pathRegexExp = regexp.MustCompile(`^[a-zA-Z0-9_.\-\/]*$`)
 
-// SanitizePath standardizes and sanitized the path, and validates it against naming requirements.
+// SanitizePath standardizes and sanitizes the path, and validates it against naming requirements.
 func SanitizePath(path string) (string, error) {
-	path = filepath.Join("/", path)
-	path = filepath.Clean(path)
-
+	path = "/" + filepath.Join("/", path)
+	cleanedPath := filepath.Clean(path) // filepath.Clean() is unnecessary and can lead to potential issues,
+	// especially when dealing with URLs or paths containing dot-segments (e.g., /../ or /./).
 	if !pathRegexExp.MatchString(path) {
-		return "", errors.New("invalid path string")
+		return "", fmt.Errorf("invalid path string; orig:  %v sanitized: %v", path, cleanedPath)
 	}
 
-	return path, nil
+	return cleanedPath, nil
 }
 
 // GetPathDepth reads the path and returns the depth value. Use SanitizePath first, because if an error


### PR DESCRIPTION
This reverts commit 1cb2e49

creating a namespace was not possible this PR fixes the issue by reverting the change to the regex

See: https://github.com/direktiv/direktiv/actions/runs/5471876848/job/14815699997 for the origin of the issue