### PR TITLE
[DIR-1207] Changed stop behaviour for "error" attribute for special command

### DIFF
--- a/cmd/cmd-exec/pkg/commands/commands.go
+++ b/cmd/cmd-exec/pkg/commands/commands.go
@@ -78,8 +78,7 @@ func RunCommands(ctx context.Context, in Commands, info *server.ExecutionInfo) (
 			// check if it has to stop here
 			if command.StopOnError {
 				commandOutput = append(commandOutput, cr)
-
-				break
+				return commandOutput, fmt.Errorf("stopped because command %d failed", a)
 			}
 		}
 

--- a/cmd/cmd-exec/pkg/server/server.go
+++ b/cmd/cmd-exec/pkg/server/server.go
@@ -65,9 +65,10 @@ func NewServer[IN any](fn func(context.Context, IN, *ExecutionInfo) (interface{}
 }
 
 func errWriter(w http.ResponseWriter, status int, errMsg string) {
-	w.WriteHeader(status)
 	w.Header().Set(DirektivErrorCodeHeader, DirektivErrorCode)
 	w.Header().Set(DirektivErrorMessageHeader, errMsg)
+
+	w.WriteHeader(status)
 
 	// nolint
 	w.Write([]byte(errMsg))


### PR DESCRIPTION
## Description

The error attribute for the special `/usr/share/direktiv/direktiv-cmd` stopped the subsequent executions of commands but did not mark the action as failed. This patch fixes this it. 

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
