### PR TITLE
[DIR-1336] correctly display v2 api errors when saving workflows

### DIFF
--- a/ui/e2e/explorer/workflow/codeEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/codeEditor.spec.ts
@@ -103,6 +103,39 @@ test("it is possible to save the workflow", async ({ page }) => {
   ).toHaveText("Updated a few seconds ago");
 });
 
+test("it renders response errors when saving an invalid workflow", async ({
+  page,
+}) => {
+  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+
+  const editor = page.locator(".lines-content");
+
+  await editor.click();
+  /* enter text under existing content with wrong indentation */
+  await editor.type("notvalidyaml");
+
+  await expect(
+    page.getByText("unsaved changes"),
+    "it renders a hint that there are unsaved changes"
+  ).toBeVisible();
+
+  await page.getByTestId("workflow-editor-btn-save").click();
+
+  await expect(
+    page.getByText("There is an issue"),
+    "after saving, it renders an error hint in the editor"
+  ).toBeVisible();
+  await expect(
+    page.getByText("updated file data has invalid yaml string"),
+    "it renders an error popup with the error message"
+  ).toBeVisible();
+
+  await expect(
+    page.getByText("unsaved changes"),
+    "it still renders a hint that there are unsaved changes"
+  ).toBeVisible();
+});
+
 test("it is possible to navigate to another route from the editor", async ({
   page,
 }) => {

--- a/ui/e2e/explorer/workflow/codeEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/codeEditor.spec.ts
@@ -111,7 +111,6 @@ test("it renders response errors when saving an invalid workflow", async ({
   const editor = page.locator(".lines-content");
 
   await editor.click();
-  /* enter text under existing content with wrong indentation */
   await editor.type("notvalidyaml");
 
   await expect(


### PR DESCRIPTION
## Description

Saving a workflow with invalid YAML failed silently because the UI did not render the error received in the api response.

The bug occurred because errors are formatted differently in API v1 and v2 and the v2 format wasn't yet implemented in the UI. For now, I decided to support both error response formats because I wasn't sure to what extent v1 errors are still relevant. I also created DIR-1417 so we'll remember to eventually remove the v1 error response format handling. 

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
