### PR TITLE
[DIR-1411] Remove router dependency from storybook

### DIFF
--- a/ui/src/components/NavigationBlocker/index.tsx
+++ b/ui/src/components/NavigationBlocker/index.tsx
@@ -1,0 +1,12 @@
+import { FC } from "react";
+import useNavigationBlocker from "~/hooks/useNavigationBlocker";
+import { useTranslation } from "react-i18next";
+
+const NavigationBlocker: FC = () => {
+  const { t } = useTranslation();
+  useNavigationBlocker(t("components.blocker.unsavedChangesWarning"));
+
+  return null;
+};
+
+export default NavigationBlocker;

--- a/ui/src/design/Editor/index.tsx
+++ b/ui/src/design/Editor/index.tsx
@@ -18,7 +18,6 @@ import themeDark from "./theme-dark";
 import themeLight from "./theme-light";
 // eslint-disable-next-line import/default
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
-import useNavigationBlocker from "~/hooks/useNavigationBlocker";
 
 self.MonacoEnvironment = {
   getWorker(_, label) {
@@ -56,7 +55,6 @@ const Editor: FC<
     onChange?: (value: string | undefined) => void;
     onMount?: EditorProps["onMount"];
     language?: EditorLanguagesType;
-    navigationWarning?: string | null;
   }
 > = ({
   options,
@@ -65,7 +63,6 @@ const Editor: FC<
   onChange,
   onMount,
   language = "yaml",
-  navigationWarning = null,
   ...props
 }) => {
   const monacoRef = useRef<EditorType>();
@@ -73,8 +70,6 @@ const Editor: FC<
   const handleChange = () => {
     onChange && onChange(monacoRef.current?.getValue());
   };
-
-  useNavigationBlocker(navigationWarning);
 
   // this is the shared onMount function, that will be called for
   // every Editor component. Each Editor can implement their own

--- a/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Consumer/ConsumerEditor/index.tsx
@@ -9,6 +9,7 @@ import { FC } from "react";
 import { FileSchemaType } from "~/api/files/schema";
 import { Form } from "./Form";
 import FormErrors from "~/components/FormErrors";
+import NavigationBlocker from "~/components/NavigationBlocker";
 import { Save } from "lucide-react";
 import { ScrollArea } from "~/design/ScrollArea";
 import { jsonToYaml } from "../../utils";
@@ -58,6 +59,7 @@ const ConsumerEditor: FC<ConsumerEditorProps> = ({ data }) => {
             onSubmit={handleSubmit(save)}
             className="relative flex-col gap-4 p-5"
           >
+            {isDirty && <NavigationBlocker />}
             <div className="flex flex-col gap-4">
               <div className="grid grow grid-cols-1 gap-5 lg:grid-cols-2">
                 <Card className="p-5 lg:h-[calc(100vh-15.5rem)] lg:overflow-y-scroll">
@@ -88,11 +90,6 @@ const ConsumerEditor: FC<ConsumerEditorProps> = ({ data }) => {
                     options={{
                       readOnly: true,
                     }}
-                    navigationWarning={
-                      isDirty
-                        ? t("components.blocker.unsavedChangesWarning")
-                        : null
-                    }
                   />
                 </Card>
               </div>

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/index.tsx
@@ -9,6 +9,7 @@ import { FC } from "react";
 import { FileSchemaType } from "~/api/files/schema";
 import { Form } from "./Form";
 import FormErrors from "~/components/FormErrors";
+import NavigationBlocker from "~/components/NavigationBlocker";
 import { Save } from "lucide-react";
 import { ScrollArea } from "~/design/ScrollArea";
 import { jsonToYaml } from "../../utils";
@@ -58,6 +59,7 @@ const EndpointEditor: FC<EndpointEditorProps> = ({ data }) => {
             onSubmit={handleSubmit(save)}
             className="relative flex-col gap-4 p-5"
           >
+            {isDirty && <NavigationBlocker />}
             <div className="flex flex-col gap-4">
               <div className="grid grow grid-cols-1 gap-5 lg:grid-cols-2">
                 <Card className="p-5 lg:h-[calc(100vh-15.5rem)] lg:overflow-y-scroll">
@@ -88,11 +90,6 @@ const EndpointEditor: FC<EndpointEditorProps> = ({ data }) => {
                     options={{
                       readOnly: true,
                     }}
-                    navigationWarning={
-                      isDirty
-                        ? t("components.blocker.unsavedChangesWarning")
-                        : null
-                    }
                   />
                 </Card>
               </div>

--- a/ui/src/pages/namespace/Explorer/Service/ServiceEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Service/ServiceEditor/index.tsx
@@ -8,6 +8,7 @@ import { FC } from "react";
 import { FileSchemaType } from "~/api/files/schema";
 import { Form } from "./Form";
 import FormErrors from "~/components/FormErrors";
+import NavigationBlocker from "~/components/NavigationBlocker";
 import { Save } from "lucide-react";
 import { ScrollArea } from "~/design/ScrollArea";
 import { ServiceFormSchemaType } from "./schema";
@@ -62,6 +63,7 @@ const ServiceEditor: FC<ServiceEditorProps> = ({ data }) => {
             onSubmit={handleSubmit(save)}
             className="relative flex-col gap-4 p-5"
           >
+            {isDirty && <NavigationBlocker />}
             <div className="flex flex-col gap-4">
               <div className="grid grow grid-cols-1 gap-5 lg:grid-cols-2">
                 <Card className="p-5 lg:h-[calc(100vh-15.5rem)] lg:overflow-y-scroll">
@@ -92,11 +94,6 @@ const ServiceEditor: FC<ServiceEditorProps> = ({ data }) => {
                     options={{
                       readOnly: true,
                     }}
-                    navigationWarning={
-                      isDirty
-                        ? t("components.blocker.unsavedChangesWarning")
-                        : null
-                    }
                   />
                 </Card>
               </div>

--- a/ui/src/pages/namespace/Explorer/Workflow/Edit/CodeEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Edit/CodeEditor.tsx
@@ -4,6 +4,7 @@ import { Bug } from "lucide-react";
 import { Card } from "~/design/Card";
 import Editor from "~/design/Editor";
 import { FC } from "react";
+import useNavigationBlocker from "~/hooks/useNavigationBlocker";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
 import useUpdatedAt from "~/hooks/useUpdatedAt";
@@ -30,6 +31,10 @@ export const CodeEditor: FC<EditorProps> = ({
   const theme = useTheme();
   const updatedAtInWords = useUpdatedAt(updatedAt);
 
+  useNavigationBlocker(
+    hasUnsavedChanges ? t("components.blocker.unsavedChangesWarning") : null
+  );
+
   return (
     <Card className="flex grow flex-col p-4">
       <div className="grow" data-testid="workflow-editor">
@@ -43,11 +48,6 @@ export const CodeEditor: FC<EditorProps> = ({
           }}
           theme={theme ?? undefined}
           onSave={onSave}
-          navigationWarning={
-            hasUnsavedChanges
-              ? t("components.blocker.unsavedChangesWarning")
-              : null
-          }
         />
       </div>
       <div


### PR DESCRIPTION
## Description

This refactors the navigation blocker, removing the react router dependency from storybook where it causes issues.

Instead, there are now two ways of adding the navigation blocker to a page:
1. Import useNavigationBlocker
2. Where (1) isn't possible because the hook is called conditionally, use the `<NavigationBlocker />` component. It does nothing more than calling useNavigationBlocker, but rendering the component conditionally is a recommended React pattern while calling the hook conditionally is not.

It would be possible to remove (1), put all logic into the component, and use only that whenever needed. I am undecided whether we should do that, or support both ways. What do you think, @stefan-kracht ?

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
