### PR TITLE
[DIR-1451] add payload type support to api factory

### DIFF
--- a/ui/e2e/utils/events.ts
+++ b/ui/e2e/utils/events.ts
@@ -52,9 +52,10 @@ export const createEvents = async (namespace: string) => {
   }));
 
   return await Promise.all(
-    events.map((event) =>
-      sendEvent({
-        payload: event,
+    events.map((event) => {
+      const payload = JSON.stringify(event);
+      return sendEvent({
+        payload,
         urlParams: {
           baseUrl: process.env.PLAYWRIGHT_UI_BASE_URL,
           namespace,
@@ -64,7 +65,7 @@ export const createEvents = async (namespace: string) => {
           "content-type": "application/cloudevents+json",
         },
         // request returns null, thus return the generated data instead for use in the test
-      }).then(() => event)
-    )
+      }).then(() => event);
+    })
   );
 };

--- a/ui/e2e/utils/files.ts
+++ b/ui/e2e/utils/files.ts
@@ -1,4 +1,4 @@
-import { FileTypeType } from "~/api/files/schema";
+import { CreateFileSchemaType } from "~/api/files/schema";
 import { createFile as apiCreateFile } from "~/api/files/mutate/createFile";
 import { encode } from "js-base64";
 import { headers } from "./testutils";
