### PR TITLE
[DIR-1025] Instance shows finished in UI although not completed

### DIFF
--- a/ui/src/pages/namespace/Instances/Detail/InstanceDetail.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/InstanceDetail.tsx
@@ -32,7 +32,11 @@ const InstancesDetail = () => {
         layout={preferedLayout}
         logComponent={<Logs />}
         diagramComponent={
-          <Diagram workflowPath={data.instance.as} flow={data.flow} />
+          <Diagram
+            workflowPath={data.instance.as}
+            flow={data.flow}
+            status={data.instance.status}
+          />
         }
         inputOutputComponent={<InputOutput />}
       />

--- a/ui/src/pages/namespace/Instances/Detail/Main/Diagram/index.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/Diagram/index.tsx
@@ -14,6 +14,7 @@ import Button from "~/design/Button";
 import { FC } from "react";
 import { InstanceSchemaType } from "~/api/instances/schema";
 import WorkflowDiagram from "~/design/WorkflowDiagram";
+import { instanceStatusToDiagramStatus } from "./utils";
 import { useNodeContent } from "~/api/tree/query/node";
 import { useTranslation } from "react-i18next";
 
@@ -23,7 +24,7 @@ type DiagramProps = {
   status: InstanceSchemaType["status"];
 };
 
-const Diagram: FC<DiagramProps> = ({ workflowPath, flow }) => {
+const Diagram: FC<DiagramProps> = ({ workflowPath, flow, status }) => {
   const { data } = useNodeContent({ path: workflowPath });
   const { setMaximizedPanel } = useLogsPreferencesActions();
   const { t } = useTranslation();
@@ -64,7 +65,7 @@ const Diagram: FC<DiagramProps> = ({ workflowPath, flow }) => {
         workflow={workflowData}
         flow={flow}
         orientation="horizontal"
-        instanceStatus="complete"
+        instanceStatus={instanceStatusToDiagramStatus(status)}
       />
     </div>
   );

--- a/ui/src/pages/namespace/Instances/Detail/Main/Diagram/index.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/Diagram/index.tsx
@@ -12,14 +12,18 @@ import {
 
 import Button from "~/design/Button";
 import { FC } from "react";
+import { InstanceSchemaType } from "~/api/instances/schema";
 import WorkflowDiagram from "~/design/WorkflowDiagram";
 import { useNodeContent } from "~/api/tree/query/node";
 import { useTranslation } from "react-i18next";
 
-const Diagram: FC<{ workflowPath: string; flow: string[] }> = ({
-  workflowPath,
-  flow,
-}) => {
+type DiagramProps = {
+  workflowPath: string;
+  flow: string[];
+  status: InstanceSchemaType["status"];
+};
+
+const Diagram: FC<DiagramProps> = ({ workflowPath, flow }) => {
   const { data } = useNodeContent({ path: workflowPath });
   const { setMaximizedPanel } = useLogsPreferencesActions();
   const { t } = useTranslation();

--- a/ui/src/pages/namespace/Instances/Detail/Main/Diagram/utils.ts
+++ b/ui/src/pages/namespace/Instances/Detail/Main/Diagram/utils.ts
@@ -1,0 +1,21 @@
+import { ComponentProps } from "react";
+import { InstanceSchemaType } from "~/api/instances/schema";
+import WorkflowDiagram from "~/design/WorkflowDiagram";
+
+type DiagramStatus = ComponentProps<typeof WorkflowDiagram>["instanceStatus"];
+
+export const instanceStatusToDiagramStatus = (
+  status: InstanceSchemaType["status"]
+): DiagramStatus => {
+  switch (status) {
+    case "failed":
+      return "failed";
+    case "complete":
+      return "complete";
+    case "crashed":
+      return "failed";
+    case "pending":
+    default:
+      return undefined;
+  }
+};


### PR DESCRIPTION
## Description

The diagram of a workflow instance shows the finish state, even if the workflow is still running.

## Checklist

- [x] Documentation updated if required
- [x] Evaluate if tests are required
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled

## Reproduce the issue

- Create this workflow that runs for 20 seconds and finishes afterwards
```yaml
direktiv_api: workflow/v1
description: A simple 'delay' state that waits for 5 seconds
states:
- id: delay
  type: delay
  duration: PT20S
``` 
- run the workflow
- the diagram displays the workflow as completed, even if it is still pending

![CleanShot 2024-01-31 at 12 18 36@2x](https://github.com/direktiv/direktiv/assets/121789579/1945dfc8-0b00-4573-9052-161e8accb32e)

Fixed in this PR: the diagram does not indicate that the workflow has completed

![CleanShot 2024-01-31 at 12 19 05@2x](https://github.com/direktiv/direktiv/assets/121789579/4bd85428-ed59-4fd1-a2b2-ed1642414581)