### PR TITLE
[DIR-1141] reenable the updated at in the code editor

### DIFF
--- a/pkg/flow/grpc-workflow.go
+++ b/pkg/flow/grpc-workflow.go
@@ -275,6 +275,10 @@ func (flow *flow) UpdateWorkflow(ctx context.Context, req *grpc.UpdateWorkflowRe
 			return nil, err
 		}
 	}
+	file, err = tx.FileStore().ForNamespace(ns.Name).GetFile(ctx, req.GetPath())
+	if err != nil {
+		return nil, err
+	}
 
 	if err = tx.Commit(ctx); err != nil {
 		return nil, err

--- a/ui/e2e/errorPage.spec.ts
+++ b/ui/e2e/errorPage.spec.ts
@@ -62,10 +62,12 @@ test("the home button on the error page navigates the user to the home page", as
   page,
 }) => {
   await page.goto("/this/page/does/not/exist");
-  await page.getByTestId("error-home-btn").click();
-  const currentUrl = new URL(await page.url());
-  expect(
-    currentUrl.pathname,
-    "clicking the home button on the 404 page navigates to '/'"
-  ).toBe("/");
+  await expect(
+    page.getByRole("link", { name: "Go to homepage" }),
+    "the home button links to /"
+  ).toHaveAttribute("href", "/");
+  /**
+   * note: the user may be redirected to the first existing namespace
+   * when visiting /. This behavior is tested in onboarding.spec.ts
+   */
 });

--- a/ui/e2e/explorer/workflow/codeEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/codeEditor.spec.ts
@@ -95,4 +95,10 @@ test("it is possible to save the workflow", async ({ page }) => {
     page.getByText(testText),
     "after reloading, screen should have the updated text"
   ).toBeVisible();
+
+  // check the text at the bottom left
+  await expect(
+    page.getByTestId("workflow-txt-updated"),
+    "text should be Updated a few seconds ago"
+  ).toHaveText("Updated a few seconds ago");
 });

--- a/ui/e2e/notificationmenu/index.spec.ts
+++ b/ui/e2e/notificationmenu/index.spec.ts
@@ -97,17 +97,17 @@ test("Notification Bell updates depending on the count of Notification Messages"
   expect(
     await notificationText.textContent(),
     "the modal should now display 'You have 1 uninitialized secret.'"
-  ).toMatch(/You have 1 uninitialized secret./);
+  ).toMatch("You have 1 uninitialized secret.");
 
   await initialize_secret2.click();
 
   await page.getByTestId("new-secret-editor").fill("123");
   await page.getByTestId("secret-create-submit").click();
 
-  expect(
-    page.getByTestId("notification-indicator").nth(1),
+  await expect(
+    page.getByTestId("notification-indicator"),
     "the indicator for new messages is NOT visible"
-  ).not.toBeVisible();
+  ).toHaveCount(0);
 
   await notificationBell.click();
 

--- a/ui/public/locales/en/translation.json
+++ b/ui/public/locales/en/translation.json
@@ -177,6 +177,7 @@
           "settings": "Settings",
           "services": "Services"
         },
+        "updated": "Updated {{relativeTime}} ago",
         "runBtn": "Run",
         "apiCommands": {
           "tooltip": "Open API commands",

--- a/ui/src/pages/namespace/Explorer/Workflow/Edit/CodeEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Edit/CodeEditor.tsx
@@ -6,12 +6,14 @@ import Editor from "~/design/Editor";
 import { FC } from "react";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
+import useUpdatedAt from "~/hooks/useUpdatedAt";
 
 type EditorProps = {
   value: string;
   onValueChange: (value: string) => void;
   onSave: Parameters<typeof Editor>[0]["onSave"];
   hasUnsavedChanges: boolean;
+  updatedAt: string | undefined;
   error: string | undefined;
 };
 
@@ -20,10 +22,12 @@ export const CodeEditor: FC<EditorProps> = ({
   onValueChange,
   onSave,
   hasUnsavedChanges,
+  updatedAt,
   error,
 }) => {
   const { t } = useTranslation();
   const theme = useTheme();
+  const updatedAtInWords = useUpdatedAt(updatedAt);
 
   return (
     <Card className="flex grow flex-col p-4">
@@ -44,6 +48,13 @@ export const CodeEditor: FC<EditorProps> = ({
         className="flex justify-between gap-2 pt-2 text-sm text-gray-8 dark:text-gray-dark-8"
         data-testid="workflow-txt-updated"
       >
+        {updatedAt && !error && (
+          <>
+            {t("pages.explorer.workflow.updated", {
+              relativeTime: updatedAtInWords,
+            })}
+          </>
+        )}
         {error && (
           <Popover defaultOpen>
             <PopoverTrigger asChild>

--- a/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
@@ -74,6 +74,7 @@ const WorkflowEditor: FC<{
           <CodeEditor
             value={editorContent}
             onValueChange={onEditorContentUpdate}
+            updatedAt={data.node.updatedAt}
             error={error}
             hasUnsavedChanges={hasUnsavedChanges}
             onSave={onSave}

--- a/ui/src/util/router/ErrorPage.tsx
+++ b/ui/src/util/router/ErrorPage.tsx
@@ -41,13 +41,7 @@ const ErrorPage = () => {
           <RefreshCcw />
           {t("pages.error.reload")}
         </Button>
-        <Button
-          variant="primary"
-          asChild
-          isAnchor
-          className="col-span-2"
-          data-testid="error-home-btn"
-        >
+        <Button variant="primary" asChild isAnchor className="col-span-2">
           <Link to="/">
             <Home />
             {t("pages.error.goHome")}


### PR DESCRIPTION
## Description

Show the last time the file was changed in the code editor again. This also fixes a backend issue where the response of the file update, did return the old updated at

## Checklist

- [x] Documentation updated if required
- [x] Are tests available
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
