### PR TITLE
[DIR-1456] Add n segment to ui paths to avoid conflicts with api paths

### DIFF
--- a/ui/e2e/events/history.spec.ts
+++ b/ui/e2e/events/history.spec.ts
@@ -17,7 +17,7 @@ test.afterEach(async () => {
 test("it is possible to navigate to the events page and between the sub pages", async ({
   page,
 }) => {
-  await page.goto(`/${namespace}`);
+  await page.goto(`/n/${namespace}`);
 
   await expect(
     page.getByTestId("breadcrumb-namespace"),
@@ -29,7 +29,7 @@ test("it is possible to navigate to the events page and between the sub pages", 
   await expect(
     page,
     "it is possible to navigate to events/history via the main navigation menu"
-  ).toHaveURL(`/${namespace}/events/history`);
+  ).toHaveURL(`/n/${namespace}/events/history`);
 
   await expect(
     page.getByTestId("breadcrumb-event-history"),
@@ -41,7 +41,7 @@ test("it is possible to navigate to the events page and between the sub pages", 
   await expect(
     page,
     "it is possible to navigate to events/listeners via the tab menu"
-  ).toHaveURL(`/${namespace}/events/listeners`);
+  ).toHaveURL(`/n/${namespace}/events/listeners`);
 
   await expect(
     page.getByTestId("breadcrumb-event-listeners"),
@@ -53,7 +53,7 @@ test("it is possible to navigate to the events page and between the sub pages", 
   await expect(
     page,
     "it is possible to navigate to events/history via the tab menu"
-  ).toHaveURL(`/${namespace}/events/history`);
+  ).toHaveURL(`/n/${namespace}/events/history`);
 
   await expect(
     page.getByTestId("breadcrumb-event-history"),
@@ -62,10 +62,10 @@ test("it is possible to navigate to the events page and between the sub pages", 
 });
 
 test("it is possible to send a new event", async ({ page }) => {
-  await page.goto(`/${namespace}/events/history`);
+  await page.goto(`/n/${namespace}/events/history`);
 
   await expect(page, "it is possible to visit events/history ").toHaveURL(
-    `/${namespace}/events/history`
+    `/n/${namespace}/events/history`
   );
 
   await expect(
@@ -91,10 +91,10 @@ test("it renders, filters, and paginates events", async ({ page }) => {
    * Visit the page, test pagination.
    */
 
-  await page.goto(`/${namespace}/events/history`);
+  await page.goto(`/n/${namespace}/events/history`);
 
   await expect(page, "it is possible to visit events/history").toHaveURL(
-    `/${namespace}/events/history`
+    `/n/${namespace}/events/history`
   );
 
   await expect(page.getByTestId("pagination-btn-page-1")).toBeVisible();

--- a/ui/e2e/events/listeners.spec.ts
+++ b/ui/e2e/events/listeners.spec.ts
@@ -45,10 +45,10 @@ test("it renders event listeners", async ({ page }) => {
   await Promise.all(workflowNames.map((name) => createListener(name)));
 
   /* visit page and assert a list of listeners is rendered */
-  await page.goto(`/${namespace}/events/listeners`);
+  await page.goto(`/n/${namespace}/events/listeners`);
 
   await expect(page, "it is possible to visit events/listeners ").toHaveURL(
-    `/${namespace}/events/listeners`
+    `/n/${namespace}/events/listeners`
   );
 
   await expect(
@@ -90,7 +90,7 @@ test("it renders event listeners", async ({ page }) => {
   await expect(
     page,
     "when clicking on the workflow name, it navigates to the workflow page"
-  ).toHaveURL(`${namespace}/explorer/workflow/edit/${workflowNames[2]}`);
+  ).toHaveURL(`/n/${namespace}/explorer/workflow/edit/${workflowNames[2]}`);
 });
 
 test("it paginates event listeners", async ({ page }) => {
@@ -103,10 +103,10 @@ test("it paginates event listeners", async ({ page }) => {
   await Promise.all(workflowNames.map((name) => createListener(name)));
 
   /* visit page and assert a list of listeners is rendered */
-  await page.goto(`/${namespace}/events/listeners`);
+  await page.goto(`/n/${namespace}/events/listeners`);
 
   await expect(page, "it is possible to visit events/listeners ").toHaveURL(
-    `/${namespace}/events/listeners`
+    `/n/${namespace}/events/listeners`
   );
 
   await expect(

--- a/ui/e2e/explorer/consumer/index.spec.ts
+++ b/ui/e2e/explorer/consumer/index.spec.ts
@@ -30,7 +30,9 @@ test("it is possible to create a consumer", async ({ page }) => {
   });
 
   /* visit page */
-  await page.goto(`/${namespace}/explorer/tree`, { waitUntil: "networkidle" });
+  await page.goto(`/n/${namespace}/explorer/tree`, {
+    waitUntil: "networkidle",
+  });
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it navigates to the test namespace in the explorer"
@@ -48,7 +50,7 @@ test("it is possible to create a consumer", async ({ page }) => {
   await expect(
     page,
     "it creates the service and opens the file in the explorer"
-  ).toHaveURL(`/${namespace}/explorer/consumer/${filename}`);
+  ).toHaveURL(`/n/${namespace}/explorer/consumer/${filename}`);
 
   /* fill in form */
   await page.getByLabel("Username").fill("my-username");

--- a/ui/e2e/explorer/index.spec.ts
+++ b/ui/e2e/explorer/index.spec.ts
@@ -42,7 +42,7 @@ test("it is possible to navigate to a namespace via breadcrumbs", async ({
     .click();
 
   await expect(page, "the namespace is reflected in the url").toHaveURL(
-    `/${namespace}/explorer/tree`
+    `/n/${namespace}/explorer/tree`
   );
   await expect(
     page.getByTestId("breadcrumb-namespace"),
@@ -52,7 +52,7 @@ test("it is possible to navigate to a namespace via breadcrumbs", async ({
 
 test("it is possible to navigate to a namespace via URL", async ({ page }) => {
   // visit url
-  await page.goto(`/${namespace}/explorer/tree`);
+  await page.goto(`/n/${namespace}/explorer/tree`);
 
   // make sure breadcrumb and url are correct after loading
   await expect(
@@ -60,7 +60,7 @@ test("it is possible to navigate to a namespace via URL", async ({ page }) => {
     "the namespace is reflected in the breadcrumbs"
   ).toHaveText(namespace);
   await expect(page, "the namespace is reflected in the url").toHaveURL(
-    `/${namespace}/explorer/tree`
+    `/n/${namespace}/explorer/tree`
   );
 });
 
@@ -68,7 +68,7 @@ test("it is possible to create a namespace via breadcrumbs", async ({
   page,
 }) => {
   // visit page and make sure explorer is loaded
-  await page.goto(`/${namespace}/explorer/tree`);
+  await page.goto(`/n/${namespace}/explorer/tree`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "a testing namespace is loaded in the explorer"
@@ -83,7 +83,7 @@ test("it is possible to create a namespace via breadcrumbs", async ({
 
   // make sure it has navigated to new namespace
   await expect(page, "it redirects to the new namespace's url").toHaveURL(
-    `/${newNamespace}/explorer/tree`
+    `/n/${newNamespace}/explorer/tree`
   );
 
   await expect(
@@ -101,7 +101,7 @@ test("it is possible to create a namespace via breadcrumbs", async ({
 
 test("it is possible to create a folder", async ({ page }) => {
   // visit page and make sure explorer is loaded
-  await page.goto(`/${namespace}/explorer/tree`);
+  await page.goto(`/n/${namespace}/explorer/tree`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "a testing namespace is loaded in the explorer"
@@ -122,14 +122,14 @@ test("it is possible to create a folder", async ({ page }) => {
   await expect(
     page,
     "it creates a new folder and navigates to it automatically"
-  ).toHaveURL(`/${namespace}/explorer/tree/${folderName}`);
+  ).toHaveURL(`/n/${namespace}/explorer/tree/${folderName}`);
 
   // navigate back to tree root
   await page.getByTestId("tree-root").click();
   await expect(
     page,
     "when clicking the tree icon, it navigates back to the tree root"
-  ).toHaveURL(`/${namespace}/explorer/tree`);
+  ).toHaveURL(`/n/${namespace}/explorer/tree`);
 
   await expect(
     page.getByTestId(`explorer-item-${folderName}`),
@@ -141,14 +141,14 @@ test("it is possible to create a folder", async ({ page }) => {
   await expect(
     page,
     "when clicking on the folder, it navigates to it"
-  ).toHaveURL(`/${namespace}/explorer/tree/${folderName}`);
+  ).toHaveURL(`/n/${namespace}/explorer/tree/${folderName}`);
 
   // navigate back by clicking on .. "folder"
   await page.getByRole("link", { name: ".." }).click();
   await expect(
     page,
     "when clicking .. it navigates back to the tree root"
-  ).toHaveURL(`/${namespace}/explorer/tree`);
+  ).toHaveURL(`/n/${namespace}/explorer/tree`);
 
   await expect(
     page.getByTestId(`explorer-item-${folderName}`),
@@ -157,7 +157,7 @@ test("it is possible to create a folder", async ({ page }) => {
 });
 
 test("it is possible to create a workflow", async ({ page }) => {
-  await page.goto(`/${namespace}/explorer/tree`);
+  await page.goto(`/n/${namespace}/explorer/tree`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "a testing namespace is loaded in the explorer"
@@ -175,7 +175,7 @@ test("it is possible to create a workflow", async ({ page }) => {
   await expect(
     page,
     "it creates the workflow and loads the edit page"
-  ).toHaveURL(`${namespace}/explorer/workflow/edit/${filename}`);
+  ).toHaveURL(`/n/${namespace}/explorer/workflow/edit/${filename}`);
 
   await expect(
     page.getByTestId("breadcrumb-namespace"),
@@ -211,7 +211,7 @@ test("it is possible to create a workflow", async ({ page }) => {
     await expect(
       page,
       "when clicking the namespace breadcrumb it navigates to tree root"
-    ).toHaveURL(`/${namespace}/explorer/tree`);
+    ).toHaveURL(`/n/${namespace}/explorer/tree`);
 
   await expect(
     page.getByTestId(`explorer-item-${filename}`),
@@ -222,7 +222,7 @@ test("it is possible to create a workflow", async ({ page }) => {
 test("it is possible to create a workflow without providing the .yaml file extension", async ({
   page,
 }) => {
-  await page.goto(`/${namespace}/explorer/tree`);
+  await page.goto(`/n/${namespace}/explorer/tree`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "a testing namespace is loaded in the explorer"
@@ -241,7 +241,7 @@ test("it is possible to create a workflow without providing the .yaml file exten
     page,
     "it creates the workflow and loads the edit page"
   ).toHaveURL(
-    `${namespace}/explorer/workflow/edit/${filenameWithoutExtension}.yaml`
+    `/n/${namespace}/explorer/workflow/edit/${filenameWithoutExtension}.yaml`
   );
 
   await expect(
@@ -273,7 +273,7 @@ test("when creating a workflow, the name (before extension) may be the same as a
   await createDirectory({ namespace, name: directoryName });
 
   // go to tree root
-  await page.goto(`/${namespace}/explorer/tree`);
+  await page.goto(`/n/${namespace}/explorer/tree`);
 
   // create workflow
   await page.getByTestId("dropdown-trg-new").click();
@@ -285,7 +285,7 @@ test("when creating a workflow, the name (before extension) may be the same as a
   await expect(
     page,
     "it creates the workflow and loads the edit page"
-  ).toHaveURL(`${namespace}/explorer/workflow/edit/${directoryName}.yaml`);
+  ).toHaveURL(`/n/${namespace}/explorer/workflow/edit/${directoryName}.yaml`);
 
   await expect(
     page.getByTestId("workflow-header"),
@@ -306,7 +306,7 @@ test("it is not possible to create a workflow when the name already exixts", asy
   await createWorkflow(namespace, alreadyExists);
 
   // go to tree root
-  await page.goto(`/${namespace}/explorer/tree`);
+  await page.goto(`/n/${namespace}/explorer/tree`);
 
   // create workflow
   await page.getByTestId("dropdown-trg-new").click();
@@ -327,7 +327,7 @@ test("it is not possible to create a workflow when the name already exists and t
   await createWorkflow(namespace, alreadyExists);
 
   // go to tree root
-  await page.goto(`/${namespace}/explorer/tree`);
+  await page.goto(`/n/${namespace}/explorer/tree`);
 
   // create workflow
   await page.getByTestId("dropdown-trg-new").click();
@@ -344,7 +344,7 @@ test(`it is possible to delete a worfklow`, async ({ page }) => {
   const name = "workflow.yaml";
   await createWorkflow(namespace, name);
 
-  await page.goto(`/${namespace}/explorer/tree/`);
+  await page.goto(`/n/${namespace}/explorer/tree/`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it renders the breadcrumb for a namespace"
@@ -386,7 +386,7 @@ test(`it is possible to rename a workflow`, async ({ page }) => {
   const newName = "new-name.yaml";
   await createWorkflow(namespace, oldName);
 
-  await page.goto(`/${namespace}/explorer/tree/`);
+  await page.goto(`/n/${namespace}/explorer/tree/`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it renders the breadcrumb for a namespace"
@@ -434,7 +434,7 @@ test(`when renaming a workflow, the name (before extension) may be the same as a
   await createDirectory({ namespace, name: directoryName });
   await createWorkflow(namespace, oldName);
 
-  await page.goto(`/${namespace}/explorer/tree/`);
+  await page.goto(`/n/${namespace}/explorer/tree/`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it renders the breadcrumb for a namespace"
@@ -481,7 +481,7 @@ test(`it will automatically add a yaml extension when renaming a workflow`, asyn
   const newNameWithYamlExtension = `${newNameWithoutYamlExtension}.yaml`;
   await createWorkflow(namespace, oldName);
 
-  await page.goto(`/${namespace}/explorer/tree/`);
+  await page.goto(`/n/${namespace}/explorer/tree/`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it renders the breadcrumb for a namespace"
@@ -531,7 +531,7 @@ test(`it is not possible to rename a workflow when the name already exists`, asy
   await createWorkflow(namespace, tobeRenamed);
   await createWorkflow(namespace, alreadyExists);
 
-  await page.goto(`/${namespace}/explorer/tree/`);
+  await page.goto(`/n/${namespace}/explorer/tree/`);
 
   await page
     .getByTestId(`explorer-item-${tobeRenamed}`)
@@ -555,7 +555,7 @@ test(`it is not possible to rename a workflow when the name already exists and e
   await createWorkflow(namespace, tobeRenamed);
   await createWorkflow(namespace, alreadyExists);
 
-  await page.goto(`/${namespace}/explorer/tree/`);
+  await page.goto(`/n/${namespace}/explorer/tree/`);
 
   await page
     .getByTestId(`explorer-item-${tobeRenamed}`)
@@ -576,7 +576,7 @@ test(`it is possible to delete a directory`, async ({ page }) => {
   const name = "directory";
   await createDirectory({ namespace, name });
 
-  await page.goto(`/${namespace}/explorer/tree/`);
+  await page.goto(`/n/${namespace}/explorer/tree/`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it renders the breadcrumb for a namespace"
@@ -618,7 +618,7 @@ test(`it is possible to rename a directory`, async ({ page }) => {
   const newName = "new-name";
   await createDirectory({ namespace, name: oldName });
 
-  await page.goto(`/${namespace}/explorer/tree/`);
+  await page.goto(`/n/${namespace}/explorer/tree/`);
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it renders the breadcrumb for a namespace"
@@ -661,7 +661,7 @@ test("it is not possible to navigate to a workflow that does not exist", async (
   page,
 }) => {
   await page.goto(
-    `${namespace}/explorer/workflow/edit/this-file-does-not-exists.yaml`
+    `/n/${namespace}/explorer/workflow/edit/this-file-does-not-exists.yaml`
   );
 
   await expect(page.getByTestId("error-title")).toContainText("404");
@@ -678,7 +678,7 @@ test("it is not possible to navigate to a workflow that does not exist", async (
 test("it is not possible to navigate to a folder that does not exist", async ({
   page,
 }) => {
-  await page.goto(`${namespace}/explorer/tree/this-folder-does-not-exist`);
+  await page.goto(`/n/${namespace}/explorer/tree/this-folder-does-not-exist`);
 
   await expect(page.getByTestId("error-title")).toContainText("404");
   await expect(page.getByTestId("error-message")).toContainText(
@@ -694,7 +694,7 @@ test("it is not possible to navigate to a folder that does not exist", async ({
 test("it is not possible to navigate to a namespace that does not exist", async ({
   page,
 }) => {
-  await page.goto(`this-namespace-does-not-exist/explorer/tree`);
+  await page.goto(`/n/this-namespace-does-not-exist/explorer/tree`);
 
   await expect(page.getByTestId("error-title")).toContainText("404");
   await expect(page.getByTestId("error-message")).toContainText(

--- a/ui/e2e/explorer/route/index.spec.ts
+++ b/ui/e2e/explorer/route/index.spec.ts
@@ -32,7 +32,9 @@ test("it is possible to create a basic route file", async ({ page }) => {
   });
 
   /* visit page */
-  await page.goto(`/${namespace}/explorer/tree`, { waitUntil: "networkidle" });
+  await page.goto(`/n/${namespace}/explorer/tree`, {
+    waitUntil: "networkidle",
+  });
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it navigates to the test namespace in the explorer"
@@ -56,7 +58,7 @@ test("it is possible to create a basic route file", async ({ page }) => {
   await expect(
     page,
     "it creates the route file and opens it in the explorer"
-  ).toHaveURL(`/${namespace}/explorer/endpoint/${filename}`);
+  ).toHaveURL(`/n/${namespace}/explorer/endpoint/${filename}`);
 
   /* fill out form */
   await page.getByLabel("path").fill("path");
@@ -105,7 +107,7 @@ test("it is possible to create a basic route file", async ({ page }) => {
   await expect(
     page,
     "when the open logs link is clicked, page should navigate to the route detail page"
-  ).toHaveURL(`/${namespace}/gateway/routes/${filename}`);
+  ).toHaveURL(`/n/${namespace}/gateway/routes/${filename}`);
 });
 
 test("it is possible to add plugins to a route file", async ({ page }) => {
@@ -139,7 +141,7 @@ test("it is possible to add plugins to a route file", async ({ page }) => {
     yaml: initialRouteYaml,
   });
 
-  await page.goto(`/${namespace}/explorer/endpoint/${filename}`, {
+  await page.goto(`/n/${namespace}/explorer/endpoint/${filename}`, {
     waitUntil: "networkidle",
   });
 

--- a/ui/e2e/explorer/service/index.spec.ts
+++ b/ui/e2e/explorer/service/index.spec.ts
@@ -53,7 +53,9 @@ test("it is possible to create a service", async ({ page }) => {
   const expectedYaml = createServiceYaml(service);
 
   /* visit page */
-  await page.goto(`/${namespace}/explorer/tree`, { waitUntil: "networkidle" });
+  await page.goto(`/n/${namespace}/explorer/tree`, {
+    waitUntil: "networkidle",
+  });
   await expect(
     page.getByTestId("breadcrumb-namespace"),
     "it navigates to the test namespace in the explorer"
@@ -70,7 +72,7 @@ test("it is possible to create a service", async ({ page }) => {
   await expect(
     page,
     "it creates the service and opens the file in the explorer"
-  ).toHaveURL(`/${namespace}/explorer/service/${service.name}`);
+  ).toHaveURL(`/n/${namespace}/explorer/service/${service.name}`);
 
   /* fill in form */
   await page.getByLabel("Image").fill("bash");
@@ -193,7 +195,7 @@ test("it is possible to edit patches", async ({ page }) => {
   await createService(namespace, service);
 
   /* visit page, assert content rendered */
-  await page.goto(`/${namespace}/explorer/service/${service.name}`);
+  await page.goto(`/n/${namespace}/explorer/service/${service.name}`);
 
   await Promise.all(
     patches.map(async (item, index) => {
@@ -340,7 +342,7 @@ test("it is possible to edit environment variables", async ({ page }) => {
   await createService(namespace, service);
 
   /* visit page, assert content rendered */
-  await page.goto(`/${namespace}/explorer/service/${service.name}`);
+  await page.goto(`/n/${namespace}/explorer/service/${service.name}`);
 
   await Promise.all(
     envs.map(async (item, index) => {

--- a/ui/e2e/explorer/workflow/codeEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/codeEditor.spec.ts
@@ -38,7 +38,7 @@ test("it is possible to navigate to the code editor ", async ({ page }) => {
     .click();
 
   await expect(page, "the namespace is reflected in the url").toHaveURL(
-    `/${namespace}/explorer/tree`
+    `/n/${namespace}/explorer/tree`
   );
 
   await expect(
@@ -54,12 +54,12 @@ test("it is possible to navigate to the code editor ", async ({ page }) => {
   ).toBeVisible();
 
   await expect(page, "the workflow is reflected in the url").toHaveURL(
-    `${namespace}/explorer/workflow/edit/${workflow}`
+    `/n/${namespace}/explorer/workflow/edit/${workflow}`
   );
 });
 
 test("it is possible to save the workflow", async ({ page }) => {
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
 
   const editorElement = page.getByText(defaultDescription);
   await editorElement.click();
@@ -106,7 +106,7 @@ test("it is possible to save the workflow", async ({ page }) => {
 test("it renders response errors when saving an invalid workflow", async ({
   page,
 }) => {
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
 
   const editor = page.locator(".lines-content");
 
@@ -145,14 +145,14 @@ test("it is possible to navigate to another route from the editor", async ({
     return dialog.dismiss();
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
   await page.getByText(defaultDescription);
 
   await page.getByRole("link", { name: "Settings" }).click();
   await expect(dialogTriggered).toBe(false);
 
   await expect(page, "it navigates to the new route").toHaveURL(
-    `${namespace}/settings`
+    `/n/${namespace}/settings`
   );
 });
 
@@ -169,7 +169,7 @@ test("it prevents navigation to another route with unsaved changes", async ({
     return dialog.dismiss();
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
   await page.getByText(defaultDescription).click();
 
   const dirtyText = faker.random.alphaNumeric(9);
@@ -181,7 +181,7 @@ test("it prevents navigation to another route with unsaved changes", async ({
   await expect(
     page,
     "after dismissing the dialog, it stays on the same route"
-  ).toHaveURL(`${namespace}/explorer/workflow/edit/${workflow}`);
+  ).toHaveURL(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
 
   await expect(
     page.getByText(dirtyText),
@@ -202,7 +202,7 @@ test("with confirmation, it navigates to another route despite unsaved changes",
     return dialog.accept();
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
   await page.getByText(defaultDescription).click();
 
   const dirtyText = faker.random.alphaNumeric(9);
@@ -214,7 +214,7 @@ test("with confirmation, it navigates to another route despite unsaved changes",
   await expect(
     page,
     "after confirming the dialog, it navigates to the new route"
-  ).toHaveURL(`${namespace}/settings`);
+  ).toHaveURL(`/n/${namespace}/settings`);
 });
 
 test("it is possible to leave the app from the editor", async ({ page }) => {
@@ -226,7 +226,7 @@ test("it is possible to leave the app from the editor", async ({ page }) => {
     await dialog.dismiss();
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
   await page.getByText(defaultDescription);
 
   await page.goto("/api/v2/status");
@@ -249,7 +249,7 @@ test("it prevents navigation away from the app with unsaved changes", async ({
     await dialog.dismiss();
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
   await page.getByText(defaultDescription).click();
 
   const dirtyText = faker.random.alphaNumeric(9);
@@ -266,7 +266,7 @@ test("it prevents navigation away from the app with unsaved changes", async ({
   await expect(
     page,
     "after dismissing the dialog, it stays on the same route"
-  ).toHaveURL(`${namespace}/explorer/workflow/edit/${workflow}`);
+  ).toHaveURL(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
 
   await expect(
     page.getByText(dirtyText),
@@ -285,7 +285,7 @@ test("with confirmation, it allows navigation away from the app with unsaved cha
     await dialog.accept();
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
   await page.getByText(defaultDescription).click();
 
   const dirtyText = faker.random.alphaNumeric(9);

--- a/ui/e2e/explorer/workflow/diagramEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/diagramEditor.spec.ts
@@ -45,7 +45,7 @@ test.afterEach(async () => {
 test("it is possible to switch between Code View, Diagram View, Split Vertically and Split Horizontally", async ({
   page,
 }) => {
-  await page.goto(`/${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
 
   const { editor, diagram, codeBtn, diagramBtn, splitVertBtn, splitHorBtn } =
     await getCommonPageElements(page);
@@ -98,7 +98,7 @@ test("it is possible to switch between Code View, Diagram View, Split Vertically
 test("it will change the direction of the diagram, when the layout is set to Split Vertically", async ({
   page,
 }) => {
-  await page.goto(`/${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
   const startNode = page.getByTestId("rf__node-startNode");
   const endNode = page.getByTestId("rf__node-endNode");
 
@@ -153,7 +153,7 @@ test("it will change the direction of the diagram, when the layout is set to Spl
 test("it will persist the preferred layout selection in local storage", async ({
   page,
 }) => {
-  await page.goto(`/${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
   const { editor, diagram, codeBtn, diagramBtn, splitVertBtn, splitHorBtn } =
     await getCommonPageElements(page);
 
@@ -192,7 +192,7 @@ test("it will update the diagram when the workflow is saved", async ({
    * networkidle is required to avoid flaky tests. The monaco
    * editor needs to be full loaded before we interact with it.
    */
-  await page.goto(`/${namespace}/explorer/workflow/edit/${workflow}`, {
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`, {
     waitUntil: "networkidle",
   });
   const { editor, diagram, splitVertBtn } = await getCommonPageElements(page);
@@ -255,7 +255,7 @@ test("it will update the diagram when the workflow is saved", async ({
 test("it is possible to switch from Code View to Diagram View without loosing the recent changes", async ({
   page,
 }) => {
-  await page.goto(`/${namespace}/explorer/workflow/edit/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflow}`);
 
   const { codeBtn, diagramBtn } = await getCommonPageElements(page);
 

--- a/ui/e2e/explorer/workflow/run.spec.ts
+++ b/ui/e2e/explorer/workflow/run.spec.ts
@@ -36,7 +36,7 @@ test("it is possible to open and use the run workflow modal from the editor and 
     yaml: basicWorkflow.data,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   // open modal via editor button
   await page.getByTestId("workflow-editor-btn-run").click();
@@ -104,7 +104,7 @@ test("it is possible to run the workflow by setting an input JSON via the editor
     yaml: basicWorkflow.data,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   await page.getByTestId("workflow-editor-btn-run").click();
   expect(
@@ -138,7 +138,7 @@ test("it is possible to run the workflow by setting an input JSON via the editor
   // submit to run the workflow
   await page.getByTestId("run-workflow-submit-btn").click();
 
-  const reg = new RegExp(`${namespace}/instances/(.*)`);
+  const reg = new RegExp(`/n/${namespace}/instances/(.*)`);
   await expect(
     page,
     "workflow was triggered with our input and user was redirected to the instances page"
@@ -179,7 +179,7 @@ test("it is possible to run a workflow with input data containing special charac
     yaml: testDiacriticsWorkflow,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${name}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${name}`);
 
   await expect(
     page.locator(".view-lines"),
@@ -212,7 +212,7 @@ test("it is not possible to run the workflow when the editor has unsaved changes
     yaml: basicWorkflow.data,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   await expect(page.getByTestId("workflow-header-btn-run")).not.toBeDisabled();
   await expect(page.getByTestId("workflow-editor-btn-run")).not.toBeDisabled();
@@ -245,7 +245,7 @@ test("it is possible to provide the input via generated form", async ({
     yaml: jsonSchemaFormWorkflow,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   await page.getByTestId("workflow-editor-btn-run").click();
   expect(
@@ -319,7 +319,7 @@ test("it is possible to provide the input via generated form", async ({
   await page.getByLabel("Last Name").fill("McFly");
   await page.getByTestId("run-workflow-submit-btn").click();
 
-  const reg = new RegExp(`${namespace}/instances/(.*)`);
+  const reg = new RegExp(`/n/${namespace}/instances/(.*)`);
   await expect(
     page,
     "workflow was triggered with our input and user was redirected to the instances page"
@@ -363,7 +363,7 @@ test("it is possible to provide the input via generated form and resolve form er
     yaml: jsonSchemaWithRequiredEnum,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   await page.getByTestId("workflow-editor-btn-run").click();
   expect(
@@ -412,7 +412,7 @@ test("it is possible to provide the input via generated form and resolve form er
   await page.getByRole("option", { name: "guest" }).click();
   await page.getByTestId("run-workflow-submit-btn").click();
 
-  const reg = new RegExp(`${namespace}/instances/(.*)`);
+  const reg = new RegExp(`/n/${namespace}/instances/(.*)`);
   await expect(
     page,
     "workflow was triggered with our input and user was redirected to the instances page"
@@ -453,7 +453,7 @@ test("it is possible to provide the input via Form Input and see the same data i
     yaml: jsonSchemaWithRequiredEnum,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   await page.getByTestId("workflow-editor-btn-run").click();
   expect(
@@ -508,7 +508,7 @@ test("it is possible to provide the input via Form Input and see the same data i
   // run the workflow from the json tab
   await page.getByTestId("run-workflow-submit-btn").click();
 
-  const reg = new RegExp(`${namespace}/instances/(.*)`);
+  const reg = new RegExp(`/n/${namespace}/instances/(.*)`);
   await expect(
     page,
     "workflow was triggered and the user was redirected to the instances page"
@@ -539,7 +539,7 @@ test("it is possible to provide the input via JSON Input and see the same data i
     yaml: jsonSchemaWithRequiredEnum,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   await page.getByTestId("workflow-editor-btn-run").click();
   expect(
@@ -590,7 +590,7 @@ test("it is possible to provide the input via JSON Input and see the same data i
 
   await page.getByTestId("run-workflow-submit-btn").click();
 
-  const reg = new RegExp(`${namespace}/instances/(.*)`);
+  const reg = new RegExp(`/n/${namespace}/instances/(.*)`);
   await expect(
     page,
     "workflow was triggered and user was redirected to the instances page"
@@ -629,7 +629,7 @@ test("the input is synchronized between tabs, but the data that is currently in 
     yaml: jsonSchemaWithRequiredEnum,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   await page.getByTestId("workflow-editor-btn-run").click();
   expect(
@@ -685,7 +685,7 @@ test("the input is synchronized between tabs, but the data that is currently in 
 
   await page.getByTestId("run-workflow-submit-btn").click();
 
-  const reg = new RegExp(`${namespace}/instances/(.*)`);
+  const reg = new RegExp(`/n/${namespace}/instances/(.*)`);
   await expect(
     page,
     "workflow was triggered with our input and user was redirected to the instances page"
@@ -737,7 +737,7 @@ test("switching the window focus will preserve the state of the form", async ({
     yaml: jsonSchemaWithRequiredEnum,
   });
 
-  await page.goto(`${namespace}/explorer/workflow/edit/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
 
   await page.getByTestId("workflow-editor-btn-run").click();
   expect(
@@ -764,7 +764,7 @@ test("switching the window focus will preserve the state of the form", async ({
   // run the workflow
   await page.getByTestId("run-workflow-submit-btn").click();
 
-  const reg = new RegExp(`${namespace}/instances/(.*)`);
+  const reg = new RegExp(`/n/${namespace}/instances/(.*)`);
   await expect(
     page,
     "workflow was triggered with our input and user was redirected to the instances page"

--- a/ui/e2e/explorer/workflow/settings.spec.ts
+++ b/ui/e2e/explorer/workflow/settings.spec.ts
@@ -37,7 +37,7 @@ test("it is possible to navigate to the workflow settings page and use paginatio
 }) => {
   await createWorkflowVariables(namespace, workflow, 15);
 
-  await page.goto(`/${namespace}/explorer/workflow/settings/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflow}`);
   await expect(
     page.getByTestId("variable-row"),
     "there should be 10 variables on the first page"
@@ -65,7 +65,7 @@ test("it is possible to navigate to the workflow settings page and use paginatio
 });
 
 test("it is possible to create a variable", async ({ page }) => {
-  await page.goto(`/${namespace}/explorer/workflow/settings/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflow}`);
 
   const subject = {
     name: "workflow-variable",
@@ -123,7 +123,7 @@ test("it is possible to update variables", async ({ page }) => {
   }
 
   /* visit page and edit variable */
-  await page.goto(`/${namespace}/explorer/workflow/settings/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflow}`);
 
   await page.getByTestId(`dropdown-trg-item-${subject.data.name}`).click();
   await page.getByRole("button", { name: "edit" }).click();
@@ -181,7 +181,7 @@ test("it is possible to delete variables", async ({ page }) => {
   }
 
   /* visit page and delete variable */
-  await page.goto(`/${namespace}/explorer/workflow/settings/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflow}`);
 
   await page.getByTestId(`dropdown-trg-item-${subject.data.name}`).click();
   await page.getByRole("button", { name: "delete" }).click();
@@ -206,7 +206,7 @@ test("it is not possible to create a variable with a name that already exists", 
   const variables = await createWorkflowVariables(namespace, workflow, 4);
   const reservedName = variables[0]?.data.name ?? "";
 
-  await page.goto(`/${namespace}/explorer/workflow/settings/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflow}`);
 
   await page.getByTestId("variable-create").click();
 
@@ -233,7 +233,7 @@ test("it is not possible to set a variables name to a name that already exists",
 
   const reservedName = variables[0]?.data.name ?? "";
 
-  await page.goto(`/${namespace}/explorer/workflow/settings/${workflow}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflow}`);
 
   await page.getByTestId(`dropdown-trg-item-${subject.data.name}`).click();
   await page.getByRole("button", { name: "edit" }).click();
@@ -269,7 +269,7 @@ test("it is possible to rename a variable that doesn't have a mimeType", async (
     headers,
   });
 
-  await page.goto(`/${namespace}/explorer/workflow/settings/${workflowName}`);
+  await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflowName}`);
   await page.getByTestId(`dropdown-trg-item-workflow`).click();
   await page.getByRole("button", { name: "edit" }).click();
 

--- a/ui/e2e/gateway/consumers/index.spec.ts
+++ b/ui/e2e/gateway/consumers/index.spec.ts
@@ -19,7 +19,7 @@ test.afterEach(async () => {
 });
 
 test("Consumer list is empty by default", async ({ page }) => {
-  await page.goto(`/${namespace}/gateway/consumers`, {
+  await page.goto(`/n/${namespace}/gateway/consumers`, {
     waitUntil: "networkidle",
   });
 
@@ -56,7 +56,7 @@ test("Consumer list shows all available consumers", async ({ page }) => {
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/gateway/consumers`, {
+  await page.goto(`/n/${namespace}/gateway/consumers`, {
     waitUntil: "networkidle",
   });
 
@@ -122,7 +122,7 @@ test("Consumer list will update the consumers when refetch button is clicked", a
     }),
   });
 
-  await page.goto(`/${namespace}/gateway/consumers`, {
+  await page.goto(`/n/${namespace}/gateway/consumers`, {
     waitUntil: "networkidle",
   });
 

--- a/ui/e2e/gateway/routes/details/index.spec.ts
+++ b/ui/e2e/gateway/routes/details/index.spec.ts
@@ -47,7 +47,7 @@ test("Route details page shows all important information about the route", async
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/gateway/routes/${fileName}`);
+  await page.goto(`/n/${namespace}/gateway/routes/${fileName}`);
 
   await expect(
     page
@@ -127,7 +127,7 @@ test("Route details page shows all important information about the route", async
   await expect(
     page,
     "when the edit route link is clicked, page should navigate to the route editor page"
-  ).toHaveURL(`/${namespace}/explorer/endpoint/${fileName}`);
+  ).toHaveURL(`/n/${namespace}/explorer/endpoint/${fileName}`);
 });
 
 test("Route details page shows warning if the route was not configured correctly", async ({
@@ -153,7 +153,7 @@ test("Route details page shows warning if the route was not configured correctly
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/gateway/routes/${fileName}`);
+  await page.goto(`/n/${namespace}/gateway/routes/${fileName}`);
 
   await page
     .getByTestId("route-details-header")

--- a/ui/e2e/gateway/routes/list/index.spec.ts
+++ b/ui/e2e/gateway/routes/list/index.spec.ts
@@ -21,7 +21,7 @@ test.afterEach(async () => {
 });
 
 test("Route list is empty by default", async ({ page }) => {
-  await page.goto(`/${namespace}/gateway/routes`, {
+  await page.goto(`/n/${namespace}/gateway/routes`, {
     waitUntil: "networkidle",
   });
 
@@ -60,7 +60,7 @@ test("Route list shows all available routes", async ({ page }) => {
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/gateway/routes`, {
+  await page.goto(`/n/${namespace}/gateway/routes`, {
     waitUntil: "networkidle",
   });
 
@@ -140,7 +140,7 @@ test("Route list shows a warning", async ({ page }) => {
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/gateway/routes`, {
+  await page.goto(`/n/${namespace}/gateway/routes`, {
     waitUntil: "networkidle",
   });
 
@@ -181,7 +181,7 @@ test("Route list shows an error", async ({ page }) => {
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/gateway/routes`, {
+  await page.goto(`/n/${namespace}/gateway/routes`, {
     waitUntil: "networkidle",
   });
 
@@ -217,7 +217,7 @@ test("Route list links the file name to the route file", async ({ page }) => {
     yaml: createRouteFile(),
   });
 
-  await page.goto(`/${namespace}/gateway/routes`, {
+  await page.goto(`/n/${namespace}/gateway/routes`, {
     waitUntil: "networkidle",
   });
 
@@ -229,5 +229,5 @@ test("Route list links the file name to the route file", async ({ page }) => {
   await expect(
     page,
     "after clicking on the file name, the user gets redirected to the file explorer page of the service file"
-  ).toHaveURL(`/${namespace}/explorer/endpoint/my-route.yaml`);
+  ).toHaveURL(`/n/${namespace}/explorer/endpoint/my-route.yaml`);
 });

--- a/ui/e2e/instances/details/index.spec.ts
+++ b/ui/e2e/instances/details/index.spec.ts
@@ -48,7 +48,7 @@ test("the header of the instance page shows the relevant data for the workflow",
       path: simpleWorkflowName,
     })
   ).instance;
-  await page.goto(`/${namespace}/instances/${instanceId}`);
+  await page.goto(`/n/${namespace}/instances/${instanceId}`);
 
   const header = page.getByTestId("instance-header-container");
   await expect(header, "It renders the header").toBeVisible();
@@ -95,7 +95,7 @@ test("the header of the instance page shows the relevant data for the workflow",
   ).toBeDisabled();
 
   await header.getByRole("link", { name: "Open workflow" }).click();
-  const editURL = `${namespace}/explorer/workflow/edit/${simpleWorkflowName}`;
+  const editURL = `/n/${namespace}/explorer/workflow/edit/${simpleWorkflowName}`;
   await expect(
     page,
     "the button 'Open Workflow' is clickable and links to the correct URL"
@@ -111,7 +111,7 @@ test("the diagram panel on the instance page responds to user interaction", asyn
       path: simpleWorkflowName,
     })
   ).instance;
-  await page.goto(`/${namespace}/instances/${instanceId}`);
+  await page.goto(`/n/${namespace}/instances/${instanceId}`);
 
   const diagramPanel = page.getByTestId("rf__wrapper");
   await expect(diagramPanel, "It renders the diagram panel").toBeVisible();
@@ -173,7 +173,7 @@ test("the diagram on the instance page changes appearance dynamically", async ({
       path: delayedWorkflowName,
     })
   ).instance;
-  await page.goto(`/${namespace}/instances/${instanceId}`);
+  await page.goto(`/n/${namespace}/instances/${instanceId}`);
 
   const diagramPanel = page.getByTestId("rf__wrapper");
   await expect(diagramPanel, "It renders the diagram panel").toBeVisible();
@@ -269,7 +269,7 @@ test("the input/output panel responds to user interaction", async ({
       path: simpleWorkflowName,
     })
   ).instance;
-  await page.goto(`/${namespace}/instances/${instanceId}`);
+  await page.goto(`/n/${namespace}/instances/${instanceId}`);
 
   const inputOutputPanel = page.getByTestId("inputOutputPanel");
 
@@ -364,7 +364,7 @@ test("The output is shown when the workflow finished running", async ({
       path: delayedWorkflowName,
     })
   ).instance;
-  await page.goto(`/${namespace}/instances/${instanceId}`);
+  await page.goto(`/n/${namespace}/instances/${instanceId}`);
 
   const inputOutputPanel = page.getByTestId("inputOutputPanel");
 
@@ -408,7 +408,7 @@ test("after a running instance finishes, the output tab is automatically selecte
       path: delayedWorkflowName,
     })
   ).instance;
-  await page.goto(`/${namespace}/instances/${instanceId}`);
+  await page.goto(`/n/${namespace}/instances/${instanceId}`);
 
   const inputOutputPanel = page.getByTestId("inputOutputPanel");
 

--- a/ui/e2e/instances/filter/index.spec.ts
+++ b/ui/e2e/instances/filter/index.spec.ts
@@ -81,7 +81,7 @@ test("it is possible to navigate to the instances list, it renders and paginates
     })
   );
 
-  await page.goto(`${namespace}/`);
+  await page.goto(`/n/${namespace}`);
 
   await page
     .getByRole("navigation")
@@ -125,7 +125,7 @@ test("it is possible to filter by date using created before", async ({
   await createInstance({ namespace, path: failingWorkflowName });
   await createInstance({ namespace, path: failingWorkflowName });
 
-  await page.goto(`${namespace}/instances/`);
+  await page.goto(`/n/${namespace}/instances/`);
 
   /* there should be 2 items initially */
   await expect(
@@ -173,7 +173,7 @@ test("it is possible to filter by date using created before", async ({
 
 test("it is possible to filter by trigger", async ({ page }) => {
   await createTriggerFilterInstances();
-  await page.goto(`${namespace}/instances/`);
+  await page.goto(`/n/${namespace}/instances/`);
 
   /* there should be 3 items initially */
   await expect(
@@ -212,7 +212,7 @@ test("it is possible to filter by trigger", async ({ page }) => {
 
 test("it is possible to filter by status", async ({ page }) => {
   await createStatusFilterInstances();
-  await page.goto(`${namespace}/instances/`);
+  await page.goto(`/n/${namespace}/instances/`);
 
   /* there should be 5 items initially */
   await expect(
@@ -278,7 +278,7 @@ test("it is possible to filter by AS (name)", async ({ page }) => {
     )
   );
 
-  await page.goto(`${namespace}/instances/`);
+  await page.goto(`/n/${namespace}/instances/`);
 
   /* there should be 4 items initially */
   await expect(
@@ -352,7 +352,7 @@ test("it is possible to apply multiple filters", async ({ page }) => {
   await Promise.all(failingInstances);
 
   /* visit page and test initial state */
-  await page.goto(`${namespace}/instances/`);
+  await page.goto(`/n/${namespace}/instances/`);
 
   await expect(
     page.getByTestId(/instance-row/),

--- a/ui/e2e/instances/list/index.spec.ts
+++ b/ui/e2e/instances/list/index.spec.ts
@@ -46,7 +46,7 @@ test.afterEach(async () => {
 test("it displays a note, when there are no instances yet.", async ({
   page,
 }) => {
-  await page.goto(`${namespace}/instances/`);
+  await page.goto(`/n/${namespace}/instances/`);
   await expect(
     page.getByTestId("no-result"),
     "no result message should be visible"
@@ -190,7 +190,7 @@ test("it renders the instance item correctly for failed and success status", asy
     await expect(
       page,
       "when the workflow name is clicked, page should navigate to the workflow page"
-    ).toHaveURL(`/${namespace}/explorer/workflow/edit${workflowName}`);
+    ).toHaveURL(`/n/${namespace}/explorer/workflow/edit${workflowName}`);
 
     await page.goBack();
 
@@ -198,11 +198,11 @@ test("it renders the instance item correctly for failed and success status", asy
     await expect(
       page,
       "on click row, page should navigate to the instance detail page"
-    ).toHaveURL(`/${namespace}/instances/${instance.instance}`);
+    ).toHaveURL(`/n/${namespace}/instances/${instance.instance}`);
     await page.goBack();
   };
 
-  await page.goto(`${namespace}/instances/`);
+  await page.goto(`/n/${namespace}/instances/`);
 
   for (let i = 0; i < instances.length; i++) {
     const instance = instances[i];
@@ -250,7 +250,7 @@ test("it provides a proper pagination", async ({ page }) => {
    */
   await page.waitForTimeout(500);
 
-  await page.goto(`${namespace}/instances/`, { waitUntil: "networkidle" });
+  await page.goto(`/n/${namespace}/instances/`, { waitUntil: "networkidle" });
 
   await expect(
     page.getByTestId("pagination-wrapper"),
@@ -337,7 +337,7 @@ test("It will display child instances as well", async ({ page }) => {
     headers,
   });
 
-  await page.goto(`${namespace}/instances/`, { waitUntil: "networkidle" });
+  await page.goto(`/n/${namespace}/instances/`, { waitUntil: "networkidle" });
 
   const instancesList = await getInstances({
     urlParams: {

--- a/ui/e2e/jqplayground/index.spec.ts
+++ b/ui/e2e/jqplayground/index.spec.ts
@@ -19,7 +19,7 @@ test.beforeEach(async ({ page }) => {
    * networkidle is required to avoid flaky tests. The monaco
    * editor needs to be full loaded before we interact with it.
    */
-  await page.goto(`/${namespace}/jq`, { waitUntil: "networkidle" });
+  await page.goto(`/n/${namespace}/jq`, { waitUntil: "networkidle" });
 });
 
 test.afterEach(async () => {

--- a/ui/e2e/mirror.spec.ts
+++ b/ui/e2e/mirror.spec.ts
@@ -37,7 +37,7 @@ test("it is possible to create and sync a mirror", async ({ page }) => {
 
   /* assert mirror page is rendered and sync is listed */
   await expect(page, "it redirects to the mirror route").toHaveURL(
-    `/${mirrorName}/mirror/`
+    `/n/${mirrorName}/mirror/`
   );
 
   await expect(

--- a/ui/e2e/notificationmenu/index.spec.ts
+++ b/ui/e2e/notificationmenu/index.spec.ts
@@ -16,7 +16,7 @@ test.afterEach(async () => {
 });
 
 test("Notification Bell has an inactive state by default", async ({ page }) => {
-  await page.goto(`/${namespace}/explorer/tree`, {
+  await page.goto(`/n/${namespace}/explorer/tree`, {
     waitUntil: "networkidle",
   });
 
@@ -46,7 +46,7 @@ test("Notification Bell updates depending on the count of Notification Messages"
     yaml: workflowWithSecrets,
   });
 
-  await page.goto(`/${namespace}/explorer/tree`, {
+  await page.goto(`/n/${namespace}/explorer/tree`, {
     waitUntil: "networkidle",
   });
 
@@ -70,7 +70,7 @@ test("Notification Bell updates depending on the count of Notification Messages"
     "the modal should now display 'You have 2 uninitialized secrets.'"
   ).toMatch(/You have 2 uninitialized secrets./);
 
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
 
   const initialize_secret1 = page
     .getByRole("cell", { name: "ACCESS_KEY Initialize secret" })

--- a/ui/e2e/onboarding.spec.ts
+++ b/ui/e2e/onboarding.spec.ts
@@ -45,7 +45,7 @@ test("if no namespaces exist, it renders the onboarding page", async ({
   await await expect(
     page,
     "it should redirect to namespace/explorer/tree"
-  ).toHaveURL(`/${namespace}/explorer/tree`);
+  ).toHaveURL(`/n/${namespace}/explorer/tree`);
 
   await expect(
     page.getByTestId("breadcrumb-namespace"),

--- a/ui/e2e/services/details.spec.ts
+++ b/ui/e2e/services/details.spec.ts
@@ -51,7 +51,7 @@ test("Service details page provides information about the service", async ({
 
   if (!createdService) throw new Error("could not find service");
 
-  await page.goto(`/${namespace}/services/${createdService.id}`);
+  await page.goto(`/n/${namespace}/services/${createdService.id}`);
 
   await expect(
     page.getByRole("heading", { name: createdService.id, exact: true }),
@@ -188,7 +188,7 @@ test("Service details page renders no logs when the service did not mount", asyn
 
   if (!createdService) throw new Error("could not find service");
 
-  await page.goto(`/${namespace}/services/${createdService.id}`);
+  await page.goto(`/n/${namespace}/services/${createdService.id}`);
 
   await expect(
     page.getByRole("heading", { name: createdService.id, exact: true }),

--- a/ui/e2e/services/list.spec.ts
+++ b/ui/e2e/services/list.spec.ts
@@ -23,7 +23,7 @@ test.afterEach(async () => {
 });
 
 test("Service list is empty by default", async ({ page }) => {
-  await page.goto(`/${namespace}/services`, {
+  await page.goto(`/n/${namespace}/services`, {
     waitUntil: "networkidle",
   });
 
@@ -61,7 +61,7 @@ test("Service list shows all available services", async ({ page }) => {
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/services`, {
+  await page.goto(`/n/${namespace}/services`, {
     waitUntil: "networkidle",
   });
 
@@ -132,7 +132,7 @@ test("Service list links the file name to the service file", async ({
     yaml: createHttpServiceFile(),
   });
 
-  await page.goto(`/${namespace}/services`, {
+  await page.goto(`/n/${namespace}/services`, {
     waitUntil: "networkidle",
   });
 
@@ -144,7 +144,7 @@ test("Service list links the file name to the service file", async ({
   await expect(
     page,
     "after clicking on the file name, the user gets redirected to the file explorer page of the service file"
-  ).toHaveURL(`/${namespace}/explorer/service/http-service.yaml`);
+  ).toHaveURL(`/n/${namespace}/explorer/service/http-service.yaml`);
 
   await expect(
     page.getByTestId("breadcrumb-segment"),
@@ -180,7 +180,7 @@ test("Service list links the row to the service details page", async ({
 
   if (!createdService) throw new Error("could not find service");
 
-  await page.goto(`/${namespace}/services`, {
+  await page.goto(`/n/${namespace}/services`, {
     waitUntil: "networkidle",
   });
 
@@ -189,7 +189,7 @@ test("Service list links the row to the service details page", async ({
   await expect(
     page,
     "after clicking on the service row, the user gets redirected to the service details page"
-  ).toHaveURL(`/${namespace}/services/${createdService.id}`);
+  ).toHaveURL(`/n/${namespace}/services/${createdService.id}`);
 
   await expect(
     page
@@ -229,7 +229,7 @@ test("Service list lets the user rebuild a service", async ({ page }) => {
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/services`, {
+  await page.goto(`/n/${namespace}/services`, {
     waitUntil: "networkidle",
   });
 
@@ -280,7 +280,7 @@ test("Service list highlights services that have errors", async ({ page }) => {
     )
     .toBeTruthy();
 
-  await page.goto(`/${namespace}/services`, {
+  await page.goto(`/n/${namespace}/services`, {
     waitUntil: "networkidle",
   });
 
@@ -311,7 +311,7 @@ test("Service list will update the services when refetch button is clicked", asy
     }),
   });
 
-  await page.goto(`/${namespace}/services`, {
+  await page.goto(`/n/${namespace}/services`, {
     waitUntil: "networkidle",
   });
 

--- a/ui/e2e/settings/deleteNamespace.spec.ts
+++ b/ui/e2e/settings/deleteNamespace.spec.ts
@@ -37,7 +37,7 @@ test("it is possible to delete a namespace and it will immediately redirect to a
   page,
 }) => {
   const namespaceToBeDeleted = await createNamespace();
-  await page.goto(`/${namespaceToBeDeleted}/settings`);
+  await page.goto(`/n/${namespaceToBeDeleted}/settings`);
   await page.getByTestId("btn-delete-namespace").click();
   const confirmButton = page.getByTestId("delete-namespace-confirm-btn");
 
@@ -97,7 +97,7 @@ test("it is possible to delete the last namespace and it will redirect to the la
   page,
 }) => {
   const namespace = await createNamespace();
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
   await page.getByTestId("btn-delete-namespace").click();
 
   const confirmButton = page.getByTestId("delete-namespace-confirm-btn");

--- a/ui/e2e/settings/index.spec.ts
+++ b/ui/e2e/settings/index.spec.ts
@@ -25,7 +25,7 @@ test("it renders secrets, variables and registries", async ({ page }) => {
   const registries = await createRegistries(namespace, 4);
   const variables = await createVariables(namespace);
 
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
 
   await expect(
     page
@@ -66,7 +66,7 @@ test("it is possible to create and delete secrets", async ({ page }) => {
   // avoid typescript errors below
   if (!secretToDelete || !firstSecretName) throw "error setting up test data";
 
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
   await page.getByTestId("secret-create").click();
   const newSecret = {
     name: faker.internet.domainWord(),
@@ -117,7 +117,7 @@ test("it is possible to create and delete registries", async ({ page }) => {
   // avoid typescript errors below
   if (!registryToDelete) throw "error setting up test data";
 
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
   await page.getByTestId("registry-create").click();
 
   const newRegistry = {
@@ -170,7 +170,7 @@ test("it is possible to create and delete variables", async ({
   if (!variableToDelete) throw "error setting up test data";
 
   /* visit page and edit variable*/
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
   await page.getByTestId("variable-create").click();
 
   await page.getByTestId("variable-name").type("awesome-variable");
@@ -244,7 +244,7 @@ test("it is possible to edit variables", async ({ page }) => {
   if (!subject) throw "There was an error setting up test data";
 
   /* visit page and edit variable */
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
   await page.getByTestId(`dropdown-trg-item-${subject.data.name}`).click();
   await page.getByRole("button", { name: "edit" }).click();
 
@@ -314,7 +314,7 @@ test("it is not possible to create a variable with a name that already exists", 
   const variables = await createVariables(namespace, 3);
   const reservedName = variables[0]?.data.name ?? "";
 
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
   await page.getByTestId("variable-create").click();
 
   page.getByTestId("variable-name").fill(reservedName);
@@ -338,7 +338,7 @@ test("it is not possible to set a variables name to a name that already exists",
 
   const reservedName = variables[0]?.data.name ?? "";
 
-  await page.goto(`/${namespace}/settings`);
+  await page.goto(`/n/${namespace}/settings`);
   await page.getByTestId(`dropdown-trg-item-${subject.data.name}`).click();
   await page.getByRole("button", { name: "edit" }).click();
 

--- a/ui/src/util/router/index.tsx
+++ b/ui/src/util/router/index.tsx
@@ -11,7 +11,7 @@ export const router = createBrowserRouter([
     errorElement: <ErrorPage />,
   },
   {
-    path: "/:namespace",
+    path: "/n/:namespace",
     element: <NamespaceLayout />,
     children: Object.values(pages).map((page) => page.route),
     errorElement: <ErrorPage />,

--- a/ui/src/util/router/pages.tsx
+++ b/ui/src/util/router/pages.tsx
@@ -258,7 +258,7 @@ export const enterprisePages: EnterprisePageType = isEnterprise()
           if (params.subpage === "tokens") {
             subpage = "/tokens";
           }
-          return `/${params.namespace}/permissions${subpage}`;
+          return `/n/${params.namespace}/permissions${subpage}`;
         },
         useParams: () => {
           const [, secondLevel, thirdLevel] = useMatches(); // first level is namespace level
@@ -350,7 +350,7 @@ export const pages: PageType & EnterprisePageType = {
       const searchParamsString = searchParams.toString();
       const urlParams = searchParamsString ? `?${searchParamsString}` : "";
 
-      return `/${params.namespace}/explorer/${subpage}${path}${urlParams}`;
+      return `/n/${params.namespace}/explorer/${subpage}${path}${urlParams}`;
     },
     useParams: () => {
       const { "*": path, namespace } = useParams();
@@ -452,7 +452,7 @@ export const pages: PageType & EnterprisePageType = {
   monitoring: {
     name: "components.mainMenu.monitoring",
     icon: ActivitySquare,
-    createHref: (params) => `/${params.namespace}/monitoring`,
+    createHref: (params) => `/n/${params.namespace}/monitoring`,
     useParams: () => {
       const [, secondLevel] = useMatches(); // first level is namespace level
       const isMonitoringPage = checkHandler(secondLevel, "isMonitoringPage");
@@ -468,7 +468,7 @@ export const pages: PageType & EnterprisePageType = {
     name: "components.mainMenu.instances",
     icon: Boxes,
     createHref: (params) =>
-      `/${params.namespace}/instances${
+      `/n/${params.namespace}/instances${
         params.instance ? `/${params.instance}` : ""
       }`,
     useParams: () => {
@@ -514,7 +514,7 @@ export const pages: PageType & EnterprisePageType = {
     name: "components.mainMenu.events",
     icon: Radio,
     createHref: (params) =>
-      `/${params.namespace}/events/${
+      `/n/${params.namespace}/events/${
         params?.subpage === "eventlisteners" ? `listeners` : "history"
       }`,
     useParams: () => {
@@ -558,7 +558,7 @@ export const pages: PageType & EnterprisePageType = {
       if (params.subpage === "consumers") {
         subpage = "consumers";
       }
-      return `/${params.namespace}/gateway/${subpage}`;
+      return `/n/${params.namespace}/gateway/${subpage}`;
     },
     useParams: () => {
       const { "*": path } = useParams();
@@ -612,7 +612,7 @@ export const pages: PageType & EnterprisePageType = {
     name: "components.mainMenu.services",
     icon: Layers,
     createHref: (params) =>
-      `/${params.namespace}/services${
+      `/n/${params.namespace}/services${
         params.service ? `/${params.service}` : ""
       }`,
     useParams: () => {
@@ -655,7 +655,7 @@ export const pages: PageType & EnterprisePageType = {
     name: "components.mainMenu.mirror",
     icon: GitCompare,
     createHref: (params) =>
-      `/${params.namespace}/mirror/${
+      `/n/${params.namespace}/mirror/${
         params?.sync ? `logs/${params.sync}` : ""
       }`,
     useParams: () => {
@@ -691,7 +691,7 @@ export const pages: PageType & EnterprisePageType = {
   settings: {
     name: "components.mainMenu.settings",
     icon: Settings,
-    createHref: (params) => `/${params.namespace}/settings`,
+    createHref: (params) => `/n/${params.namespace}/settings`,
     useParams: () => {
       const [, secondLevel] = useMatches(); // first level is namespace level
       const isSettingsPage = checkHandler(secondLevel, "isSettingsPage");
@@ -706,7 +706,7 @@ export const pages: PageType & EnterprisePageType = {
   jqPlayground: {
     name: "components.mainMenu.jqPlayground",
     icon: PlaySquare,
-    createHref: (params) => `/${params.namespace}/jq`,
+    createHref: (params) => `/n/${params.namespace}/jq`,
     useParams: () => {
       const [, secondLevel] = useMatches(); // first level is namespace level
       const isJqPlaygroundPage = checkHandler(


### PR DESCRIPTION
## Description

This updates the ui to use a prefix for namespaces, resulting in paths like `localhost/n/${namespace}/settings`

Previously, paths were `localhost/${namespace}/settings/`. This might cause conflicts, e.g. a namespace called "api" would cause errors because `localhost/api` is forwarded to the backend.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
