### PR TITLE
[DIR-1253] Added Gitlab webhook plugin

### DIFF
--- a/pkg/refactor/gateway/plugins/auth/gitlab-event.go
+++ b/pkg/refactor/gateway/plugins/auth/gitlab-event.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/direktiv/direktiv/pkg/refactor/core"
+	"github.com/direktiv/direktiv/pkg/refactor/gateway/plugins"
+)
+
+const (
+	GitlabWebhookPluginName = "gitlab-webhook-auth"
+	GitlabSecretHeaderName  = "X-Gitlab-Token"
+)
+
+type GitlabWebhookPluginConfig struct {
+	Secret string `mapstructure:"secret" yaml:"secret"`
+}
+
+type GitlabWebhookPlugin struct {
+	config *GitlabWebhookPluginConfig
+}
+
+func ConfigureGitlabWebhook(config interface{}, _ string) (core.PluginInstance, error) {
+	requestConvertConfig := &GitlabWebhookPluginConfig{}
+
+	err := plugins.ConvertConfig(config, requestConvertConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GitlabWebhookPlugin{
+		config: requestConvertConfig,
+	}, nil
+}
+
+func (p *GitlabWebhookPlugin) Config() interface{} {
+	return p.config
+}
+
+func (p *GitlabWebhookPlugin) ExecutePlugin(c *core.ConsumerFile, _ http.ResponseWriter, r *http.Request) bool {
+	secret := r.Header.Get(GitlabSecretHeaderName)
+
+	if secret != p.config.Secret {
+		return false
+	}
+
+	*c = core.ConsumerFile{
+		Username: "gitlab",
+	}
+
+	return true
+}
+
+func (*GitlabWebhookPlugin) Type() string {
+	return GithubWebhookPluginName
+}
+
+//nolint:gochecknoinits
+func init() {
+	plugins.AddPluginToRegistry(plugins.NewPluginBase(
+		GitlabWebhookPluginName,
+		plugins.AuthPluginType,
+		ConfigureGitlabWebhook))
+}

--- a/pkg/refactor/gateway/plugins/auth/gitlab-event.go
+++ b/pkg/refactor/gateway/plugins/auth/gitlab-event.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	GitlabWebhookPluginName = "gitlab-webhook-auth"
-	GitlabSecretHeaderName  = "X-Gitlab-Token"
+	GitlabHeaderName        = "X-Gitlab-Token"
 )
 
 type GitlabWebhookPluginConfig struct {
@@ -38,7 +38,7 @@ func (p *GitlabWebhookPlugin) Config() interface{} {
 }
 
 func (p *GitlabWebhookPlugin) ExecutePlugin(c *core.ConsumerFile, _ http.ResponseWriter, r *http.Request) bool {
-	secret := r.Header.Get(GitlabSecretHeaderName)
+	secret := r.Header.Get(GitlabHeaderName)
 
 	if secret != p.config.Secret {
 		return false

--- a/pkg/refactor/gateway/plugins/auth/gitlab-event_test.go
+++ b/pkg/refactor/gateway/plugins/auth/gitlab-event_test.go
@@ -1,0 +1,47 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/direktiv/direktiv/pkg/refactor/core"
+	"github.com/direktiv/direktiv/pkg/refactor/gateway/plugins"
+	"github.com/direktiv/direktiv/pkg/refactor/gateway/plugins/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	correctGitlabPwd   = "secret"
+	incorrectGitlabPwd = "incorrectsecret"
+)
+
+func TestGitlabEvent(t *testing.T) {
+	c := &core.ConsumerFile{}
+
+	config := auth.GitlabWebhookPluginConfig{
+		Secret: correctGitlabPwd,
+	}
+
+	assert.True(t, executeGitlab(config, c, correctGitlabPwd))
+
+	// consumer file is gitlab
+	assert.Equal(t, c.Username, "gitlab")
+
+	assert.False(t, executeGitlab(config, c, incorrectGitlabPwd))
+}
+
+func executeGitlab(config auth.GitlabWebhookPluginConfig, c *core.ConsumerFile, secret string) bool {
+	p, _ := plugins.GetPluginFromRegistry(auth.GitlabWebhookPluginName)
+
+	p2, _ := p.Configure(config, core.MagicalGatewayNamespace)
+
+	r, _ := http.NewRequest(http.MethodGet, "/dummy", nil)
+	r.Header.Add(auth.GitlabSecretHeaderName, secret)
+
+	w := httptest.NewRecorder()
+
+	ret := p2.ExecutePlugin(c, w, r)
+
+	return ret
+}

--- a/pkg/refactor/gateway/plugins/auth/gitlab-event_test.go
+++ b/pkg/refactor/gateway/plugins/auth/gitlab-event_test.go
@@ -37,7 +37,7 @@ func executeGitlab(config auth.GitlabWebhookPluginConfig, c *core.ConsumerFile, 
 	p2, _ := p.Configure(config, core.MagicalGatewayNamespace)
 
 	r, _ := http.NewRequest(http.MethodGet, "/dummy", nil)
-	r.Header.Add(auth.GitlabSecretHeaderName, secret)
+	r.Header.Add(auth.GitlabHeaderName, secret)
 
 	w := httptest.NewRecorder()
 

--- a/tests/gateway/gitlab_auth.test.js
+++ b/tests/gateway/gitlab_auth.test.js
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, it } from '@jest/globals'
+
+import common from '../common'
+import request from '../common/request'
+import { retry10 } from '../common/retry'
+
+const testNamespace = 'gitlab-auth'
+
+const wf = `
+direktiv_api: workflow/v1
+states:
+- id: helloworld
+  type: noop
+  transform:
+    result: jq(.)
+`
+
+const endpointFile = `
+direktiv_api: endpoint/v1
+allow_anonymous: false
+plugins:
+  target:
+    type: target-flow
+    configuration:
+        flow: /target.yaml
+        content_type: application/json
+  auth:
+    - type: gitlab-webhook-auth
+      configuration:
+        secret: secret
+methods: 
+  - POST
+path: /target`
+
+describe('Test gitlab auth plugin', () => {
+	beforeAll(common.helpers.deleteAllNamespaces)
+
+    common.helpers.itShouldCreateNamespace(it, expect, testNamespace)
+
+	common.helpers.itShouldCreateYamlFileV2(
+		it,
+		expect,
+		testNamespace,
+		'/', 'target.yaml', 'workflow',
+		wf,
+	)
+
+    common.helpers.itShouldCreateYamlFileV2(
+		it,
+		expect,
+		testNamespace,
+		'/', 'endpoint.yaml', 'endpoint',
+		endpointFile,
+	)
+
+    retry10(`should execute`, async () => {
+		const req = await request(common.config.getDirektivHost()).post(
+			`/ns/` + testNamespace + `/target`,
+		)
+        .set('X-Gitlab-Token', 'secret')
+        .send({ hello: 'world' })
+
+
+		expect(req.statusCode).toEqual(200)
+	})
+
+    retry10(`should fail`, async () => {
+		const req = await request(common.config.getDirektivHost()).post(
+			`/ns/` + testNamespace + `/target`,
+		)
+        .set('X-Gitlab-Token', 'wrongsecret')
+        .send({ hello: 'world' })
+
+
+		expect(req.statusCode).toEqual(401)
+	})
+
+})


### PR DESCRIPTION
## Description

Added plugin to authenticate Gitlab webhooks via `X-Gitlab-Token` header.
## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
