### PR TITLE
[DIR-1243] Set default content type for flow target plugin

### DIFF
--- a/pkg/refactor/gateway/plugins/target/target-workflow.go
+++ b/pkg/refactor/gateway/plugins/target/target-workflow.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	FlowPluginName = "target-flow"
+	FlowPluginName     = "target-flow"
+	defaultContentType = "application/json"
 )
 
 type WorkflowConfig struct {
@@ -49,6 +50,11 @@ func ConfigureTargetFlowPlugin(config interface{}, ns string) (core.PluginInstan
 	// set default to gateway namespace
 	if targetflowConfig.Namespace == "" {
 		targetflowConfig.Namespace = ns
+	}
+
+	// if content type is not set use application/json
+	if targetflowConfig.ContentType == "" {
+		targetflowConfig.ContentType = defaultContentType
 	}
 
 	// throw error if non magic namespace targets different namespace

--- a/tests/gateway/target_flow.test.js
+++ b/tests/gateway/target_flow.test.js
@@ -138,6 +138,39 @@ states:
   message: 'Missing or invalid value for required input.'
 `
 
+
+const endpointNoContentType = `direktiv_api: endpoint/v1
+allow_anonymous: true
+plugins:
+  target:
+    type: target-flow
+    configuration:
+      flow: /contentType.yaml
+methods: 
+  - GET
+path: /endpointct`
+
+const endpointContentType = `direktiv_api: endpoint/v1
+allow_anonymous: true
+plugins:
+  target:
+    type: target-flow
+    configuration:
+      flow: /contentType.yaml
+      content_type: test/me
+methods: 
+  - GET
+path: /endpointcttest`
+
+const contentType = `
+direktiv_api: workflow/v1
+states:
+- id: helloworld
+  type: noop
+  transform:
+    result: Hello world!
+`
+
 describe("Test target workflow wrong config", () => {
     beforeAll(common.helpers.deleteAllNamespaces);
 
@@ -407,4 +440,58 @@ describe("Test scope for target workflow plugin", () => {
     expect(req.statusCode).toEqual(200);
     expect(req.text).toEqual("{\"result\":\"Hello world!\"}")
   });
+});
+
+
+
+describe("Test target workflow default contenttype", () => {
+  beforeAll(common.helpers.deleteAllNamespaces);
+
+  common.helpers.itShouldCreateNamespace(it, expect, testNamespace);
+
+  common.helpers.itShouldCreateFile(
+    it,
+    expect,
+    testNamespace,
+    "/epnoct.yaml",
+    endpointNoContentType
+  );
+
+
+  common.helpers.itShouldCreateFile(
+    it,
+    expect,
+    testNamespace,
+    "/epct.yaml",
+    endpointContentType
+  );
+
+  common.helpers.itShouldCreateFile(
+    it,
+    expect,
+    testNamespace,
+    "/contentType.yaml",
+    contentType
+  );
+
+  it(`should return a json content type`, async () => {
+    const req = await request(common.config.getDirektivHost()).get(
+        `/gw/endpointct`
+    );
+
+    expect(req.headers["content-type"]).toEqual("application/json")
+    expect(req.statusCode).toEqual(200);
+
+   });  
+
+   it(`should return a configured content type`, async () => {
+    const req = await request(common.config.getDirektivHost()).get(
+        `/gw/endpointcttest`
+    );
+
+    expect(req.headers["content-type"]).toEqual("test/me")
+    expect(req.statusCode).toEqual(200);
+
+   });  
+
 });


### PR DESCRIPTION
## Description

Default content-type was set to `text` instead of `json` for the flow target plugin. The default response type is json for Direktiv and this PR configures the content type to json if not set in configuration.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
