### PR TITLE
[DIR-1293] JSON Form Input - Fix for copy and pasting values behavior

### DIFF
--- a/ui/e2e/explorer/workflow/run.spec.ts
+++ b/ui/e2e/explorer/workflow/run.spec.ts
@@ -724,7 +724,7 @@ test("the input is synchronized between tabs, but the data that is currently in 
   });
 });
 
-test("the input values are sent, although the window focus was switched before sending the data", async ({
+test("switching the window focus will preserve the state of the form", async ({
   page,
 }) => {
   const workflowName = faker.system.commonFileName("yaml");
@@ -755,7 +755,7 @@ test("the input values are sent, although the window focus was switched before s
   await page.getByRole("combobox", { name: "role" }).click();
   await page.getByRole("option", { name: "guest" }).click();
 
-  // switch focus to another window
+  // dispatch visibilitychange event to emulate switching
   page.evaluate(() => {
     window.dispatchEvent(new Event("visibilitychange"));
   });

--- a/ui/e2e/explorer/workflow/run.spec.ts
+++ b/ui/e2e/explorer/workflow/run.spec.ts
@@ -755,7 +755,7 @@ test("switching the window focus will preserve the state of the form", async ({
   await page.getByRole("combobox", { name: "role" }).click();
   await page.getByRole("option", { name: "guest" }).click();
 
-  // dispatch visibilitychange event to emulate switching
+  // dispatch visibilitychange event to emulate switching the window focus
   page.evaluate(() => {
     window.dispatchEvent(new Event("visibilitychange"));
   });

--- a/ui/src/pages/namespace/Explorer/Workflow/components/RunWorkflow.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/components/RunWorkflow.tsx
@@ -57,7 +57,7 @@ const RunWorkflow = ({ path }: { path: string }) => {
   );
 
   const [jsonInput, setJsonInput] = useState(defaultEmptyJson);
-  const [formInput, setFormInput] = useState({});
+  const [formInput, setFormInput] = useState<object>({});
 
   // it is possible that no data (or stale cache data) is available when this component mounts
   // and the initial value of activeTab is out of sync with the actual isFormAvailable value

--- a/ui/src/pages/namespace/Explorer/Workflow/components/RunWorkflow.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/components/RunWorkflow.tsx
@@ -206,6 +206,9 @@ const RunWorkflow = ({ path }: { path: string }) => {
               {isFormAvailable ? (
                 <ScrollArea className="h-full">
                   <JSONSchemaForm
+                    onChange={() => {
+                      setFormInput(jsonSchemaFormRef.current?.state.formData);
+                    }}
                     formData={formInput}
                     ref={jsonSchemaFormRef}
                     schema={validationSchema}

--- a/ui/src/pages/namespace/Explorer/Workflow/components/RunWorkflow.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/components/RunWorkflow.tsx
@@ -114,11 +114,10 @@ const RunWorkflow = ({ path }: { path: string }) => {
 
   const syncInputData = (selectedTab: "form" | "json") => {
     if (selectedTab === "json") {
-      const formState = jsonSchemaFormRef.current?.state.formData as unknown;
+      const formState = jsonSchemaFormRef.current?.state.formData;
       const formDataObj = isObject(formState) ? formState : {};
       const formDataString = prettifyJsonString(JSON.stringify(formDataObj));
       const formIsEmpty = Object.keys(formDataObj).length === 0;
-
       setJsonInput(formIsEmpty ? defaultEmptyJson : formDataString);
     }
 

--- a/ui/src/pages/namespace/Explorer/Workflow/components/RunWorkflow.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/components/RunWorkflow.tsx
@@ -205,8 +205,11 @@ const RunWorkflow = ({ path }: { path: string }) => {
               {isFormAvailable ? (
                 <ScrollArea className="h-full">
                   <JSONSchemaForm
-                    onChange={() => {
-                      setFormInput(jsonSchemaFormRef.current?.state.formData);
+                    onChange={(e) => {
+                      const newFormInput = isObject(e.formData)
+                        ? e.formData
+                        : {};
+                      setFormInput(newFormInput);
                     }}
                     formData={formInput}
                     ref={jsonSchemaFormRef}


### PR DESCRIPTION
## Description

Before we had a rarely seen bug, where the input fields were filled, but nevertheless were detected as empty by the form.
We found that the reason for this error is a refetch query when the window gets out of focus and back in focus.

(So if you would set _refetchOnWindowFocus: false_ the bug would be gone too, but we want all pages to have the same settings)

Solution was to update the state of the form input on every input event, so the data can't get lost.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
