### PR TITLE
Fix non-mirror gateway routes

### DIFF
--- a/pkg/flow/grpc-namespaces.go
+++ b/pkg/flow/grpc-namespaces.go
@@ -251,6 +251,11 @@ func (flow *flow) CreateNamespace(ctx context.Context, req *grpc.CreateNamespace
 	var resp grpc.CreateNamespaceResponse
 	resp.Namespace = bytedata.ConvertNamespaceToGrpc(ns, annotations)
 
+	err = flow.pBus.Publish(pubsub2.NamespaceCreate, ns.Name)
+	if err != nil {
+		flow.sugar.Error("pubsub publish", "error", err)
+	}
+
 	return &resp, nil
 }
 

--- a/pkg/refactor/cmd/main.go
+++ b/pkg/refactor/cmd/main.go
@@ -96,6 +96,7 @@ func NewMain(config *core.Config, db *database.DB, pbus pubsub.Bus, logger *zap.
 	pbus.Subscribe(func(ns string) {
 		gatewayManager.UpdateNamespace(ns)
 	},
+		pubsub.NamespaceCreate,
 		pubsub.MirrorSync,
 		pubsub.EndpointCreate,
 		pubsub.EndpointUpdate,

--- a/pkg/refactor/pubsub/pubsub_sql.go
+++ b/pkg/refactor/pubsub/pubsub_sql.go
@@ -28,6 +28,7 @@ var (
 
 	MirrorSync      = "mirror_sync"
 	NamespaceDelete = "namespace_delete"
+	NamespaceCreate = "namespace_create"
 
 	SecretCreate = "secret_create"
 	SecretDelete = "secret_delete"

--- a/tests/gateway/endpoints_crud.test.js
+++ b/tests/gateway/endpoints_crud.test.js
@@ -63,6 +63,28 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+describe("Test gateway endpoints on create", () => {
+  beforeAll(common.helpers.deleteAllNamespaces);
+
+    common.helpers.itShouldCreateNamespace(it, expect, testNamespace);
+
+    retry(`should list all endpoints`, 10, async () => {
+      const listRes = await request(common.config.getDirektivHost()).get(
+        `/api/v2/namespaces/${testNamespace}/gateway/routes`
+      );
+      expect(listRes.statusCode).toEqual(200);
+      expect(listRes.body.data.length).toEqual(0);
+      expect(listRes.body.data).toEqual(
+        expect.arrayContaining(
+          [
+          ]
+        )
+      );
+    });
+  
+
+});
+
 describe("Test gateway endpoints crud operations", () => {
   beforeAll(common.helpers.deleteAllNamespaces);
 


### PR DESCRIPTION
## Description

The gateway route structures are getting setup on git mirror. This did not work with local-only namespaces. This adds a pubsub for namespace create which triggers the gateway setup.