### PR TITLE
[DIR-1409] fix(chart): remove hard-coded envs

### DIFF
--- a/charts/direktiv/templates/flow/flow-deployment.yaml
+++ b/charts/direktiv/templates/flow/flow-deployment.yaml
@@ -136,11 +136,11 @@ spec:
           - name: DIREKTIV_ENABLE_EVENTING
             value: {{ .Values.eventing.enabled | quote }}
           - name: DIREKTIV_KNATIVE_SERVICE_ACCOUNT
-            value: "direktiv-functions-pod"
+            value: "{{ include "direktiv.serviceAccountName" . }}-functions-pod"
           - name: DIREKTIV_KNATIVE_NAMESPACE
-            value: "direktiv-services-direktiv"
+            value: {{ .Values.functions.namespace | quote }}
           - name: DIREKTIV_KNATIVE_INGRESS_CLASS
-            value: "contour.ingress.networking.knative.dev"
+            value: {{ .Values.functions.ingressClass | quote }}
           - name: DIREKTIV_KNATIVE_SIDECAR
             value: "{{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag | default .Chart.AppVersion }}"
           - name: DIREKTIV_KNATIVE_MAX_SCALE


### PR DESCRIPTION
## Description

I found some environment variables in flow deployment are hard-coded. These are configured from the value file.
I changed the envs to get values from values or templates.

## Checklist

- dirkectiv services are generated and working in istio mesh cluster.
- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
