### PR TITLE
[DIR-1267] Fix e2e Service tests on v2 API

### DIFF
--- a/ui/e2e/instances/list/index.spec.ts
+++ b/ui/e2e/instances/list/index.spec.ts
@@ -243,9 +243,15 @@ test("it provides a proper pagination", async ({ page }) => {
     headers,
   });
 
-  page.waitForTimeout(500);
+  /**
+   * child workflows are spawned asynchronously in the backend and the page
+   * does not refresh, so we need to wait until they are initialized before
+   * visiting the page.
+   */
+  await page.waitForTimeout(500);
 
   await page.goto(`${namespace}/instances/`, { waitUntil: "networkidle" });
+
   await expect(
     page.getByTestId("pagination-wrapper"),
     "there should be pagination component"

--- a/ui/e2e/services/details.spec.ts
+++ b/ui/e2e/services/details.spec.ts
@@ -59,7 +59,7 @@ test("Service details page provides information about the service", async ({
   ).toBeVisible();
 
   await expect(
-    page.getByRole("link", { name: "/http-service.yaml", exact: true }),
+    page.getByRole("link", { name: serviceFile.data.path, exact: true }),
     "it renders a link to the service file"
   ).toBeVisible();
 

--- a/ui/e2e/services/details.spec.ts
+++ b/ui/e2e/services/details.spec.ts
@@ -1,9 +1,9 @@
+import { createNamespace, deleteNamespace } from "../utils/namespace";
 import {
-  createHttpServiceFile,
+  createRequestServiceFile,
   findServiceWithApiRequest,
   serviceWithAnError,
 } from "./utils";
-import { createNamespace, deleteNamespace } from "../utils/namespace";
 import { expect, test } from "@playwright/test";
 
 import { createFile } from "e2e/utils/files";
@@ -23,10 +23,10 @@ test("Service details page provides information about the service", async ({
   page,
 }) => {
   const serviceFile = await createFile({
-    name: "http-service.yaml",
+    name: "request-service.yaml",
     namespace,
     type: "service",
-    yaml: createHttpServiceFile({ scale: 2 }),
+    yaml: createRequestServiceFile({ scale: 2 }),
   });
 
   await expect
@@ -64,9 +64,7 @@ test("Service details page provides information about the service", async ({
   ).toBeVisible();
 
   await expect(
-    page
-      .getByTestId("service-detail-header")
-      .getByText("gcr.io/direktiv/functions/http-request:1.0"),
+    page.getByTestId("service-detail-header").getByText("direktiv/request:v4"),
     "it renders the service image name"
   ).toBeVisible();
 
@@ -96,6 +94,11 @@ test("Service details page provides information about the service", async ({
   ).toBeVisible();
 
   await expect(
+    page.getByText("cmd/request"),
+    "it renders the cmd"
+  ).toBeVisible();
+
+  await expect(
     page.getByText("Logs for"),
     "it renders the headline for the pods logs"
   ).toBeVisible();
@@ -103,7 +106,7 @@ test("Service details page provides information about the service", async ({
   const firstPodLogHeadline = await page.getByText("Logs for").innerText();
 
   await expect(
-    page.getByText("Serving HTTP request at http://[::]:8080"),
+    page.getByText("Starting server."),
     "it renders the log entries"
   ).toBeVisible();
 

--- a/ui/e2e/services/details.spec.ts
+++ b/ui/e2e/services/details.spec.ts
@@ -22,7 +22,7 @@ test.afterEach(async () => {
 test("Service details page provides information about the service", async ({
   page,
 }) => {
-  const service = await createFile({
+  const serviceFile = await createFile({
     name: "http-service.yaml",
     namespace,
     type: "service",
@@ -34,9 +34,9 @@ test("Service details page provides information about the service", async ({
       async () =>
         await findServiceWithApiRequest({
           namespace,
-          match: (item) =>
-            item.filePath === service.data.path &&
-            (item.conditions ?? []).some(
+          match: (service) =>
+            service.filePath === serviceFile.data.path &&
+            (service.conditions ?? []).some(
               (c) => c.type === "ConfigurationsReady" && c.status === "True"
             ),
         }),
@@ -46,7 +46,7 @@ test("Service details page provides information about the service", async ({
 
   const createdService = await findServiceWithApiRequest({
     namespace,
-    match: (item) => item.filePath === service.data.path,
+    match: (service) => service.filePath === serviceFile.data.path,
   });
 
   if (!createdService) throw new Error("could not find service");

--- a/ui/e2e/services/list.spec.ts
+++ b/ui/e2e/services/list.spec.ts
@@ -1,6 +1,5 @@
 import {
   createHttpServiceFile,
-  createRedisServiceFile,
   findServiceWithApiRequest,
   serviceWithAnError,
 } from "./utils";
@@ -126,11 +125,11 @@ test("Service list shows all available services", async ({ page }) => {
 test("Service list links the file name to the service file", async ({
   page,
 }) => {
-  await createFile({
-    name: "redis-service.yaml",
+  const serviceFile = await createFile({
+    name: "http-service.yaml",
     namespace,
     type: "service",
-    yaml: createRedisServiceFile(),
+    yaml: createHttpServiceFile(),
   });
 
   await page.goto(`/${namespace}/services`, {
@@ -139,28 +138,28 @@ test("Service list links the file name to the service file", async ({
 
   await page
     .getByTestId("service-row")
-    .getByRole("link", { name: "/redis-service.yaml" })
+    .getByRole("link", { name: serviceFile.data.path })
     .click();
 
   await expect(
     page,
     "after clicking on the file name, the user gets redirected to the file explorer page of the service file"
-  ).toHaveURL(`/${namespace}/explorer/service/redis-service.yaml`);
+  ).toHaveURL(`/${namespace}/explorer/service/http-service.yaml`);
 
   await expect(
     page.getByTestId("breadcrumb-segment"),
     "it renders the filename in the breadcrumb"
-  ).toHaveText("redis-service.yaml");
+  ).toHaveText("http-service.yaml");
 });
 
 test("Service list links the row to the service details page", async ({
   page,
 }) => {
-  await createFile({
-    name: "redis-service.yaml",
+  const serviceFile = await createFile({
+    name: "http-service.yaml",
     namespace,
     type: "service",
-    yaml: createRedisServiceFile(),
+    yaml: createHttpServiceFile(),
   });
 
   await expect
@@ -168,7 +167,7 @@ test("Service list links the row to the service details page", async ({
       async () =>
         await findServiceWithApiRequest({
           namespace,
-          match: (service) => service.filePath === "/redis-service.yaml",
+          match: (service) => service.filePath === serviceFile.data.path,
         }),
       "the service was mounted in the backend"
     )
@@ -176,7 +175,7 @@ test("Service list links the row to the service details page", async ({
 
   const createdService = await findServiceWithApiRequest({
     namespace,
-    match: (service) => service.filePath === "/redis-service.yaml",
+    match: (service) => service.filePath === serviceFile.data.path,
   });
 
   if (!createdService) throw new Error("could not find service");

--- a/ui/e2e/services/list.spec.ts
+++ b/ui/e2e/services/list.spec.ts
@@ -40,7 +40,7 @@ test("Service list is empty by default", async ({ page }) => {
 });
 
 test("Service list shows all available services", async ({ page }) => {
-  const service = await createFile({
+  const serviceFile = await createFile({
     name: "http-service.yaml",
     namespace,
     type: "service",
@@ -52,9 +52,9 @@ test("Service list shows all available services", async ({ page }) => {
       async () =>
         await findServiceWithApiRequest({
           namespace,
-          match: (item) =>
-            item.filePath === service.data.path &&
-            (item.conditions ?? []).some(
+          match: (service) =>
+            service.filePath === serviceFile.data.path &&
+            (service.conditions ?? []).some(
               (c) => c.type === "ConfigurationsReady" && c.status === "True"
             ),
         }),
@@ -74,7 +74,7 @@ test("Service list shows all available services", async ({ page }) => {
   await expect(
     page
       .getByTestId("service-row")
-      .getByRole("link", { name: service.data.path }),
+      .getByRole("link", { name: serviceFile.data.path }),
     "it renders the link to the service file"
   ).toBeVisible();
 

--- a/ui/e2e/services/utils.ts
+++ b/ui/e2e/services/utils.ts
@@ -6,19 +6,6 @@ type CreateServiceFileParams = {
   size?: "large" | "medium" | "small";
 };
 
-export const createRedisServiceFile = ({
-  scale = 1,
-  size = "small",
-}: CreateServiceFileParams = {}) => `direktiv_api: service/v1
-image: "redis"
-scale: ${scale}
-size: ${size}
-cmd: "redis-server"
-envs:
-  - name: "MY_ENV_VAR"
-    value: "env-var-value"
-`;
-
 export const createHttpServiceFile = ({
   scale = 1,
   size = "small",

--- a/ui/e2e/services/utils.ts
+++ b/ui/e2e/services/utils.ts
@@ -1,7 +1,7 @@
 import { ServiceSchemaType } from "~/api/services/schema/services";
 import { getServices } from "~/api/services/query/services";
 
-type CreateRedisServiceFileParams = {
+type CreateServiceFileParams = {
   scale?: number;
   size?: "large" | "medium" | "small";
 };
@@ -9,11 +9,24 @@ type CreateRedisServiceFileParams = {
 export const createRedisServiceFile = ({
   scale = 1,
   size = "small",
-}: CreateRedisServiceFileParams = {}) => `direktiv_api: service/v1
+}: CreateServiceFileParams = {}) => `direktiv_api: service/v1
 image: "redis"
 scale: ${scale}
 size: ${size}
 cmd: "redis-server"
+envs:
+  - name: "MY_ENV_VAR"
+    value: "env-var-value"
+`;
+
+export const createHttpServiceFile = ({
+  scale = 1,
+  size = "small",
+}: CreateServiceFileParams = {}) => `direktiv_api: service/v1
+image: "gcr.io/direktiv/functions/http-request:1.0"
+scale: ${scale}
+size: ${size}
+cmd: ""
 envs:
   - name: "MY_ENV_VAR"
     value: "env-var-value"

--- a/ui/e2e/services/utils.ts
+++ b/ui/e2e/services/utils.ts
@@ -19,6 +19,19 @@ envs:
     value: "env-var-value"
 `;
 
+export const createRequestServiceFile = ({
+  scale = 1,
+  size = "small",
+}: CreateServiceFileParams = {}) => `direktiv_api: service/v1
+image: "direktiv/request:v4"
+scale: ${scale}
+size: ${size}
+cmd: "/request"
+envs:
+  - name: "MY_ENV_VAR"
+    value: "env-var-value"
+`;
+
 export const serviceWithAnError = `direktiv_api: service/v1
 image: "this-image-does-not-exist"
 scale: 1

--- a/ui/e2e/utils/files.ts
+++ b/ui/e2e/utils/files.ts
@@ -15,7 +15,7 @@ export const createFile = async ({
   namespace: string;
   type: FileTypeType;
   path?: string;
-}) => {
+}) =>
   await apiCreateFile({
     payload: {
       data: encode(yaml),
@@ -30,4 +30,3 @@ export const createFile = async ({
     },
     headers,
   });
-};


### PR DESCRIPTION
## Description

Our tests for the services were written based on their behavior in the Docker driver setup.

Some aspects behave differently in the k8s setup with Docker Desktop.

This updates the tests to expect that behavior, in addition to some changes related to our update to the v2 filesystem API.

### Notes

I replaced the redis image used in the service tests with a http image as recommended by the backend team. 

The redis image has some odd behavior because kubernetes can't detect its status.

 I used the "http-request" image for our main test because this is the only example I could find where it is possible to enter a custom "cmd" and have the service initialize successfully.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
