### PR TITLE
[DIR-1135] Load plugins in flow only

### DIFF
--- a/.github/workflows/go-unittests.yml
+++ b/.github/workflows/go-unittests.yml
@@ -24,3 +24,5 @@ jobs:
       - name: Run unit tests
         run: |
             go test $(go list ./... | egrep -v '(direktiv/pkg/flow/grpc)') -coverprofile coverage.out -covermode count
+        env:
+          DIREKTIV_APP: flow

--- a/pkg/refactor/gateway/plugins/plugin.go
+++ b/pkg/refactor/gateway/plugins/plugin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/direktiv/direktiv/pkg/refactor/core"
 	"github.com/mitchellh/mapstructure"
@@ -82,8 +83,10 @@ func GetAllPlugins() map[string]Plugin {
 }
 
 func AddPluginToRegistry(plugin Plugin) {
-	slog.Info("adding plugin", slog.String("name", plugin.Name()))
-	registry[plugin.Name()] = plugin
+	if os.Getenv("DIREKTIV_APP") == "flow" {
+		slog.Info("adding plugin", slog.String("name", plugin.Name()))
+		registry[plugin.Name()] = plugin
+	}
 }
 
 func GetPluginFromRegistry(plugin string) (Plugin, error) {


### PR DESCRIPTION
## Description

Gateway plugins load on startup during `init`. This causes logging in the Direktiv sidecar in functions. This will guard the login registration for the sidecar and will prevent logs from being in the sidecar logs. 

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
