### PR TITLE
[DIR-1592] jq Playground: store query and input after clicking an example

### DIFF
--- a/ui/e2e/jqplayground/index.spec.ts
+++ b/ui/e2e/jqplayground/index.spec.ts
@@ -375,3 +375,43 @@ test("running a snippet will automatically scroll the page to the top", async ({
     )
     .toBe(true);
 });
+
+test("running a snippet will store the jqx and input in local storage", async ({
+  page,
+}) => {
+  const { inputTextArea, queryInput } = getCommonElements(page);
+  const snippetButton = page.getByTestId(`jq-run-snippet-valueAtKey-btn`);
+
+  await snippetButton.click();
+
+  const expectedInput = `{
+    "foo": 42,
+    "bar": "less interesting data"
+}`;
+
+  const expectedJqx = "jq(.foo)";
+
+  expect(
+    await queryInput.inputValue(),
+    "the jqx from the example snippet is used"
+  ).toBe(expectedJqx);
+  await expect
+    .poll(
+      async () => await inputTextArea.inputValue(),
+      "the input from the example snippet is used"
+    )
+    .toBe(expectedInput);
+
+  await page.reload();
+
+  expect(
+    await queryInput.inputValue(),
+    "the jqx will be restored from local storage"
+  ).toBe(expectedJqx);
+  await expect
+    .poll(
+      async () => await inputTextArea.inputValue(),
+      "the input will be restored from local storage"
+    )
+    .toBe(expectedInput);
+});

--- a/ui/src/pages/namespace/JqPlayground/index.tsx
+++ b/ui/src/pages/namespace/JqPlayground/index.tsx
@@ -99,8 +99,11 @@ const JqPlaygroundPage: FC = () => {
 
   const onRunSnippet = (params: ExecuteJxQueryPayloadType) => {
     window.scrollTo({ top: 0, behavior: "smooth" });
-    setValue("data", prettifyJsonString(params.data));
+    const data = prettifyJsonString(params.data);
+    setValue("data", data);
+    storePlaygroundDataInLocalstorage(data);
     setValue("jx", params.jx);
+    storeJxInLocalstorage(params.jx);
     formRef.current?.requestSubmit();
   };
 


### PR DESCRIPTION
## Description

When a user clicks an example in the jq Playground, the jqx and input should be stored in local storage to persists after a page reload

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
