### PR TITLE
Fixes and reintroduces the make help command to our newly divided mak…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,9 @@ RELEASE_VERSION := ${RELEASE}-${GIT_HASH}${GIT_DIRTY}
 
 include make_protobuf.mk make_direktiv.mk make_direktiv_ui.mk make_k3s.mk make_tests.mk
 
-
+.PHONY: help
+help: ## Prints usage information.
+	@echo "\033[36mMakefile Help\033[0m"
+	@echo ""
+	@echo "\033[36mTargets\033[0m"
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":"}; {printf "  %-24s %s\n", $$2, $$3}'


### PR DESCRIPTION
…efile.

## Description

I didn't know you could split up Makefiles. Seeing that we'd done this recently, I wanted to experiment with it. I noticed you removed the help command, which I use a lot. I learned how to re-add it. I had to fix it to work with the changes. 

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [ ] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
