### PR TITLE
[DIR-1447] Migrates the linting api to the v2 api, and renames it to notifications.

### DIFF
--- a/.github/workflows/k3s-e2e-tests.yml
+++ b/.github/workflows/k3s-e2e-tests.yml
@@ -69,6 +69,7 @@ jobs:
             "logparser/",
             "mirror/",
             "namespaces/",
+            "notifications/",
             "registry/",
             "secrets/",
             "services/",

--- a/openapi/src/openapi.yaml
+++ b/openapi/src/openapi.yaml
@@ -102,6 +102,8 @@ tags:
     description: Endpoints reading and changing filesystem tree nodes
   - name: plattformlogs
     description: Endpoints to access logs that are exposed by the components
+  - name: notifications
+    description: Endpoints for managing notifications
 x-tagGroups:
   - name: Endpoints
     tags:

--- a/openapi/src/paths/notifications.yaml
+++ b/openapi/src/paths/notifications.yaml
@@ -1,0 +1,30 @@
+
+/api/v2/namespaces/{namespace}/notifications:
+  get:
+    tags:
+      - notifications
+    summary: Gets all notifications in a namespace
+    parameters:
+      - $ref: '../parameters.yaml#/namespace'
+    responses:
+      "200":
+        description: list of notifications
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      issue:
+                        type: string
+                        description: dynamic string for humans to read
+                      level:
+                        type: string
+                        description: enum of the notification severity level (currently only 'warning' exists)
+                      type:
+                        type: string
+                        description: one of many fixed values that can be used as by tools to categorize the notification

--- a/pkg/refactor/api/api.go
+++ b/pkg/refactor/api/api.go
@@ -54,6 +54,9 @@ func Initialize(app core.App, db *database.SQLStore, bus *pubsub2.Bus, instanceM
 		db:      db,
 		manager: instanceManager,
 	}
+	notificationsCtr := &notificationsController{
+		db: db,
+	}
 
 	mw := &appMiddlewares{dStore: db.DataStore()}
 
@@ -124,6 +127,9 @@ func Initialize(app core.App, db *database.SQLStore, bus *pubsub2.Bus, instanceM
 			})
 			r.Route("/namespaces/{namespace}/logs", func(r chi.Router) {
 				logCtr.mountRouter(r)
+			})
+			r.Route("/namespaces/{namespace}/notifications", func(r chi.Router) {
+				notificationsCtr.mountRouter(r)
 			})
 			r.Get("/namespaces/{namespace}/gateway/consumers", func(w http.ResponseWriter, r *http.Request) {
 				data, err := app.GatewayManager.GetConsumers(chi.URLParam(r, "namespace"))

--- a/pkg/refactor/api/notifications.go
+++ b/pkg/refactor/api/notifications.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/direktiv/direktiv/pkg/refactor/database"
+	"github.com/direktiv/direktiv/pkg/refactor/datastore"
+	"github.com/go-chi/chi/v5"
+)
+
+// NOTE: We can potentially build a real notifications system if that seems useful.
+// For now, this is just a port of the v1 linting API. The UI guys requested that I rename it to notifications.
+
+type notificationsController struct {
+	db *database.SQLStore
+}
+
+func (c *notificationsController) mountRouter(r chi.Router) {
+	r.Get("/", c.list)
+}
+
+type apiNotification struct {
+	Type  string `json:"type"`
+	Issue string `json:"issue"`
+	Level string `json:"level"`
+}
+
+func (c *notificationsController) list(w http.ResponseWriter, r *http.Request) {
+	ns := extractContextNamespace(r)
+
+	notifications := make([]*apiNotification, 0)
+
+	ctx := r.Context()
+
+	db, err := c.db.BeginTx(ctx)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	defer db.Rollback()
+
+	secretIssues, err := c.lintSecrets(ctx, db, ns)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	if len(secretIssues) > 0 {
+		notifications = append(notifications, secretIssues...)
+	}
+
+	writeJSON(w, notifications)
+}
+
+func (c *notificationsController) lintSecrets(ctx context.Context, tx *database.SQLStore, ns *datastore.Namespace) ([]*apiNotification, error) {
+	secrets, err := tx.DataStore().Secrets().GetAll(ctx, ns.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	issues := make([]*apiNotification, 0)
+	keys := []string{}
+
+	for _, secret := range secrets {
+		if secret.Data == nil {
+			keys = append(keys, secret.Name)
+		}
+	}
+
+	if len(keys) == 0 {
+		return nil, err
+	}
+
+	issues = append(issues, &apiNotification{
+		Level: "warning",
+		Type:  "uninitialized_secrets",
+		Issue: fmt.Sprintf(`secrets have not been initialized: %v`, keys),
+	})
+
+	return issues, nil
+}

--- a/tests/notifications/uninitialized_secrets.test.js
+++ b/tests/notifications/uninitialized_secrets.test.js
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, it } from '@jest/globals'
+import { basename } from 'path'
+
+import config from '../common/config'
+import helpers from '../common/helpers'
+import regex from '../common/regex'
+import request from '../common/request'
+
+const namespace = basename(__filename)
+
+describe('Test uninitialized secrets notifications', () => {
+	beforeAll(helpers.deleteAllNamespaces)
+
+	helpers.itShouldCreateNamespace(it, expect, namespace)
+
+    it(`should read no notifications`, async () => {
+        const res = await request(config.getDirektivHost())
+			.get(`/api/v2/namespaces/${ namespace }/notifications`)
+		expect(res.statusCode).toEqual(200)
+        expect(res.body).toEqual({
+            data: [],
+        })
+    })
+
+    helpers.itShouldCreateFileV2(it, expect, namespace,
+		'/',
+		'foo1',
+		'workflow',
+		'text/plain',
+		btoa(`
+direktiv_api: workflow/v1
+functions:
+- type: subflow
+  id: myfunc
+  workflow: subflow.yaml
+states:
+- id: a
+  type: action
+  action:
+    function: myfunc
+    input: 'jq(.x)'
+    secrets: ["a", "b"]
+`))
+
+    it(`should read one notification`, async () => {
+        await helpers.sleep(500)
+
+        const res = await request(config.getDirektivHost())
+            .get(`/api/v2/namespaces/${ namespace }/notifications`)
+        expect(res.statusCode).toEqual(200)
+        expect(res.body).toEqual({
+            data: [{
+                issue: "secrets have not been initialized: [a b]",
+                level: "warning",
+                type: "uninitialized_secrets",
+            }],
+        })
+    })   
+})


### PR DESCRIPTION
## Description

Migrates the linting api to the v2 api. Also renames it to notifications, recategorizes the secret issue as a warning, and merges all secret issues into a single notification (all at the request of the UI team).

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
