### PR TITLE
Fix pipeline should not run private tests

### DIFF
--- a/.github/workflows/go-unittests.yml
+++ b/.github/workflows/go-unittests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-            go test $(go list ./... | egrep -v '(direktiv/pkg/flow/ent|direktiv/pkg/flow/grpc)') -coverprofile coverage.out -covermode count
+            go test $(go list ./... | egrep -v '(direktiv/pkg/flow/ent|direktiv/pkg/flow/grpc)') -coverprofile coverage.out -covermode count -run 'Test'
             go tool cover -func coverage.out
 
       - name: Quality Gate - Test coverage shall be above threshold


### PR DESCRIPTION
## Description

This PR changes the unit-test pipeline so that it excludes tests testing private methods from the pipeline.