### PR TITLE
[DIR-1393] fix log scrolling issue

### DIFF
--- a/ui/src/pages/namespace/Instances/Detail/Main/Logs/Entry.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/Logs/Entry.tsx
@@ -23,21 +23,22 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
 
     const workflowPath = workflow?.workflow;
 
-    if (!workflow) return <></>;
-    if (!namespace) return <></>;
+    const hasWorkflowInformation = !!workflow;
 
     const workflowLink = pages.explorer.createHref({
       path: workflow?.workflow,
-      namespace,
+      namespace: namespace ?? "",
       subpage: "workflow",
     });
 
     const instanceLink = pages.instances.createHref({
-      namespace,
+      namespace: namespace ?? "",
       instance: workflow?.instance,
     });
 
-    const isChildInstanceEntry = instanceId !== workflow.instance;
+    const isChildInstanceEntry = workflow
+      ? instanceId !== workflow.instance
+      : false;
 
     return (
       <LogEntry
@@ -46,13 +47,16 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
         ref={ref}
         {...props}
       >
-        <LogSegment display={verbose} className="opacity-60">
-          {t("components.logs.logEntry.stateLabel")} {workflow.state}
+        <LogSegment
+          display={verbose && hasWorkflowInformation}
+          className="opacity-60"
+        >
+          {t("components.logs.logEntry.stateLabel")} {workflow?.state}
         </LogSegment>
         <LogSegment display={true}>
           {t("components.logs.logEntry.messageLabel")} {msg}
         </LogSegment>
-        <LogSegment display={isChildInstanceEntry}>
+        <LogSegment display={isChildInstanceEntry && hasWorkflowInformation}>
           <span className="opacity-60">
             <Link to={workflowLink} className="underline" target="_blank">
               {workflowPath}
@@ -60,7 +64,7 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
             (
             <Link to={instanceLink} className="underline" target="_blank">
               {t("components.logs.logEntry.instanceLabel")}{" "}
-              {workflow.instance.slice(0, 8)}
+              {workflow?.instance.slice(0, 8)}
             </Link>
             )
           </span>

--- a/ui/src/pages/namespace/Monitoring/Logs/Entry.tsx
+++ b/ui/src/pages/namespace/Monitoring/Logs/Entry.tsx
@@ -15,19 +15,19 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
     const { t } = useTranslation();
     const { msg, level, time, workflow, namespace } = logEntry;
     const formattedTime = formatLogTime(time);
-
-    if (!namespace) return <></>;
+    const hasNamespaceInformation = !!namespace;
 
     const isWorkflowLog = !!workflow;
     const workflowPath = workflow?.workflow;
+
     const workflowLink = pages.explorer.createHref({
       path: workflow?.workflow,
-      namespace,
+      namespace: namespace ?? "",
       subpage: "workflow",
     });
 
     const instanceLink = pages.instances.createHref({
-      namespace,
+      namespace: namespace ?? "",
       instance: workflow?.instance,
     });
 
@@ -41,7 +41,7 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
         <LogSegment display={true}>
           {t("components.logs.logEntry.messageLabel")} {msg}
         </LogSegment>
-        <LogSegment display={isWorkflowLog}>
+        <LogSegment display={isWorkflowLog && hasNamespaceInformation}>
           <span className="opacity-60">
             <Link to={workflowLink} className="underline" target="_blank">
               {workflowPath}


### PR DESCRIPTION
## Description


Log entry components should never return an empty segment. This will screw up the virtualizes height calculations and the scrolling breaks. This issue was not found earlier because the backend seems to have changed a bit. If I recall correctly the workflow logs always returned a workflow attribute and now this can also be empty.


https://github.com/direktiv/direktiv/assets/121789579/932957bf-bd88-44ff-acde-3f9cec480600

**Workflow to reproduce**

```
description: I will loop and wait on each loop
states:
  - id: prep
    type: noop
    transform:
      x: 100
    transition: loop
  - id: loop
    type: switch
    conditions:
      - condition: "jq(.x > 0)"
        transition: wait
  - id: wait
    type: delay
    duration: PT1S
    transition: loop
    transform:
      x: "jq(.x - 1)"
``` 

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