@@ -13,7 +13,7 @@ export const createFile = async ({
   name: string;
   yaml: string;
   namespace: string;
-  type: FileTypeType;
+  type: CreateFileSchemaType["type"];
   path?: string;
 }) =>
   await apiCreateFile({

--- a/ui/src/api/apiFactory.ts
+++ b/ui/src/api/apiFactory.ts
@@ -21,7 +21,7 @@ type FactoryParams<TUrlParams, TSchema> = {
 
 type ApiParams<TPayload, THeaders, TUrlParams> = {
   apiKey?: string;
-  payload?: TPayload extends undefined ? undefined : TPayload;
+  payload?: TPayload;
   headers?: THeaders extends undefined ? undefined : THeaders;
   urlParams: TUrlParams;
 };
@@ -76,8 +76,17 @@ const defaultResponseParser: ResponseParser = async ({ res, schema }) => {
  * resonse.
  * @returns a Promise that resolves to the zod parsed response.
  */
+
 export const apiFactory =
-  <TSchema, TPayload, THeaders, TUrlParams>({
+  <
+    TPayload = unknown,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TSchema = any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    THeaders = any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TUrlParams = any
+  >({
     url,
     method,
     schema,

--- a/ui/src/api/enterprise/groups/mutation/create.ts
+++ b/ui/src/api/enterprise/groups/mutation/create.ts
@@ -9,7 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-const createGroup = apiFactory({
+const createGroup = apiFactory<GroupFormSchemaType>({
   url: ({ namespace, baseUrl }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/groups`,
   method: "POST",

--- a/ui/src/api/enterprise/groups/mutation/edit.ts
+++ b/ui/src/api/enterprise/groups/mutation/edit.ts
@@ -9,7 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-const editGroup = apiFactory({
+const editGroup = apiFactory<GroupFormSchemaType>({
   url: ({
     namespace,
     baseUrl,

--- a/ui/src/api/enterprise/policy/mutate/update.ts
+++ b/ui/src/api/enterprise/policy/mutate/update.ts
@@ -7,7 +7,7 @@ import useMutationWithPermissions from "~/api/useMutationWithPermissions";
 import { useNamespace } from "~/util/store/namespace";
 import { useQueryClient } from "@tanstack/react-query";
 
-const updatePolicy = apiFactory({
+const updatePolicy = apiFactory<string>({
   url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/policy`,
   method: "PUT",

--- a/ui/src/api/enterprise/tokens/mutate/create.ts
+++ b/ui/src/api/enterprise/tokens/mutate/create.ts
@@ -9,7 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-const createToken = apiFactory({
+const createToken = apiFactory<TokenFormSchemaType>({
   url: ({ namespace, baseUrl }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/tokens`,
   method: "POST",

--- a/ui/src/api/events/mutate/sendEvent.ts
+++ b/ui/src/api/events/mutate/sendEvent.ts
@@ -11,12 +11,7 @@ import { useNamespace } from "~/util/store/namespace";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-/**
- * TODO: apiFactory<NewEventSchemaType["body"]> should be the correct type, which
- * resolves to a string type. But createEvents in e2e/utils/events.ts is sending
- * something different. Leaving the type as is for now.
- */
-export const sendEvent = apiFactory({
+export const sendEvent = apiFactory<NewEventSchemaType["body"]>({
   url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/namespaces/${namespace}/broadcast`,
   method: "POST",

--- a/ui/src/api/events/mutate/sendEvent.ts
+++ b/ui/src/api/events/mutate/sendEvent.ts
@@ -11,7 +11,7 @@ import { useNamespace } from "~/util/store/namespace";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-export const sendEvent = apiFactory({
+export const sendEvent = apiFactory<NewEventSchemaType["body"]>({
   url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/namespaces/${namespace}/broadcast`,
   method: "POST",

--- a/ui/src/api/events/mutate/sendEvent.ts
+++ b/ui/src/api/events/mutate/sendEvent.ts
@@ -12,8 +12,9 @@ import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
 /**
- * TODO: apiFactory<NewEventSchemaType["body"]> should be the correct type
- *  but the but e2e/utils/events.ts is sending something different.
+ * TODO: apiFactory<NewEventSchemaType["body"]> should be the correct type, which
+ * resolves to a string type. But createEvents in e2e/utils/events.ts is sending
+ * something different. Leaving the type as is for now.
  */
 export const sendEvent = apiFactory({
   url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>

--- a/ui/src/api/events/mutate/sendEvent.ts
+++ b/ui/src/api/events/mutate/sendEvent.ts
@@ -11,7 +11,11 @@ import { useNamespace } from "~/util/store/namespace";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-export const sendEvent = apiFactory<NewEventSchemaType["body"]>({
+/**
+ * TODO: apiFactory<NewEventSchemaType["body"]> should be the correct type
+ *  but the but e2e/utils/events.ts is sending something different.
+ */
+export const sendEvent = apiFactory({
   url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/namespaces/${namespace}/broadcast`,
   method: "POST",

--- a/ui/src/api/files/mutate/createFile.ts
+++ b/ui/src/api/files/mutate/createFile.ts
@@ -12,7 +12,7 @@ import { useNamespace } from "~/util/store/namespace";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-export const createFile = apiFactory({
+export const createFile = apiFactory<CreateFileSchemaType>({
   url: ({
     baseUrl,
     namespace,

--- a/ui/src/api/files/mutate/patchFile.ts
+++ b/ui/src/api/files/mutate/patchFile.ts
@@ -1,9 +1,15 @@
-import { FilePatchedSchema, RenameFileSchemaType } from "../schema";
+import {
+  FilePatchedSchema,
+  RenameFileSchemaType,
+  UpdateFileSchemaType,
+} from "../schema";
 
 import { apiFactory } from "~/api/apiFactory";
 import { forceLeadingSlash } from "~/api/files/utils";
 
-export const patchFile = apiFactory<RenameFileSchemaType>({
+export const patchFile = apiFactory<
+  RenameFileSchemaType | UpdateFileSchemaType
+>({
   url: ({
     baseUrl,
     namespace,

--- a/ui/src/api/files/mutate/patchFile.ts
+++ b/ui/src/api/files/mutate/patchFile.ts
@@ -1,8 +1,9 @@
-import { FilePatchedSchema } from "../schema";
+import { FilePatchedSchema, RenameFileSchemaType } from "../schema";
+
 import { apiFactory } from "~/api/apiFactory";
 import { forceLeadingSlash } from "~/api/files/utils";
 
-export const patchFile = apiFactory({
+export const patchFile = apiFactory<RenameFileSchemaType>({
   url: ({
     baseUrl,
     namespace,

--- a/ui/src/api/jq/mutate/executeQuery.ts
+++ b/ui/src/api/jq/mutate/executeQuery.ts
@@ -6,7 +6,7 @@ import { getMessageFromApiError } from "~/api/errorHandling";
 import { useApiKey } from "~/util/store/apiKey";
 import useMutationWithPermissions from "~/api/useMutationWithPermissions";
 
-export const executeJquery = apiFactory({
+export const executeJquery = apiFactory<{ query: string; data: string }>({
   url: ({ baseUrl }: { baseUrl?: string }) => `${baseUrl ?? ""}/api/jq`,
   method: "POST",
   schema: JqQueryResult,

--- a/ui/src/api/namespaces/mutate/createNamespace.ts
+++ b/ui/src/api/namespaces/mutate/createNamespace.ts
@@ -10,7 +10,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-const createNamespace = apiFactory({
+const createNamespace = apiFactory<MirrorPostSchemaType>({
   url: ({ name }: { name: string }) => `/api/namespaces/${name}`,
   method: "PUT",
   schema: NamespaceCreatedSchema,

--- a/ui/src/api/registries/mutate/createRegistry.ts
+++ b/ui/src/api/registries/mutate/createRegistry.ts
@@ -9,7 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
-export const createRegistry = apiFactory({
+export const createRegistry = apiFactory<RegistryFormSchemaType>({
   url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/registries`,
   method: "POST",

--- a/ui/src/api/secrets/mutate/create.ts
+++ b/ui/src/api/secrets/mutate/create.ts
@@ -14,7 +14,7 @@ import { useTranslation } from "react-i18next";
 
 type CreateSecretParams = { baseUrl?: string; namespace: string };
 
-export const createSecret = apiFactory({
+export const createSecret = apiFactory<SecretFormCreateEditSchemaType>({
   url: ({ baseUrl, namespace }: CreateSecretParams) =>
     `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/secrets`,
   method: "POST",

--- a/ui/src/api/secrets/mutate/update.ts
+++ b/ui/src/api/secrets/mutate/update.ts
@@ -14,7 +14,9 @@ import { useTranslation } from "react-i18next";
 
 type UpdateSecretParams = { baseUrl?: string; namespace: string; name: string };
 
-export const updateSecret = apiFactory({
+export const updateSecret = apiFactory<
+  Omit<SecretFormCreateEditSchemaType, "name">
+>({
   url: ({ baseUrl, namespace, name }: UpdateSecretParams) =>
     `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/secrets/${name}`,
   method: "PATCH",

--- a/ui/src/api/tree/mutate/runWorkflow.ts
+++ b/ui/src/api/tree/mutate/runWorkflow.ts
@@ -6,7 +6,7 @@ import { useApiKey } from "~/util/store/apiKey";
 import useMutationWithPermissions from "~/api/useMutationWithPermissions";
 import { useNamespace } from "~/util/store/namespace";
 
-export const runWorkflow = apiFactory({
+export const runWorkflow = apiFactory<string>({
   url: ({
     baseUrl,
     namespace,

--- a/ui/src/api/variables/mutate/create.ts
+++ b/ui/src/api/variables/mutate/create.ts
@@ -13,7 +13,7 @@ import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 import { varKeys } from "..";
 
-export const createVar = apiFactory({
+export const createVar = apiFactory<VarFormCreateEditSchemaType>({
   url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/variables`,
   method: "POST",

--- a/ui/src/api/variables/mutate/create.ts
+++ b/ui/src/api/variables/mutate/create.ts
@@ -13,7 +13,7 @@ import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 import { varKeys } from "..";
 
-export const createVar = apiFactory<VarFormCreateEditSchemaType>({
+export const createVar = apiFactory({
   url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>
     `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/variables`,
   method: "POST",

--- a/ui/src/api/variables/mutate/update.ts
+++ b/ui/src/api/variables/mutate/update.ts
@@ -12,7 +12,7 @@ import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 import { varKeys } from "..";
 
-const updateVar = apiFactory({
+const updateVar = apiFactory<VarFormCreateEditSchemaType>({
   url: ({
     baseUrl,
     namespace,


### PR DESCRIPTION
## Description

The current result of a `apiFactory` will type the payload parameter as `unknown`. It would be nice if we could optionally use a generic to add stronger typing to the payload. I know we had a better payload typing at some point, but it came with the downside of us having to pass at `payload:undefined` and we decided to remove that. 

I figured out a solution that lets us optionally type the payload with a generic, without making the payload a mandatory parameter.

I added types to all payloads already.

I added one TODO comment to `ui/src/api/events/mutate/sendEvent.ts`. It seems that the payload might be wrong in the test, or at least it is different from our app usage (this is a good validation on why strong payload typing is very useful 😃). Since the API will be changed in the next cycle, I decided to not look into that right now. 

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
