### PR TITLE
[DIR-1542] - change endpoint that is used for checkApiKeyAgainstServer

### DIFF
--- a/ui/src/api/authenticate/index.ts
+++ b/ui/src/api/authenticate/index.ts
@@ -8,7 +8,7 @@ export const authenticationKeys = {
 
 /**
  * There is no dedicated authentication endpoint. Instead, we query the
- * "version" endpoint. Like with any other endpoint, it will succeed with the
+ * "namespaces" endpoint. Like with any other endpoint, it will succeed with the
  * correct auth keys and fail otherwise.
  */
 export const checkApiKeyAgainstServer = (apiKey?: string) =>

--- a/ui/src/api/authenticate/index.ts
+++ b/ui/src/api/authenticate/index.ts
@@ -1,5 +1,5 @@
 import { ApiErrorSchema } from "../errorHandling";
-import { getVersion } from "../version/query/get";
+import { getNamespaces } from "../namespaces/query/get";
 
 export const authenticationKeys = {
   authentication: (apiKey: string | undefined) =>
@@ -12,9 +12,9 @@ export const authenticationKeys = {
  * correct auth keys and fail otherwise.
  */
 export const checkApiKeyAgainstServer = (apiKey?: string) =>
-  getVersion({
+  getNamespaces({
     apiKey,
-    urlParams: undefined,
+    urlParams: {},
   })
     .then(() => true)
     /**


### PR DESCRIPTION
## Description

When the user enters the API key on the login screen, the endpoint that is used to check the password is still `/api/v2/status` (previously `api/version`). 

But this endpoint changed to never require any authentication, which means that submitting the password will always be treated as successful. 

When the password is incorrect, the user sees this

![CleanShot 2024-05-08 at 08 11 28@2x](https://github.com/direktiv/direktiv/assets/121789579/28fd9332-625b-41c1-95b2-e95df06defe7)



## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
