### PR TITLE
[DIR-1412] Save files when clicking save in a subform

### DIFF
--- a/ui/e2e/explorer/route/index.spec.ts
+++ b/ui/e2e/explorer/route/index.spec.ts
@@ -86,14 +86,7 @@ test("it is possible to create a basic route file", async ({ page }) => {
     "all entered data is represented in the editor preview"
   ).toContainText(expectedYaml, { useInnerText: true });
 
-  /* save file */
-  await expect(
-    page.getByText("unsaved changes"),
-    "it renders a hint that there are unsaved changes"
-  ).toBeVisible();
-
-  await page.getByRole("button", { name: "Save" }).click();
-
+  /* note: saving the plugin should have saved the whole file. */
   await expect(
     page.getByText("unsaved changes"),
     "it does not render a hint that there are unsaved changes"
@@ -338,14 +331,7 @@ test("it is possible to add plugins to a route file", async ({ page }) => {
     useInnerText: true,
   });
 
-  /* save file */
-  await expect(
-    page.getByText("unsaved changes"),
-    "it renders a hint that there are unsaved changes"
-  ).toBeVisible();
-
-  await page.getByRole("button", { name: "Save" }).click();
-
+  /* note: saving the plugin should have saved the whole file. */
   await expect(
     page.getByText("unsaved changes"),
     "it does not render a hint that there are unsaved changes"

--- a/ui/e2e/explorer/service/index.spec.ts
+++ b/ui/e2e/explorer/service/index.spec.ts
@@ -315,12 +315,7 @@ test("it is possible to edit patches", async ({ page }) => {
     "all entered data is represented in the editor preview"
   ).toContainText(expectedYaml, { useInnerText: true });
 
-  await expect(
-    page.getByTestId("unsaved-note"),
-    "it renders a hint that there are unsaved changes"
-  ).toBeVisible();
-  await page.getByRole("button", { name: "Save" }).click();
-
+  /* note: saving the plugin should have saved the whole file. */
   await expect(
     page.getByTestId("unsaved-note"),
     "it does not render a hint that there are unsaved changes"

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/index.tsx
@@ -24,6 +24,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type FormProps = {
   defaultConfig?: EndpointFormSchemaType;
+  onSave: (value: EndpointFormSchemaType) => void;
   children: (args: {
     formControls: UseFormReturn<EndpointFormSchemaType>;
     formMarkup: JSX.Element;
@@ -31,7 +32,7 @@ type FormProps = {
   }) => JSX.Element;
 };
 
-export const Form: FC<FormProps> = ({ defaultConfig, children }) => {
+export const Form: FC<FormProps> = ({ defaultConfig, children, onSave }) => {
   const { t } = useTranslation();
   const formControls = useForm<EndpointFormSchemaType>({
     resolver: zodResolver(EndpointFormSchema),
@@ -128,10 +129,10 @@ export const Form: FC<FormProps> = ({ defaultConfig, children }) => {
             )}
           />
         </Fieldset>
-        <TargetPluginForm form={formControls} />
-        <InboundPluginForm form={formControls} />
-        <OutboundPluginForm form={formControls} />
-        <AuthPluginForm formControls={formControls} />
+        <TargetPluginForm form={formControls} onSave={onSave} />
+        <InboundPluginForm form={formControls} onSave={onSave} />
+        <OutboundPluginForm form={formControls} onSave={onSave} />
+        <AuthPluginForm formControls={formControls} onSave={onSave} />
       </div>
     ),
   });

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/index.tsx
@@ -41,11 +41,15 @@ import { useTranslation } from "react-i18next";
 
 type AuthPluginFormProps = {
   formControls: UseFormReturn<EndpointFormSchemaType>;
+  onSave: (value: EndpointFormSchemaType) => void;
 };
 
-export const AuthPluginForm: FC<AuthPluginFormProps> = ({ formControls }) => {
+export const AuthPluginForm: FC<AuthPluginFormProps> = ({
+  formControls,
+  onSave,
+}) => {
   const { t } = useTranslation();
-  const { control } = formControls;
+  const { control, handleSubmit: parentSubmit } = formControls;
   const {
     append: addPlugin,
     remove: deletePlugin,
@@ -77,6 +81,7 @@ export const AuthPluginForm: FC<AuthPluginFormProps> = ({ formControls }) => {
     } else {
       editPlugin(editIndex, configuration);
     }
+    parentSubmit(onSave)();
     setEditIndex(undefined);
   };
 

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/index.tsx
@@ -49,7 +49,7 @@ export const AuthPluginForm: FC<AuthPluginFormProps> = ({
   onSave,
 }) => {
   const { t } = useTranslation();
-  const { control, handleSubmit: parentSubmit } = formControls;
+  const { control, handleSubmit: handleParentSubmit } = formControls;
   const {
     append: addPlugin,
     remove: deletePlugin,
@@ -81,7 +81,7 @@ export const AuthPluginForm: FC<AuthPluginFormProps> = ({
     } else {
       editPlugin(editIndex, configuration);
     }
-    parentSubmit(onSave)();
+    handleParentSubmit(onSave)();
     setEditIndex(undefined);
   };
 

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
@@ -39,11 +39,15 @@ import { useTranslation } from "react-i18next";
 
 type InboundPluginFormProps = {
   form: UseFormReturn<EndpointFormSchemaType>;
+  onSave: (value: EndpointFormSchemaType) => void;
 };
 
-export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
+export const InboundPluginForm: FC<InboundPluginFormProps> = ({
+  form,
+  onSave,
+}) => {
   const { t } = useTranslation();
-  const { control } = form;
+  const { control, handleSubmit: parentSubmit } = form;
   const {
     append: addPlugin,
     remove: deletePlugin,
@@ -62,6 +66,17 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
 
   const { jsInbound, requestConvert, acl, eventFilter, headerManipulation } =
     inboundPluginTypes;
+
+  const handleSubmit = (configuration: InboundPluginFormSchemaType) => {
+    setDialogOpen(false);
+    if (editIndex === undefined) {
+      addPlugin(configuration);
+    } else {
+      editPlugin(editIndex, configuration);
+    }
+    parentSubmit(onSave)();
+    setEditIndex(undefined);
+  };
 
   const pluginsCount = fields.length;
   const formId = "inboundPluginForm";
@@ -189,45 +204,21 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
           <RequestConvertForm
             formId={formId}
             defaultConfig={getRequestConvertConfigAtIndex(fields, editIndex)}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              if (editIndex === undefined) {
-                addPlugin(configuration);
-              } else {
-                editPlugin(editIndex, configuration);
-              }
-              setEditIndex(undefined);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
         {selectedPlugin === jsInbound.name && (
           <JsInboundForm
             formId={formId}
             defaultConfig={getJsInboundConfigAtIndex(fields, editIndex)}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              if (editIndex === undefined) {
-                addPlugin(configuration);
-              } else {
-                editPlugin(editIndex, configuration);
-              }
-              setEditIndex(undefined);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
         {selectedPlugin === acl.name && (
           <AclForm
             formId={formId}
             defaultConfig={getAclConfigAtIndex(fields, editIndex)}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              if (editIndex === undefined) {
-                addPlugin(configuration);
-              } else {
-                editPlugin(editIndex, configuration);
-              }
-              setEditIndex(undefined);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
 
@@ -238,30 +229,14 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
               fields,
               editIndex
             )}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              if (editIndex === undefined) {
-                addPlugin(configuration);
-              } else {
-                editPlugin(editIndex, configuration);
-              }
-              setEditIndex(undefined);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
         {selectedPlugin === eventFilter.name && (
           <EventFilterForm
             formId={formId}
             defaultConfig={getEventFilterConfigAtIndex(fields, editIndex)}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              if (editIndex === undefined) {
-                addPlugin(configuration);
-              } else {
-                editPlugin(editIndex, configuration);
-              }
-              setEditIndex(undefined);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
       </ModalWrapper>

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
@@ -47,7 +47,7 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({
   onSave,
 }) => {
   const { t } = useTranslation();
-  const { control, handleSubmit: parentSubmit } = form;
+  const { control, handleSubmit: handleParentSubmit } = form;
   const {
     append: addPlugin,
     remove: deletePlugin,
@@ -74,7 +74,7 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({
     } else {
       editPlugin(editIndex, configuration);
     }
-    parentSubmit(onSave)();
+    handleParentSubmit(onSave)();
     setEditIndex(undefined);
   };
 

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
@@ -37,7 +37,7 @@ export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({
   onSave,
 }) => {
   const { t } = useTranslation();
-  const { control, handleSubmit } = form;
+  const { control, handleSubmit: parentSubmit } = form;
   const {
     append: addPlugin,
     remove: deletePlugin,
@@ -187,7 +187,7 @@ export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({
               } else {
                 editPlugin(editIndex, configuration);
               }
-              handleSubmit(onSave)();
+              parentSubmit(onSave)();
               setEditIndex(undefined);
             }}
           />

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
@@ -37,7 +37,7 @@ export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({
   onSave,
 }) => {
   const { t } = useTranslation();
-  const { control, handleSubmit: parentSubmit } = form;
+  const { control, handleSubmit: handleParentSubmit } = form;
   const {
     append: addPlugin,
     remove: deletePlugin,
@@ -187,7 +187,7 @@ export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({
               } else {
                 editPlugin(editIndex, configuration);
               }
-              parentSubmit(onSave)();
+              handleParentSubmit(onSave)();
               setEditIndex(undefined);
             }}
           />

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
@@ -29,11 +29,15 @@ import { useTranslation } from "react-i18next";
 
 type OutboundPluginFormProps = {
   form: UseFormReturn<EndpointFormSchemaType>;
+  onSave: (value: EndpointFormSchemaType) => void;
 };
 
-export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({ form }) => {
+export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({
+  form,
+  onSave,
+}) => {
   const { t } = useTranslation();
-  const { control } = form;
+  const { control, handleSubmit } = form;
   const {
     append: addPlugin,
     remove: deletePlugin,
@@ -183,6 +187,7 @@ export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({ form }) => {
               } else {
                 editPlugin(editIndex, configuration);
               }
+              handleSubmit(onSave)();
               setEditIndex(undefined);
             }}
           />

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
@@ -38,7 +38,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({
   form,
   onSave,
 }) => {
-  const { control, handleSubmit } = form;
+  const { control, handleSubmit: parentSubmit } = form;
   const values = useWatch({ control });
   const { t } = useTranslation();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -174,7 +174,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({
             onSubmit={(configuration) => {
               setDialogOpen(false);
               form.setValue("plugins.target", configuration);
-              handleSubmit(onSave)();
+              parentSubmit(onSave)();
             }}
           />
         )}

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
@@ -27,6 +27,7 @@ import { TargetFlowForm } from "./TargetFlowForm";
 import { TargetFlowVarForm } from "./TargetFlowVarForm";
 import { TargetNamespaceFileForm } from "./TargetNamespaceFileForm";
 import { TargetNamespaceVarForm } from "./TargetNamespaceVarForm";
+import { TargetPluginFormSchemaType } from "../../../schema/plugins/target/schema";
 import { useTranslation } from "react-i18next";
 
 type TargetPluginFormProps = {
@@ -45,6 +46,12 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({
 
   const currentType = values.plugins?.target?.type;
   const [selectedPlugin, setSelectedPlugin] = useState(currentType);
+
+  const handleSubmit = (configuration: TargetPluginFormSchemaType) => {
+    setDialogOpen(false);
+    form.setValue("plugins.target", configuration);
+    parentSubmit(onSave)();
+  };
 
   const {
     instantResponse,
@@ -171,61 +178,42 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({
           <InstantResponseForm
             formId={formId}
             defaultConfig={currentInstantResponseConfig}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              form.setValue("plugins.target", configuration);
-              parentSubmit(onSave)();
-            }}
+            onSubmit={handleSubmit}
           />
         )}
         {selectedPlugin === targetFlow.name && (
           <TargetFlowForm
             formId={formId}
             defaultConfig={currentTargetFlowConfig}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              form.setValue("plugins.target", configuration);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
         {selectedPlugin === targetFlowVar.name && (
           <TargetFlowVarForm
             formId={formId}
             defaultConfig={currentTargetFlowVarConfig}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              form.setValue("plugins.target", configuration);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
         {selectedPlugin === targetNamespaceFile.name && (
           <TargetNamespaceFileForm
             formId={formId}
             defaultConfig={currentTargetNamespaceFileConfig}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              form.setValue("plugins.target", configuration);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
         {selectedPlugin === targetNamespaceVar.name && (
           <TargetNamespaceVarForm
             formId={formId}
             defaultConfig={currentTargetNamespaceVarConfig}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              form.setValue("plugins.target", configuration);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
         {selectedPlugin === targetEvent.name && (
           <TargetEventForm
             formId={formId}
             defaultConfig={currentTargetEventConfig}
-            onSubmit={(configuration) => {
-              setDialogOpen(false);
-              form.setValue("plugins.target", configuration);
-            }}
+            onSubmit={handleSubmit}
           />
         )}
       </ModalWrapper>

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
@@ -31,10 +31,14 @@ import { useTranslation } from "react-i18next";
 
 type TargetPluginFormProps = {
   form: UseFormReturn<EndpointFormSchemaType>;
+  onSave: (value: EndpointFormSchemaType) => void;
 };
 
-export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
-  const { control } = form;
+export const TargetPluginForm: FC<TargetPluginFormProps> = ({
+  form,
+  onSave,
+}) => {
+  const { control, handleSubmit } = form;
   const values = useWatch({ control });
   const { t } = useTranslation();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -170,6 +174,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
             onSubmit={(configuration) => {
               setDialogOpen(false);
               form.setValue("plugins.target", configuration);
+              handleSubmit(onSave)();
             }}
           />
         )}

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
@@ -39,7 +39,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({
   form,
   onSave,
 }) => {
-  const { control, handleSubmit: parentSubmit } = form;
+  const { control, handleSubmit: handleParentSubmit } = form;
   const values = useWatch({ control });
   const { t } = useTranslation();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -50,7 +50,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({
   const handleSubmit = (configuration: TargetPluginFormSchemaType) => {
     setDialogOpen(false);
     form.setValue("plugins.target", configuration);
-    parentSubmit(onSave)();
+    handleParentSubmit(onSave)();
   };
 
   const {

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/index.tsx
@@ -39,7 +39,7 @@ const EndpointEditor: FC<EndpointEditorProps> = ({ data }) => {
   };
 
   return (
-    <Form defaultConfig={endpointConfig}>
+    <Form defaultConfig={endpointConfig} onSave={save}>
       {({
         formControls: {
           formState: { errors },

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/schema.ts
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/schema.ts
@@ -14,3 +14,5 @@ export const TargetPluginFormSchema = z.discriminatedUnion("type", [
   TargetNamespaceVarFormSchema,
   TargetEventFormSchema,
 ]);
+
+export type TargetPluginFormSchemaType = z.infer<typeof TargetPluginFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Service/ServiceEditor/Form/Patches/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Service/ServiceEditor/Form/Patches/index.tsx
@@ -18,7 +18,7 @@ type PatchesFormProps = {
 };
 
 export const PatchesForm: FC<PatchesFormProps> = ({ form, onSave }) => {
-  const { control, handleSubmit: parentSubmit } = form;
+  const { control, handleSubmit: handleParentSubmit } = form;
   const values = useWatch({ control });
   const { t } = useTranslation();
 
@@ -44,7 +44,7 @@ export const PatchesForm: FC<PatchesFormProps> = ({ form, onSave }) => {
     } else {
       updateItem(indexToEdit, item);
     }
-    parentSubmit(onSave)();
+    handleParentSubmit(onSave)();
     setDialogOpen(false);
   };
 

--- a/ui/src/pages/namespace/Explorer/Service/ServiceEditor/Form/Patches/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Service/ServiceEditor/Form/Patches/index.tsx
@@ -14,10 +14,11 @@ import { useTranslation } from "react-i18next";
 
 type PatchesFormProps = {
   form: UseFormReturn<ServiceFormSchemaType>;
+  onSave: (value: ServiceFormSchemaType) => void;
 };
 
-export const PatchesForm: FC<PatchesFormProps> = ({ form }) => {
-  const { control } = form;
+export const PatchesForm: FC<PatchesFormProps> = ({ form, onSave }) => {
+  const { control, handleSubmit: parentSubmit } = form;
   const values = useWatch({ control });
   const { t } = useTranslation();
 
@@ -43,6 +44,7 @@ export const PatchesForm: FC<PatchesFormProps> = ({ form }) => {
     } else {
       updateItem(indexToEdit, item);
     }
+    parentSubmit(onSave)();
     setDialogOpen(false);
   };
 

--- a/ui/src/pages/namespace/Explorer/Service/ServiceEditor/Form/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Service/ServiceEditor/Form/index.tsx
@@ -38,6 +38,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type FormProps = {
   defaultConfig?: ServiceFormSchemaType;
+  onSave: (value: ServiceFormSchemaType) => void;
   children: (args: {
     formControls: UseFormReturn<ServiceFormSchemaType>;
     formMarkup: JSX.Element;
@@ -45,7 +46,7 @@ type FormProps = {
   }) => JSX.Element;
 };
 
-export const Form: FC<FormProps> = ({ defaultConfig, children }) => {
+export const Form: FC<FormProps> = ({ defaultConfig, children, onSave }) => {
   const { t } = useTranslation();
   const formControls = useForm<ServiceFormSchemaType>({
     resolver: zodResolver(ServiceFormSchema),
@@ -164,7 +165,7 @@ export const Form: FC<FormProps> = ({ defaultConfig, children }) => {
           <Input {...register("cmd")} id="cmd" />
         </Fieldset>
 
-        <PatchesForm form={formControls} />
+        <PatchesForm form={formControls} onSave={onSave} />
 
         <Fieldset
           label={t("pages.explorer.service.editor.form.envs.label")}

--- a/ui/src/pages/namespace/Explorer/Service/ServiceEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Service/ServiceEditor/index.tsx
@@ -42,7 +42,7 @@ const ServiceEditor: FC<ServiceEditorProps> = ({ data }) => {
   };
 
   return (
-    <Form defaultConfig={serviceConfig}>
+    <Form defaultConfig={serviceConfig} onSave={save}>
       {({
         formControls: {
           formState: { errors },


### PR DESCRIPTION
## Description

In Services and Endpoints, the file will now be saved to server when clicking save in a subform (e.g., when adding plugins or service patches).

No changes to editing workflows and consumers, because there are no subforms. 

## Discussion

I don't find it 100% logical that the file is saved without clicking the main "save" button under the editor. There are still situations where you have to click it manually (for example, when adding tags in consumers or envs in services). 

But on the other hand, its unlikely to be harmful.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
