### PR TITLE
[DIR-1598] enable monitoring logs test and fix log deduplication 

### DIFF
--- a/ui/e2e/monitoring/index.spec.ts
+++ b/ui/e2e/monitoring/index.spec.ts
@@ -1,6 +1,9 @@
 import { createNamespace, deleteNamespace } from "../utils/namespace";
 import { expect, test } from "@playwright/test";
 
+import { createInstance } from "e2e/instances/utils";
+import { createWorkflow } from "e2e/utils/workflow";
+
 let namespace = "";
 
 test.beforeEach(async () => {
@@ -13,16 +16,16 @@ test.afterEach(async () => {
 });
 
 test("It will show the logs on the monitoring page", async ({ page }) => {
-  test.slow();
+  await createWorkflow(namespace, "test-workflow");
+  await createInstance({ namespace, path: "test-workflow" });
+
   await page.goto(`/n/${namespace}/monitoring`, {
     waitUntil: "domcontentloaded",
   });
 
-  await page.waitForTimeout(5000);
-
   await expect(
-    page.getByText("msg: updating namespace gateway"),
-    "TEST TEST TEST It will show a log message"
+    page.getByText("msg: Workflow has been triggered"),
+    "It will show a log message"
   ).toBeVisible();
 
   await expect(
@@ -41,7 +44,7 @@ test("It will show the logs on the monitoring page", async ({ page }) => {
   await page.waitForTimeout(3000);
 
   await expect(
-    page.getByText("msg: updating namespace gateway"),
+    page.getByText("msg: Workflow has been triggered"),
     "When coming back to the monitoring page, it still shows the same log message"
   ).toBeVisible();
 

--- a/ui/e2e/monitoring/index.spec.ts
+++ b/ui/e2e/monitoring/index.spec.ts
@@ -22,7 +22,7 @@ test("It will show the logs on the monitoring page", async ({ page }) => {
 
   await expect(
     page.getByText("msg: updating namespace gateway"),
-    "It will show a log message"
+    "TEST TEST TEST It will show a log message"
   ).toBeVisible();
 
   await expect(

--- a/ui/e2e/monitoring/index.spec.ts
+++ b/ui/e2e/monitoring/index.spec.ts
@@ -12,8 +12,7 @@ test.afterEach(async () => {
   namespace = "";
 });
 
-// disable for now since it fails in CI
-test.skip("It will show the logs on the monitoring page", async ({ page }) => {
+test("It will show the logs on the monitoring page", async ({ page }) => {
   test.slow();
   await page.goto(`/n/${namespace}/monitoring`, {
     waitUntil: "domcontentloaded",

--- a/ui/e2e/monitoring/index.spec.ts
+++ b/ui/e2e/monitoring/index.spec.ts
@@ -18,6 +18,8 @@ test("It will show the logs on the monitoring page", async ({ page }) => {
     waitUntil: "domcontentloaded",
   });
 
+  await page.waitForTimeout(5000);
+
   await expect(
     page.getByText("msg: updating namespace gateway"),
     "It will show a log message"

--- a/ui/e2e/monitoring/index.spec.ts
+++ b/ui/e2e/monitoring/index.spec.ts
@@ -16,8 +16,9 @@ test.afterEach(async () => {
 });
 
 test("It will show the logs on the monitoring page", async ({ page }) => {
-  await createWorkflow(namespace, "test-workflow");
-  await createInstance({ namespace, path: "test-workflow" });
+  const workflowName = "workflow.yaml";
+  await createWorkflow(namespace, workflowName);
+  await createInstance({ namespace, path: workflowName });
 
   await page.goto(`/n/${namespace}/monitoring`, {
     waitUntil: "domcontentloaded",

--- a/ui/src/api/logs/query/logs.ts
+++ b/ui/src/api/logs/query/logs.ts
@@ -65,7 +65,7 @@ const updateCache = (
 
   const pages = oldData.pages;
   const olderPages = pages.slice(0, -1);
-  const newestPage = pages.at(-1);
+  const newestPage = pages[0];
   if (newestPage === undefined) return undefined;
 
   const newestPageData = newestPage.data ?? [];

--- a/ui/src/pages/namespace/Monitoring/Logs/Entry.tsx
+++ b/ui/src/pages/namespace/Monitoring/Logs/Entry.tsx
@@ -14,7 +14,7 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
   ({ logEntry, ...props }, ref) => {
     const pages = usePages();
     const { t } = useTranslation();
-    const { msg, error, level, time, workflow, namespace } = logEntry;
+    const { msg, id, error, level, time, workflow, namespace } = logEntry;
     const formattedTime = formatLogTime(time);
     const hasNamespaceInformation = !!namespace;
 
@@ -40,7 +40,7 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
         {...props}
       >
         <LogSegment display={true}>
-          {t("components.logs.logEntry.messageLabel")} {msg}
+          ({id}) {t("components.logs.logEntry.messageLabel")} {msg}
         </LogSegment>
         <LogSegment display={error ? true : false}>
           {t("components.logs.logEntry.errorLabel")} {error}

--- a/ui/src/pages/namespace/Monitoring/Logs/Entry.tsx
+++ b/ui/src/pages/namespace/Monitoring/Logs/Entry.tsx
@@ -14,7 +14,7 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
   ({ logEntry, ...props }, ref) => {
     const pages = usePages();
     const { t } = useTranslation();
-    const { msg, id, error, level, time, workflow, namespace } = logEntry;
+    const { msg, error, level, time, workflow, namespace } = logEntry;
     const formattedTime = formatLogTime(time);
     const hasNamespaceInformation = !!namespace;
 
@@ -40,7 +40,7 @@ export const Entry = forwardRef<HTMLDivElement, Props>(
         {...props}
       >
         <LogSegment display={true}>
-          ({id}) {t("components.logs.logEntry.messageLabel")} {msg}
+          {t("components.logs.logEntry.messageLabel")} {msg}
         </LogSegment>
         <LogSegment display={error ? true : false}>
           {t("components.logs.logEntry.errorLabel")} {error}


### PR DESCRIPTION
## Description

Logs behave differently in CI than on my local machine, because the logs were configured to be in debug level (`logging: json`). On my local machine, I got a default log entry on the monitoring page that was not shown in CI (and production). We should try to use a local setup that is as close to production as possible, I updated our internal wiki and removed the additional flow configuration:

```yaml
flow:
  logging: json
  debug: true
```

For that test to pass, I now trigger a workflow to produce a log entry on the monitoring page

There was also another issue that this test uncovered. It is technically possible that we can get a log message twice. Once from the initial log request and a second time directly after that via the stream. This is a rare race condition, but since the CI is doing interactions very fast, it happened all the time in that test. I already had deduplication in place, but it seemed to stop working after https://github.com/direktiv/direktiv/pull/1595 was merged. The pages in the cache are now in a different order. Fixed in in this commit https://github.com/direktiv/direktiv/pull/1620/commits/ec9cfe483aa4c03ef46c101b91a49dc52bf33552

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
