### PR TITLE
[DIR-1283] Inject custom headers in backend e2e tests

### DIFF
--- a/tests/api/version.test.js
+++ b/tests/api/version.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/cli/cli.test.js
+++ b/tests/cli/cli.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/common/helpers.js
+++ b/tests/common/helpers.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "./request"
 
 import config from './config'
 import common from './index'

--- a/tests/common/index.js
+++ b/tests/common/index.js
@@ -4,6 +4,7 @@ import helpers from './helpers.js'
 import regex from './regex.js'
 import structs from './structs.js'
 import utils from './utils.js'
+import request from './request.js'
 
 export default {
 	config,
@@ -12,4 +13,5 @@ export default {
 	structs,
 	filesystem,
 	helpers,
+	request,
 }

--- a/tests/common/request.js
+++ b/tests/common/request.js
@@ -1,17 +1,42 @@
 import request from "supertest";
 
+/**
+ * checks if the environment variables AUTH_TOKEN_KEY and AUTH_TOKEN_VALUE are set and returns
+ * either an array with the key and value or null.
+ */
+const getAuthHeader = () => {
+  if (process.env.AUTH_TOKEN_KEY && process.env.AUTH_TOKEN_VALUE) {
+    return [process.env.AUTH_TOKEN_KEY, process.env.AUTH_TOKEN_VALUE];
+  }
+  return null;
+};
+
 const requestWithHeaders =
   (appConfig, method = "post") =>
-  (args) =>
-    request(appConfig)[method](args).set("Direktiv-Token", "password");
+  (args) => {
+    const authHeader = getAuthHeader();
 
+    if (!authHeader) {
+      return request(appConfig)[method](args);
+    }
+
+    return request(appConfig)
+      [method](args)
+      .set(...authHeader);
+  };
+
+/**
+ * overwrites the http methods (get, head, post, put, delete, patch)
+ * from supertest and injects a custom header if the environment variables
+ * AUTH_TOKEN_KEY and AUTH_TOKEN_VALUE are set.
+ */
 const customRequest = (appConfig) => ({
   get: requestWithHeaders(appConfig, "get"),
   head: requestWithHeaders(appConfig, "head"),
   post: requestWithHeaders(appConfig, "post"),
   put: requestWithHeaders(appConfig, "put"),
   delete: requestWithHeaders(appConfig, "delete"),
-  patch: requestWithHeaders(appConfig, "patch")
+  patch: requestWithHeaders(appConfig, "patch"),
 });
 
 export default customRequest;

--- a/tests/common/request.js
+++ b/tests/common/request.js
@@ -1,0 +1,17 @@
+import request from "supertest";
+
+const requestWithHeaders =
+  (appConfig, method = "post") =>
+  (args) =>
+    request(appConfig)[method](args).set("Direktiv-Token", "password");
+
+const customRequest = (appConfig) => ({
+  get: requestWithHeaders(appConfig, "get"),
+  head: requestWithHeaders(appConfig, "head"),
+  post: requestWithHeaders(appConfig, "post"),
+  put: requestWithHeaders(appConfig, "put"),
+  delete: requestWithHeaders(appConfig, "delete"),
+  patch: requestWithHeaders(appConfig, "patch")
+});
+
+export default customRequest;

--- a/tests/engine/cancel.test.js
+++ b/tests/engine/cancel.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/catch.test.js
+++ b/tests/engine/catch.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/error-state.test.js
+++ b/tests/engine/error-state.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/getter-setter.test.js
+++ b/tests/engine/getter-setter.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/instance-data.test.js
+++ b/tests/engine/instance-data.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/noop.test.js
+++ b/tests/engine/noop.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/simple-chain.test.js
+++ b/tests/engine/simple-chain.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/simple-events.test.js
+++ b/tests/engine/simple-events.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/simple-loop.test.js
+++ b/tests/engine/simple-loop.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/engine/simple-subflow.test.js
+++ b/tests/engine/simple-subflow.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/errors/not_found.test.js
+++ b/tests/errors/not_found.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import common from "../common";
 
 describe('Test path not found', () => {

--- a/tests/events/send_events.test.js
+++ b/tests/events/send_events.test.js
@@ -1,6 +1,6 @@
 // http://192.168.0.145/api/namespaces/test/broadcast
 
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/events/send_helper.js
+++ b/tests/events/send_helper.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/events/workflow_events.test.js
+++ b/tests/events/workflow_events.test.js
@@ -1,6 +1,6 @@
 import common from "../common"
 import events from "./send_helper.js"
-import request from 'supertest'
+import request from "../common/request"
 
 const namespaceName = "wfevents"
 

--- a/tests/events/workflow_events_and.test.js
+++ b/tests/events/workflow_events_and.test.js
@@ -1,6 +1,6 @@
 import common from "../common"
 import events from "./send_helper.js"
-import request from 'supertest'
+import request from "../common/request"
 
 const namespaceName = "sendeventsand"
 

--- a/tests/events/workflow_events_or.test.js
+++ b/tests/events/workflow_events_or.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/filesystem/create_file.test.js
+++ b/tests/filesystem/create_file.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
 import { basename } from 'path'
-import request from 'supertest'
+import request from "../common/request"
 
 import common from '../common'
 

--- a/tests/filesystem/create_file_v2.test.js
+++ b/tests/filesystem/create_file_v2.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
 import { basename } from 'path'
-import request from 'supertest'
+import request from "../common/request"
 
 import config from '../common/config'
 import helpers from '../common/helpers'

--- a/tests/filesystem/create_workflow_file.test.js
+++ b/tests/filesystem/create_workflow_file.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
 import { basename } from 'path'
-import request from 'supertest'
+import request from "../common/request"
 
 import common from '../common'
 

--- a/tests/filesystem/directory.test.js
+++ b/tests/filesystem/directory.test.js
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
-import request from 'supertest'
+import request from "../common/request"
 
 import common from '../common'
 

--- a/tests/filesystem/read_directory_v2.test.js
+++ b/tests/filesystem/read_directory_v2.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
 import { basename } from 'path'
-import request from 'supertest'
+import request from "../common/request"
 
 import config from '../common/config'
 import helpers from '../common/helpers'

--- a/tests/filesystem/root.test.js
+++ b/tests/filesystem/root.test.js
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
-import request from 'supertest'
+import request from "../common/request"
 
 import common from '../common'
 

--- a/tests/filesystem/update_file.test.js
+++ b/tests/filesystem/update_file.test.js
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
-import request from 'supertest'
+import request from "../common/request"
 
 import common from '../common'
 

--- a/tests/filesystem/validation_v2.test.js
+++ b/tests/filesystem/validation_v2.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
 import { basename } from 'path'
-import request from 'supertest'
+import request from "../common/request"
 
 import config from '../common/config'
 import helpers from '../common/helpers'

--- a/tests/filesystem/workflow.test.js
+++ b/tests/filesystem/workflow.test.js
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from '@jest/globals'
-import request from 'supertest'
+import request from "../common/request"
 
 import common from '../common'
 

--- a/tests/functions/files.test.js
+++ b/tests/functions/files.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/gateway/endpoints_crud.test.js
+++ b/tests/gateway/endpoints_crud.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 import retry from "jest-retries";
 
 const testNamespace = "gateway";

--- a/tests/gateway/http_header_plugin.test.js
+++ b/tests/gateway/http_header_plugin.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 
 
 const testNamespace = "headers";

--- a/tests/gateway/js_inbound.test.js
+++ b/tests/gateway/js_inbound.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 
 
 const testNamespace = "js-inbound";

--- a/tests/gateway/js_outbound.test.js
+++ b/tests/gateway/js_outbound.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 
 
 const testNamespace = "js-outbound";

--- a/tests/gateway/target_file.test.js
+++ b/tests/gateway/target_file.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 import retry from "jest-retries";
 
 

--- a/tests/gateway/target_flow.test.js
+++ b/tests/gateway/target_flow.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 import retry from "jest-retries";
 
 const testNamespace = "gateway";

--- a/tests/gateway/target_ns_var.test.js
+++ b/tests/gateway/target_ns_var.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 import retry from "jest-retries";
 
 const testNamespace = "gateway";

--- a/tests/gateway/target_wf_var.test.js
+++ b/tests/gateway/target_wf_var.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 import retry from "jest-retries";
 
 const testNamespace = "gateway";

--- a/tests/kubernetes/function-patch.test.js
+++ b/tests/kubernetes/function-patch.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 import retry from "jest-retries";
 
 

--- a/tests/kubernetes/generic-container.test.js
+++ b/tests/kubernetes/generic-container.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 import retry from "jest-retries";
 
 

--- a/tests/kubernetes/special-command.test.js
+++ b/tests/kubernetes/special-command.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from "supertest";
+import request from "../common/request";
 import retry from "jest-retries";
 
 

--- a/tests/logparser/callpath.test.js
+++ b/tests/logparser/callpath.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/mirror/mirror.test.js
+++ b/tests/mirror/mirror.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/mirror/namespaces_git_mirror.test.js
+++ b/tests/mirror/namespaces_git_mirror.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from 'supertest'
+import request from "../common/request"
 
 const testNamespace = "test-git-namespace"
 

--- a/tests/namespaces/lists.test.js
+++ b/tests/namespaces/lists.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/namespaces/logs.test.js
+++ b/tests/namespaces/logs.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/namespaces/namespace.test.js
+++ b/tests/namespaces/namespace.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/namespaces/namespaces.test.js
+++ b/tests/namespaces/namespaces.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import common from "../common";
 
 const testNamespace = "test-namespace"

--- a/tests/namespaces/regex.test.js
+++ b/tests/namespaces/regex.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/registry/multiple_namespaces.test.js
+++ b/tests/registry/multiple_namespaces.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import common from "../common";
 
 describe('Test services crud operations', () => {

--- a/tests/registry/registry_crud_and_run.test.js
+++ b/tests/registry/registry_crud_and_run.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import common from "../common";
 
 

--- a/tests/secrets/secrets_crud_operations.test.js
+++ b/tests/secrets/secrets_crud_operations.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import common from "../common";
 
 const testNamespace = "test-file-namespace"

--- a/tests/secrets/secrets_read.test.js
+++ b/tests/secrets/secrets_read.test.js
@@ -1,5 +1,5 @@
 import common from "../common";
-import request from 'supertest'
+import request from "../common/request"
 
 const testNamespace = "test-secrets-namespace"
 let testWorkflow = "test-secret"

--- a/tests/services/action_workflow_and_run.test.js
+++ b/tests/services/action_workflow_and_run.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import common from "../common";
 
 const testNamespace = "test-services"

--- a/tests/services/env_variables.test.js
+++ b/tests/services/env_variables.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import retry from "jest-retries";
 import common from "../common";
 

--- a/tests/services/git_mirror_with_services.test.js
+++ b/tests/services/git_mirror_with_services.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import retry from "jest-retries";
 import common from "../common";
 

--- a/tests/services/new_service_crud_and_run.test.js
+++ b/tests/services/new_service_crud_and_run.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import retry from "jest-retries";
 import common from "../common";
 

--- a/tests/services/parse_multiple_workflow_services.test.js
+++ b/tests/services/parse_multiple_workflow_services.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import retry from "jest-retries";
 import common from "../common";
 

--- a/tests/services/rename_delete_service.test.js
+++ b/tests/services/rename_delete_service.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import retry from "jest-retries";
 import common from "../common";
 

--- a/tests/services/update_service.test.js
+++ b/tests/services/update_service.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 import retry from "jest-retries";
 import common from "../common";
 

--- a/tests/variables/instvars.test.js
+++ b/tests/variables/instvars.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/variables/nsvars.test.js
+++ b/tests/variables/nsvars.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 

--- a/tests/variables/wfvars.test.js
+++ b/tests/variables/wfvars.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest'
+import request from "../common/request"
 
 import common from "../common"
 


### PR DESCRIPTION
## Description

Adds the possibility to set an auth header to the backend e2e tests

E2E tests are currently only capable of running against an API that does not require any kind of authorization. To fix this, I introduced two environment variables `AUTH_TOKEN_KEY` and `AUTH_TOKEN_VALUE`. When these environment variables are both set when the test runs, the headers will be injected in every supertest request. However, we have to use `import request from "../common/request";` instead of `import request from 'supertest'` to make this work.

Example I used for local testing

`NODE_TLS_REJECT_UNAUTHORIZED=0 DIREKTIV_HOST=http://localhost:8181 AUTH_TOKEN_KEY=Direktiv-Token AUTH_TOKEN_VALUE=password npm run without-k8s -- --watch`


I already updated all request imports to the new `common/request`

### How I tested it
- I successfully ran all the test against an unauthenticated API. Since supertest is only imported once in this repo now, I'm very confident that I did not break any previously working test.
- I then ran the same tests against an API that requires authentication, but without providing the `AUTH_TOKEN_KEY` and `AUTH_TOKEN_VALUE` environment variables. This resulted in 497/521 tests failing, which is expected.
- I then ran the same WITH the `AUTH_TOKEN_KEY` and `AUTH_TOKEN_VALUE` environment variables. This resulted in all tests passing again.

### Implementation
The solution is [based on this suggestion](https://github.com/ladjs/supertest/issues/398#issuecomment-607463304), but I added a parameter to make it work like a drop-in replacement to the supertest request method. The reason why this overwrite is a little bit complicated/trickey is, that we supertest only allows set the header AFTER the http method was called:
- So you can not do `request("http://mydomain.com).set("header", "value").post("my-endpoint")`
- It must be `request("http://mydomain.com).post("my-endpoint").set("header", "value")`
That's why we have to hook into all the http method functions (get, post, etc),

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
