### PR TITLE
[DIR-1194] test consumer editor

### DIFF
--- a/ui/e2e/explorer/consumer/index.spec.ts
+++ b/ui/e2e/explorer/consumer/index.spec.ts
@@ -1,0 +1,149 @@
+import { createNamespace, deleteNamespace } from "e2e/utils/namespace";
+import { expect, test } from "@playwright/test";
+
+import { faker } from "@faker-js/faker";
+
+let namespace = "";
+
+test.beforeEach(async () => {
+  namespace = await createNamespace();
+});
+
+test.afterEach(async () => {
+  await deleteNamespace(namespace);
+  namespace = "";
+});
+
+test("it is possible to create a consumer", async ({ page }) => {
+  /* prepare data */
+  const filename = "myconsumer.yaml";
+  const groups = Array.from({ length: 5 }, () => faker.lorem.word());
+  const tags = Array.from({ length: 2 }, () => faker.lorem.word());
+  const groupsYaml = groups.map((group) => `\n  - "${group}"`).join("");
+  const tagsYaml = tags.map((tag) => `\n  - "${tag}"`).join("");
+
+  const expectedYaml = `direktiv_api: "consumer/v1"
+  username: "my-username"
+  password: "a-v3ry-g00d-pASSw0rd"
+  api_key: "some-api-key"
+  tags:${tagsYaml}
+  groups:${groupsYaml}
+  `;
+
+  /* visit page */
+  await page.goto(`/${namespace}/explorer/tree`, { waitUntil: "networkidle" });
+  await expect(
+    page.getByTestId("breadcrumb-namespace"),
+    "it navigates to the test namespace in the explorer"
+  ).toHaveText(namespace);
+
+  /* create consumer */
+  await page.getByRole("button", { name: "New" }).first().click();
+  await page.getByRole("menuitem", { name: "Gateway" }).click();
+  await page.getByRole("button", { name: "New Consumer" }).click();
+
+  await expect(page.getByRole("button", { name: "Create" })).toBeDisabled();
+  await page.getByPlaceholder("consumer-name.yaml").fill(filename);
+  await page.getByRole("button", { name: "Create" }).click();
+
+  await expect(
+    page,
+    "it creates the service and opens the file in the explorer"
+  ).toHaveURL(`/${namespace}/explorer/consumer/${filename}`);
+
+  /* fill in form */
+  await page.getByLabel("Username").fill("my-username");
+  await page.getByLabel("Password").fill("a-v3ry-g00d-pASSw0rd");
+  await page.getByLabel("Api key").fill("some-api-key");
+
+  const groupsElement = page.getByPlaceholder("Enter a group");
+
+  await Promise.all(
+    groups.map(async (group, index) => {
+      await expect(
+        groupsElement,
+        "it renders one input for every existing group +1 empty one"
+      ).toHaveCount(index + 1);
+
+      await groupsElement.last().fill(group);
+      await page
+        .locator("fieldset")
+        .filter({ hasText: "Groups (optional)" })
+        .getByRole("button")
+        .last()
+        .click();
+    })
+  );
+
+  const tagsElement = page.getByPlaceholder("Enter a tag");
+  await Promise.all(
+    tags.map(async (tag, index) => {
+      await expect(
+        tagsElement,
+        "it renders one input for every existing tag +1 empty one"
+      ).toHaveCount(index + 1);
+
+      await tagsElement.last().fill(tag);
+      await page
+        .locator("fieldset")
+        .filter({ hasText: "Tags (optional)" })
+        .getByRole("button")
+        .last()
+        .click();
+    })
+  );
+
+  const editor = page.locator(".lines-content");
+
+  await expect(
+    editor,
+    "all entered data is represented in the editor preview"
+  ).toContainText(expectedYaml, { useInnerText: true });
+
+  await expect(
+    page.getByTestId("unsaved-note"),
+    "it renders a hint that there are unsaved changes"
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(
+    page.getByTestId("unsaved-note"),
+    "it does not render a hint that there are unsaved changes"
+  ).not.toBeVisible();
+
+  /* reload and assert data has been persisted */
+  await page.reload({ waitUntil: "domcontentloaded" });
+
+  await expect(
+    editor,
+    "after reloading, the entered data is still in the editor preview"
+  ).toContainText(expectedYaml, { useInnerText: true });
+
+  await expect(page.getByLabel("Username")).toHaveValue("my-username");
+  await expect(page.getByLabel("Password")).toHaveValue("a-v3ry-g00d-pASSw0rd");
+  await expect(page.getByLabel("Api Key")).toHaveValue("some-api-key");
+
+  await Promise.all(
+    groups.map(async (group, index) => {
+      await expect(
+        page
+          .locator("fieldset")
+          .filter({ hasText: "Groups (optional)" })
+          .getByRole("textbox")
+          .nth(index)
+      ).toHaveValue(group);
+    })
+  );
+
+  await Promise.all(
+    tags.map(async (group, index) => {
+      await expect(
+        page
+          .locator("fieldset")
+          .filter({ hasText: "Tags (optional)" })
+          .getByRole("textbox")
+          .nth(index)
+      ).toHaveValue(group);
+    })
+  );
+});

--- a/ui/e2e/explorer/consumer/index.spec.ts
+++ b/ui/e2e/explorer/consumer/index.spec.ts
@@ -1,6 +1,7 @@
 import { createNamespace, deleteNamespace } from "e2e/utils/namespace";
 import { expect, test } from "@playwright/test";
 
+import { createConsumerYaml } from "./utils";
 import { faker } from "@faker-js/faker";
 
 let namespace = "";
@@ -19,16 +20,14 @@ test("it is possible to create a consumer", async ({ page }) => {
   const filename = "myconsumer.yaml";
   const groups = Array.from({ length: 5 }, () => faker.lorem.word());
   const tags = Array.from({ length: 2 }, () => faker.lorem.word());
-  const groupsYaml = groups.map((group) => `\n  - "${group}"`).join("");
-  const tagsYaml = tags.map((tag) => `\n  - "${tag}"`).join("");
 
-  const expectedYaml = `direktiv_api: "consumer/v1"
-  username: "my-username"
-  password: "a-v3ry-g00d-pASSw0rd"
-  api_key: "some-api-key"
-  tags:${tagsYaml}
-  groups:${groupsYaml}
-  `;
+  const expectedYaml = createConsumerYaml({
+    username: "my-username",
+    password: "a-v3ry-g00d-pASSw0rd",
+    apiKey: "some-api-key",
+    groups,
+    tags,
+  });
 
   /* visit page */
   await page.goto(`/${namespace}/explorer/tree`, { waitUntil: "networkidle" });

--- a/ui/e2e/explorer/consumer/index.spec.ts
+++ b/ui/e2e/explorer/consumer/index.spec.ts
@@ -57,40 +57,45 @@ test("it is possible to create a consumer", async ({ page }) => {
 
   const groupsElement = page.getByPlaceholder("Enter a group");
 
-  await Promise.all(
-    groups.map(async (group, index) => {
-      await expect(
-        groupsElement,
-        "it renders one input for every existing group +1 empty one"
-      ).toHaveCount(index + 1);
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups?.[i];
+    if (!group) {
+      throw new Error("group is undefined");
+    }
 
-      await groupsElement.last().fill(group);
-      await page
-        .locator("fieldset")
-        .filter({ hasText: "Groups (optional)" })
-        .getByRole("button")
-        .last()
-        .click();
-    })
-  );
+    await expect(
+      groupsElement,
+      "it renders one input for every existing group +1 empty one"
+    ).toHaveCount(i + 1);
+    await groupsElement.last().fill(group);
+    await page
+      .locator("fieldset")
+      .filter({ hasText: "Groups (optional)" })
+      .getByRole("button")
+      .last()
+      .click();
+  }
 
   const tagsElement = page.getByPlaceholder("Enter a tag");
-  await Promise.all(
-    tags.map(async (tag, index) => {
-      await expect(
-        tagsElement,
-        "it renders one input for every existing tag +1 empty one"
-      ).toHaveCount(index + 1);
 
-      await tagsElement.last().fill(tag);
-      await page
-        .locator("fieldset")
-        .filter({ hasText: "Tags (optional)" })
-        .getByRole("button")
-        .last()
-        .click();
-    })
-  );
+  for (let i = 0; i < tags.length; i++) {
+    const tag = tags?.[i];
+    if (!tag) {
+      throw new Error("tag is undefined");
+    }
+
+    await expect(
+      tagsElement,
+      "it renders one input for every existing tag +1 empty one"
+    ).toHaveCount(i + 1);
+    await tagsElement.last().fill(tag);
+    await page
+      .locator("fieldset")
+      .filter({ hasText: "Tags (optional)" })
+      .getByRole("button")
+      .last()
+      .click();
+  }
 
   const editor = page.locator(".lines-content");
 

--- a/ui/e2e/explorer/consumer/utils.ts
+++ b/ui/e2e/explorer/consumer/utils.ts
@@ -1,0 +1,27 @@
+const groupsYaml = (groups: string[]) =>
+  groups.map((group) => `\n  - "${group}"`).join("");
+
+const tagsYaml = (tags: string[]) =>
+  tags.map((tag) => `\n  - "${tag}"`).join("");
+
+type Consumer = {
+  username: string;
+  password: string;
+  apiKey: string;
+  tags: string[];
+  groups: string[];
+};
+
+export const createConsumerYaml = ({
+  username,
+  password,
+  apiKey,
+  groups,
+  tags,
+}: Consumer) => `direktiv_api: "consumer/v1"
+username: "${username}"
+password: "${password}"
+api_key: "${apiKey}"
+tags:${tagsYaml(tags)}
+groups:${groupsYaml(groups)}
+`;

--- a/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/Form/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/Form/index.tsx
@@ -33,9 +33,16 @@ export const Form: FC<FormProps> = ({ defaultConfig, children }) => {
     },
   });
 
-  const values = useWatch({
+  const fieldsInOrder = ConsumerFormSchema.keyof().options;
+
+  const watchedValues = useWatch({
     control: formControls.control,
   });
+
+  const values = fieldsInOrder.reduce(
+    (object, key) => ({ ...object, [key]: watchedValues[key] }),
+    {}
+  );
 
   const { register, control } = formControls;
 

--- a/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
@@ -99,7 +99,7 @@ const ConsumerEditor: FC<ConsumerEditorProps> = ({ data, path }) => {
               <div className="flex flex-col justify-end gap-4 sm:flex-row sm:items-center">
                 {isDirty && (
                   <div className="text-sm text-gray-8 dark:text-gray-dark-8">
-                    <span className="text-center">
+                    <span className="text-center" data-testid="unsaved-note">
                       {t("pages.explorer.consumer.editor.unsavedNote")}
                     </span>
                   </div>

--- a/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
@@ -1,5 +1,3 @@
-import { compareYamlStructure, jsonToYaml } from "../../utils";
-
 import Alert from "~/design/Alert";
 import Button from "~/design/Button";
 import { Card } from "~/design/Card";
@@ -10,6 +8,7 @@ import { Form } from "./Form";
 import FormErrors from "~/components/FormErrors";
 import { Save } from "lucide-react";
 import { ScrollArea } from "~/design/ScrollArea";
+import { jsonToYaml } from "../../utils";
 import { serializeConsumerFile } from "./utils";
 import { useNodeContent } from "~/api/tree/query/node";
 import { useTheme } from "~/util/store/theme";

--- a/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
@@ -51,10 +51,7 @@ const ConsumerEditor: FC<ConsumerEditorProps> = ({ data, path }) => {
         values,
       }) => {
         const preview = jsonToYaml(values);
-        const filehasChanged = compareYamlStructure(
-          preview,
-          fileContentFromServer
-        );
+        const filehasChanged = preview === fileContentFromServer;
         const isDirty = !consumerConfigError && !filehasChanged;
         const disableButton = isLoading || !!consumerConfigError;
 

--- a/ui/src/pages/namespace/Explorer/Service/ServiceEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Service/ServiceEditor/index.tsx
@@ -1,5 +1,3 @@
-import { compareYamlStructure, jsonToYaml } from "../../utils";
-
 import Alert from "~/design/Alert";
 import Button from "~/design/Button";
 import { Card } from "~/design/Card";
@@ -10,6 +8,7 @@ import FormErrors from "~/components/FormErrors";
 import { Save } from "lucide-react";
 import { ScrollArea } from "~/design/ScrollArea";
 import { ServiceFormSchemaType } from "./schema";
+import { jsonToYaml } from "../../utils";
 import { serializeServiceFile } from "./utils";
 import { useNodeContent } from "~/api/tree/query/node";
 import { useTheme } from "~/util/store/theme";
@@ -54,10 +53,8 @@ const ServiceEditor: FC<ServiceEditorProps> = ({ data, path }) => {
         values,
       }) => {
         const preview = jsonToYaml(values);
-        const filehasChanged = compareYamlStructure(
-          preview,
-          fileContentFromServer
-        );
+
+        const filehasChanged = preview === fileContentFromServer;
         const isDirty = !serviceConfigError && !filehasChanged;
         const disableButton = isLoading || !!serviceConfigError;
 


### PR DESCRIPTION
## Description

- introducing e2e test to the consumer editor. 
- this also fixes an issue where the keys of the yaml were sorted differently after saving (as we already addressed in the services)
- I also removed an unnecessary `compareYamlStructure ` in the service editor. I introduced the compareYamlStructure function to detect changes even if the keys were sorted differently. But since you already solved the root cause and the keys are now always sorted the same way, this function call is not needed any more (and your test are still passing). [I suggested this change here](https://github.com/direktiv/direktiv/pull/1204/files#r1467458062) but lost track of it.

## Checklist

- [x] Documentation updated if required
- [x] Are tests available
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
