### PR TITLE
[DIR-722] Fix console error in Input/Output panel on the instances page

### DIFF
--- a/ui/src/pages/namespace/Instances/Detail/Main/InputOutput/Input.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/InputOutput/Input.tsx
@@ -1,12 +1,13 @@
 import Editor from "~/design/Editor";
 import Toolbar from "./Toolbar";
 import { decode } from "js-base64";
+import { forwardRef } from "react";
 import { prettifyJsonString } from "~/util/helpers";
 import { useInput } from "~/api/instances/query/input";
 import { useInstanceId } from "../../store/instanceContext";
 import { useTheme } from "~/util/store/theme";
 
-const Input = () => {
+const Input = forwardRef<HTMLDivElement>((_, ref) => {
   const instanceId = useInstanceId();
   const { data } = useInput({ instanceId });
   const theme = useTheme();
@@ -15,7 +16,7 @@ const Input = () => {
   const workflowInputPretty = prettifyJsonString(workflowInput);
 
   return (
-    <div className="flex grow flex-col gap-5 pb-12">
+    <div className="flex grow flex-col gap-5 pb-12" ref={ref}>
       <Toolbar copyText={workflowInputPretty} variant="input" />
       <Editor
         value={workflowInputPretty}
@@ -25,6 +26,8 @@ const Input = () => {
       />
     </div>
   );
-};
+});
+
+Input.displayName = "Input";
 
 export default Input;

--- a/ui/src/pages/namespace/Instances/Detail/Main/InputOutput/Output.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/InputOutput/Output.tsx
@@ -1,17 +1,20 @@
 import Editor from "~/design/Editor";
-import { FC } from "react";
 import InfoText from "./OutputInfo";
 import Toolbar from "./Toolbar";
 import { decode } from "js-base64";
+import { forwardRef } from "react";
 import { prettifyJsonString } from "~/util/helpers";
 import { useInstanceId } from "../../store/instanceContext";
 import { useOutput } from "~/api/instances/query/output";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
 
-const Output: FC<{ instanceIsFinished: boolean }> = ({
-  instanceIsFinished,
-}) => {
+const Output = forwardRef<
+  HTMLDivElement,
+  {
+    instanceIsFinished: boolean;
+  }
+>(({ instanceIsFinished }, ref) => {
   const instanceId = useInstanceId();
   const { t } = useTranslation();
   const { data, isError } = useOutput({
@@ -40,7 +43,7 @@ const Output: FC<{ instanceIsFinished: boolean }> = ({
   const workflowOutputPretty = prettifyJsonString(workflowOutput);
 
   return (
-    <div className="flex grow flex-col gap-5 pb-12">
+    <div className="flex grow flex-col gap-5 pb-12" ref={ref}>
       <Toolbar copyText={workflowOutput} variant="output" />
       <Editor
         value={workflowOutputPretty}
@@ -50,6 +53,8 @@ const Output: FC<{ instanceIsFinished: boolean }> = ({
       />
     </div>
   );
-};
+});
+
+Output.displayName = "Output";
 
 export default Output;


### PR DESCRIPTION
## Description

Fix console error in Input/Output panel on the instances page

![image](https://github.com/direktiv/direktiv/assets/121789579/befe5a27-8290-42c9-8065-589612de074d)


The error was caused by this component composition:

```JSX
<TabsContent value={tabs[0]} className="flex grow" asChild> 
   <Input />
</TabsContent>
<TabsContent value={tabs[1]} className="flex grow" asChild>
   <Output instanceIsFinished={instanceIsFinished} />
</TabsContent>
```

When a tab component is passed, an `asChild` property, it expects the child component to expose a ref for hooking into the DOM element. This issue does not have any known impact to the issue.

Please note, that there are currently still some other console errors that are caused by the editor. This will be addressed in a different issue.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
