### PR TITLE
[DIR-1146] warn when navigating with unsaved changes

### DIFF
--- a/ui/e2e/explorer/workflow/codeEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/codeEditor.spec.ts
@@ -103,6 +103,27 @@ test("it is possible to save the workflow", async ({ page }) => {
   ).toHaveText("Updated a few seconds ago");
 });
 
+test("it is possible to navigate to another route from the editor", async ({
+  page,
+}) => {
+  let dialogTriggered = false;
+
+  page.on("dialog", async (dialog) => {
+    dialogTriggered = true;
+    return dialog.dismiss();
+  });
+
+  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.getByText(defaultDescription);
+
+  await page.getByRole("link", { name: "Settings" }).click();
+  await expect(dialogTriggered).toBe(false);
+
+  await expect(page, "it navigates to the new route").toHaveURL(
+    `${namespace}/settings`
+  );
+});
+
 test("it prevents navigation to another route with unsaved changes", async ({
   page,
 }) => {
@@ -162,6 +183,27 @@ test("with confirmation, it navigates to another route despite unsaved changes",
     page,
     "after confirming the dialog, it navigates to the new route"
   ).toHaveURL(`${namespace}/settings`);
+});
+
+test("it is possible to leave the app from the editor", async ({ page }) => {
+  let dialogTriggered = false;
+
+  page.on("dialog", async (dialog) => {
+    await expect(dialog.type()).toBe("beforeunload");
+    dialogTriggered = true;
+    await dialog.dismiss();
+  });
+
+  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.getByText(defaultDescription);
+
+  await page.goto("https://example.com");
+
+  await expect(dialogTriggered).toBe(false);
+
+  await expect(page, "it navigates to the new document").toHaveURL(
+    "https://example.com"
+  );
 });
 
 test("it prevents navigation away from the app with unsaved changes", async ({

--- a/ui/e2e/explorer/workflow/codeEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/codeEditor.spec.ts
@@ -102,3 +102,125 @@ test("it is possible to save the workflow", async ({ page }) => {
     "text should be Updated a few seconds ago"
   ).toHaveText("Updated a few seconds ago");
 });
+
+test("it prevents navigation to another route with unsaved changes", async ({
+  page,
+}) => {
+  const expectedMsg =
+    "You have unsaved changes that will be lost when leaving this route. Are you sure you want to leave?";
+  let dialogTriggered = false;
+
+  page.on("dialog", async (dialog) => {
+    await expect(dialog.message()).toBe(expectedMsg);
+    dialogTriggered = true;
+    return dialog.dismiss();
+  });
+
+  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.getByText(defaultDescription).click();
+
+  const dirtyText = faker.random.alphaNumeric(9);
+  await page.type("textarea", dirtyText);
+
+  await page.getByRole("link", { name: "Settings" }).click();
+  await expect(dialogTriggered).toBe(true);
+
+  await expect(
+    page,
+    "after dismissing the dialog, it stays on the same route"
+  ).toHaveURL(`${namespace}/explorer/workflow/edit/${workflow}`);
+
+  await expect(
+    page.getByText(dirtyText),
+    "the edited text is still in the editor"
+  ).toBeVisible();
+});
+
+test("with confirmation, it navigates to another route despite unsaved changes", async ({
+  page,
+}) => {
+  const expectedMsg =
+    "You have unsaved changes that will be lost when leaving this route. Are you sure you want to leave?";
+  let dialogTriggered = false;
+
+  page.on("dialog", async (dialog) => {
+    await expect(dialog.message()).toBe(expectedMsg);
+    dialogTriggered = true;
+    return dialog.accept();
+  });
+
+  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.getByText(defaultDescription).click();
+
+  const dirtyText = faker.random.alphaNumeric(9);
+  await page.type("textarea", dirtyText);
+
+  await page.getByRole("link", { name: "Settings" }).click();
+  await expect(dialogTriggered).toBe(true);
+
+  await expect(
+    page,
+    "after confirming the dialog, it navigates to the new route"
+  ).toHaveURL(`${namespace}/settings`);
+});
+
+test("it prevents navigation away from the app with unsaved changes", async ({
+  page,
+}) => {
+  let dialogTriggered = false;
+
+  page.on("dialog", async (dialog) => {
+    await expect(dialog.type()).toBe("beforeunload");
+    dialogTriggered = true;
+    await dialog.dismiss();
+  });
+
+  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.getByText(defaultDescription).click();
+
+  const dirtyText = faker.random.alphaNumeric(9);
+  await page.type("textarea", dirtyText);
+
+  try {
+    await page.goto("https://example.com").catch();
+  } catch (error) {
+    return;
+  }
+
+  await expect(dialogTriggered).toBe(true);
+
+  await expect(
+    page,
+    "after dismissing the dialog, it stays on the same route"
+  ).toHaveURL(`${namespace}/explorer/workflow/edit/${workflow}`);
+
+  await expect(
+    page.getByText(dirtyText),
+    "the edited text is still in the editor"
+  ).toBeVisible();
+});
+
+test("with confirmation, it allows navigation away from the app with unsaved changes", async ({
+  page,
+}) => {
+  let dialogTriggered = false;
+
+  page.on("dialog", async (dialog) => {
+    await expect(dialog.type()).toBe("beforeunload");
+    dialogTriggered = true;
+    await dialog.accept();
+  });
+
+  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.getByText(defaultDescription).click();
+
+  const dirtyText = faker.random.alphaNumeric(9);
+  await page.type("textarea", dirtyText);
+
+  await page.goto("https://example.com");
+
+  await expect(dialogTriggered).toBe(true);
+  await expect(page, "it has navigated to the new page").toHaveURL(
+    "https://example.com"
+  );
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -82,7 +82,7 @@
     "react-i18next": "^12.2.2",
     "react-icons": "^4.8.0",
     "react-oidc-context": "^2.3.1",
-    "react-router-dom": "^6.0.2",
+    "react-router-dom": "^6.22.3",
     "react-virtualized": "^9.22.3",
     "react-virtualized-auto-sizer": "^1.0.6",
     "reactflow": "^11.7.4",

--- a/ui/public/locales/en/translation.json
+++ b/ui/public/locales/en/translation.json
@@ -1232,6 +1232,9 @@
         "stateLabel": "state:",
         "instanceLabel": "instance:"
       }
+    },
+    "blocker": {
+      "unsavedChangesWarning": "You have unsaved changes that will be lost when leaving this route. Are you sure you want to leave?"
     }
   },
   "api": {

--- a/ui/src/design/Editor/index.tsx
+++ b/ui/src/design/Editor/index.tsx
@@ -18,6 +18,7 @@ import themeDark from "./theme-dark";
 import themeLight from "./theme-light";
 // eslint-disable-next-line import/default
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+import useNavigationBlocker from "~/hooks/useNavigationBlocker";
 
 self.MonacoEnvironment = {
   getWorker(_, label) {
@@ -55,6 +56,7 @@ const Editor: FC<
     onChange?: (value: string | undefined) => void;
     onMount?: EditorProps["onMount"];
     language?: EditorLanguagesType;
+    navigationWarning?: string | null;
   }
 > = ({
   options,
@@ -63,6 +65,7 @@ const Editor: FC<
   onChange,
   onMount,
   language = "yaml",
+  navigationWarning = null,
   ...props
 }) => {
   const monacoRef = useRef<EditorType>();
@@ -70,6 +73,8 @@ const Editor: FC<
   const handleChange = () => {
     onChange && onChange(monacoRef.current?.getValue());
   };
+
+  useNavigationBlocker(navigationWarning);
 
   // this is the shared onMount function, that will be called for
   // every Editor component. Each Editor can implement their own

--- a/ui/src/hooks/useNavigationBlocker.tsx
+++ b/ui/src/hooks/useNavigationBlocker.tsx
@@ -1,0 +1,48 @@
+import { BlockerFunction, useBlocker } from "react-router-dom";
+
+import { useEffect } from "react";
+
+/**
+ * Define a message to show that text as a warning before leaving the page.
+ * Set message to null to disable.
+ */
+const useNavigationBlocker = (message: string | null) => {
+  /**
+   * This triggers the browser's built in warning when navigating to another
+   * document (that is, leaving this app) with unsaved changes.
+   */
+  const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+    event.preventDefault();
+    event.returnValue = true;
+  };
+
+  useEffect(() => {
+    if (message) {
+      window.addEventListener("beforeunload", beforeUnloadHandler);
+    } else {
+      window.removeEventListener("beforeunload", beforeUnloadHandler);
+    }
+
+    return () =>
+      window.removeEventListener("beforeunload", beforeUnloadHandler);
+  });
+
+  /**
+   * This triggers a confirmation dialog when navigating away from the
+   * current route, but staying within our app.
+   */
+  const blockerFunction: BlockerFunction = ({
+    currentLocation,
+    nextLocation,
+  }) => (message ? currentLocation !== nextLocation : false);
+
+  const blocker = useBlocker(blockerFunction);
+
+  useEffect(() => {
+    message && blocker.state === "blocked" && window.confirm(message)
+      ? blocker.proceed()
+      : blocker.reset?.();
+  }, [blocker, blocker.state, message]);
+};
+
+export default useNavigationBlocker;

--- a/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
@@ -88,6 +88,11 @@ const ConsumerEditor: FC<ConsumerEditorProps> = ({ data }) => {
                     options={{
                       readOnly: true,
                     }}
+                    navigationWarning={
+                      isDirty
+                        ? t("components.blocker.unsavedChangesWarning")
+                        : null
+                    }
                   />
                 </Card>
               </div>

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/index.tsx
@@ -88,6 +88,11 @@ const EndpointEditor: FC<EndpointEditorProps> = ({ data }) => {
                     options={{
                       readOnly: true,
                     }}
+                    navigationWarning={
+                      isDirty
+                        ? t("components.blocker.unsavedChangesWarning")
+                        : null
+                    }
                   />
                 </Card>
               </div>

--- a/ui/src/pages/namespace/Explorer/Service/ServiceEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Service/ServiceEditor/index.tsx
@@ -92,6 +92,11 @@ const ServiceEditor: FC<ServiceEditorProps> = ({ data }) => {
                     options={{
                       readOnly: true,
                     }}
+                    navigationWarning={
+                      isDirty
+                        ? t("components.blocker.unsavedChangesWarning")
+                        : null
+                    }
                   />
                 </Card>
               </div>

--- a/ui/src/pages/namespace/Explorer/Workflow/Edit/CodeEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Edit/CodeEditor.tsx
@@ -1,10 +1,9 @@
-import { BlockerFunction, useBlocker } from "react-router-dom";
-import { FC, useEffect } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "~/design/Popover";
 
 import { Bug } from "lucide-react";
 import { Card } from "~/design/Card";
 import Editor from "~/design/Editor";
+import { FC } from "react";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
 import useUpdatedAt from "~/hooks/useUpdatedAt";
@@ -31,37 +30,6 @@ export const CodeEditor: FC<EditorProps> = ({
   const theme = useTheme();
   const updatedAtInWords = useUpdatedAt(updatedAt);
 
-  const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
-    event.preventDefault();
-    event.returnValue = true;
-  };
-
-  useEffect(() => {
-    if (hasUnsavedChanges) {
-      window.addEventListener("beforeunload", beforeUnloadHandler);
-    } else {
-      window.removeEventListener("beforeunload", beforeUnloadHandler);
-    }
-
-    return () =>
-      window.removeEventListener("beforeunload", beforeUnloadHandler);
-  });
-
-  const blockerFunction: BlockerFunction = ({
-    currentLocation,
-    nextLocation,
-  }) => hasUnsavedChanges && currentLocation !== nextLocation;
-
-  const blocker = useBlocker(blockerFunction);
-
-  const blockerMsg = t("components.blocker.unsavedChangesWarning");
-
-  useEffect(() => {
-    blocker.state === "blocked" && window.confirm(blockerMsg)
-      ? blocker.proceed()
-      : blocker.reset?.();
-  }, [blocker, blocker.state, blockerMsg]);
-
   return (
     <Card className="flex grow flex-col p-4">
       <div className="grow" data-testid="workflow-editor">
@@ -75,6 +43,11 @@ export const CodeEditor: FC<EditorProps> = ({
           }}
           theme={theme ?? undefined}
           onSave={onSave}
+          navigationWarning={
+            hasUnsavedChanges
+              ? t("components.blocker.unsavedChangesWarning")
+              : null
+          }
         />
       </div>
       <div

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2860,10 +2860,10 @@
     classcat "^5.0.3"
     zustand "^4.3.1"
 
-"@remix-run/router@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.3.tgz#d6d531d69c0fa3a44fda7dc00b20d49b44549164"
-  integrity sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==
+"@remix-run/router@1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.3.tgz#d2509048d69dbb72d5389a14945339f1430b2d3c"
+  integrity sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==
 
 "@rjsf/core@^5.7.3":
   version "5.7.3"
@@ -11319,20 +11319,20 @@ react-resize-detector@^8.0.4:
   dependencies:
     lodash "^4.17.21"
 
-react-router-dom@^6.0.2:
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.8.2.tgz#a6654a3400be9aafd504d7125573568921b78b57"
-  integrity sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==
+react-router-dom@^6.22.3:
+  version "6.22.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.22.3.tgz#9781415667fd1361a475146c5826d9f16752a691"
+  integrity sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==
   dependencies:
-    "@remix-run/router" "1.3.3"
-    react-router "6.8.2"
+    "@remix-run/router" "1.15.3"
+    react-router "6.22.3"
 
-react-router@6.8.2:
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.8.2.tgz#98f83582a73f316a3287118b440f0cee30ed6f33"
-  integrity sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==
+react-router@6.22.3:
+  version "6.22.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.3.tgz#9d9142f35e08be08c736a2082db5f0c9540a885e"
+  integrity sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==
   dependencies:
-    "@remix-run/router" "1.3.3"
+    "@remix-run/router" "1.15.3"
 
 react-smooth@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
## Description

This adds warnings against leaving the current page when an editor has unsaved changes.

Implemented on all file creation routes:
* Workflow
* Service
* Endpoint
* Consumer

Added tests for the correct behavior for the Workflow editor route. No redundant tests for the other routes were added.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
