### PR TITLE
[DIR-1608] Display error message on errors when fetching logs

### DIFF
--- a/ui/e2e/events/listeners.spec.ts
+++ b/ui/e2e/events/listeners.spec.ts
@@ -102,7 +102,7 @@ test("it paginates event listeners", async ({ page }) => {
   await expect(
     page.getByRole("cell", { name: "start workflow" }),
     "it renders the expected number of items on page 1"
-  ).toHaveCount(10, { timeout: 10000 });
+  ).toHaveCount(10);
 
   const paginationWrapper = page.getByTestId("pagination-wrapper");
 

--- a/ui/e2e/events/listeners.spec.ts
+++ b/ui/e2e/events/listeners.spec.ts
@@ -102,7 +102,7 @@ test("it paginates event listeners", async ({ page }) => {
   await expect(
     page.getByRole("cell", { name: "start workflow" }),
     "it renders the expected number of items on page 1"
-  ).toHaveCount(10);
+  ).toHaveCount(10, { timeout: 10000 });
 
   const paginationWrapper = page.getByTestId("pagination-wrapper");
 

--- a/ui/e2e/instances/details/errorHandling.spec.ts
+++ b/ui/e2e/instances/details/errorHandling.spec.ts
@@ -54,6 +54,6 @@ test("it renders an error when the api response returns an error", async ({
   await page.goto(`/n/${namespace}/instances/${instanceId}`);
 
   await expect(
-    page.getByText("An error was received when fetching logs: oh no!")
+    page.getByText("The API returned an unexpected error: oh no!")
   ).toBeVisible();
 });

--- a/ui/e2e/instances/details/errorHandling.spec.ts
+++ b/ui/e2e/instances/details/errorHandling.spec.ts
@@ -1,0 +1,59 @@
+import { createNamespace, deleteNamespace } from "../../utils/namespace";
+import { expect, test } from "@playwright/test";
+
+import { createFile } from "e2e/utils/files";
+import { createInstance } from "../utils/index";
+import { faker } from "@faker-js/faker";
+import { simpleWorkflow as simpleWorkflowContent } from "../utils/workflows";
+
+let namespace = "";
+
+test.beforeEach(async () => {
+  namespace = await createNamespace();
+});
+
+test.afterEach(async () => {
+  await deleteNamespace(namespace);
+  namespace = "";
+});
+
+test("it renders an error when the api response returns an error", async ({
+  page,
+}) => {
+  /* prepare data */
+  const simpleWorkflowName = faker.system.commonFileName("yaml");
+
+  await createFile({
+    name: simpleWorkflowName,
+    namespace,
+    type: "workflow",
+    yaml: simpleWorkflowContent,
+  });
+
+  const instanceId = (
+    await createInstance({
+      namespace,
+      path: simpleWorkflowName,
+    })
+  ).data.id;
+
+  /* register mock error response */
+  await page.route(
+    `/api/v2/namespaces/${namespace}/logs?instance=${instanceId}`,
+    async (route) => {
+      if (route.request().method() === "GET") {
+        const json = {
+          error: { code: 422, message: "oh no!" },
+        };
+        await route.fulfill({ status: 422, json });
+      } else route.continue();
+    }
+  );
+
+  /* perform test */
+  await page.goto(`/n/${namespace}/instances/${instanceId}`);
+
+  await expect(
+    page.getByText("An error was received when fetching logs: oh no!")
+  ).toBeVisible();
+});

--- a/ui/e2e/instances/filter/index.spec.ts
+++ b/ui/e2e/instances/filter/index.spec.ts
@@ -131,7 +131,17 @@ test("it is possible to filter by date using created before", async ({
 
   const today = new Date().getDate();
 
-  await page.getByText(today.toString(), { exact: true }).last().click();
+  const todayElement =
+    today > 15
+      ? page
+          .getByRole("gridcell", { name: today.toString(), exact: true })
+          .last()
+      : page
+          .getByRole("gridcell", { name: today.toString(), exact: true })
+          .first();
+
+  await todayElement.click();
+
   await expect(
     page.getByTestId(/instance-row/),
     "there should be 0 rows when we filter before today"

--- a/ui/e2e/monitoring/index.spec.ts
+++ b/ui/e2e/monitoring/index.spec.ts
@@ -55,7 +55,9 @@ test("It will show the logs on the monitoring page", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("it will render an alert", async ({ page }) => {
+test("it renders an error when the api response returns an error", async ({
+  page,
+}) => {
   await page.route(`/api/v2/namespaces/${namespace}/logs`, async (route) => {
     if (route.request().method() === "GET") {
       const json = {
@@ -67,5 +69,7 @@ test("it will render an alert", async ({ page }) => {
 
   await page.goto(`/n/${namespace}/monitoring`);
 
-  await expect(page.getByText("oh no!")).toBeVisible();
+  await expect(
+    page.getByText("An error was received when fetching logs: oh no!")
+  ).toBeVisible();
 });

--- a/ui/e2e/monitoring/index.spec.ts
+++ b/ui/e2e/monitoring/index.spec.ts
@@ -54,3 +54,18 @@ test("It will show the logs on the monitoring page", async ({ page }) => {
     "When coming back to the monitoring page, it still shows the same number of logs"
   ).toBeVisible();
 });
+
+test("it will render an alert", async ({ page }) => {
+  await page.route(`/api/v2/namespaces/${namespace}/logs`, async (route) => {
+    if (route.request().method() === "GET") {
+      const json = {
+        error: { code: 422, message: "oh no!" },
+      };
+      await route.fulfill({ status: 422, json });
+    } else route.continue();
+  });
+
+  await page.goto(`/n/${namespace}/monitoring`);
+
+  await expect(page.getByText("oh no!")).toBeVisible();
+});

--- a/ui/e2e/monitoring/index.spec.ts
+++ b/ui/e2e/monitoring/index.spec.ts
@@ -70,6 +70,6 @@ test("it renders an error when the api response returns an error", async ({
   await page.goto(`/n/${namespace}/monitoring`);
 
   await expect(
-    page.getByText("An error was received when fetching logs: oh no!")
+    page.getByText("The API returned an unexpected error: oh no!")
   ).toBeVisible();
 });

--- a/ui/e2e/utils/files.ts
+++ b/ui/e2e/utils/files.ts
@@ -72,7 +72,7 @@ export const createDirectory = async ({
     headers,
   });
 
-type ErrorType = { response: { status?: number } };
+type ErrorType = { status?: number };
 
 export const checkIfFileExists = async ({
   namespace,
@@ -98,13 +98,13 @@ export const checkIfFileExists = async ({
     return response.data.path === path;
   } catch (error) {
     const typedError = error as ErrorType;
-    if (typedError?.response?.status === 404) {
+    if (typedError?.status === 404) {
       // fail silently to allow for using poll() in tests
       return false;
     }
 
     throw new Error(
-      `Unexpected error ${typedError?.response?.status} fetching ${path} in namespace ${namespace}`
+      `Unexpected error ${typedError?.status} fetching ${path} in namespace ${namespace}`
     );
   }
 };

--- a/ui/src/api/__tests__/apiFactory.test.ts
+++ b/ui/src/api/__tests__/apiFactory.test.ts
@@ -217,8 +217,8 @@ describe("processApiResponse", () => {
       const res = result.current.error;
       const parsedRes = ApiErrorSchema.safeParse(res);
       if (parsedRes.success) {
-        expect(parsedRes.data.response.status).toBe(401);
-        expect(parsedRes.data.json).toBe(undefined);
+        expect(parsedRes.data.status).toBe(401);
+        expect(parsedRes.data.body).toBe(undefined);
       } else {
         throw new Error("api response does not match ApiErrorSchema");
       }
@@ -310,8 +310,8 @@ describe("processApiResponse", () => {
       const res = result.current.error;
       const parsedRes = ApiErrorSchema.safeParse(res);
       if (parsedRes.success) {
-        expect(parsedRes.data.response.status).toBe(404);
-        expect(parsedRes.data.json).toBe(undefined);
+        expect(parsedRes.data.status).toBe(404);
+        expect(parsedRes.data.body).toBe(undefined);
       } else {
         throw new Error("api response does not match ApiErrorSchema");
       }
@@ -339,8 +339,8 @@ describe("processApiResponse", () => {
       const res = result.current.error;
       const parsedRes = ApiErrorSchema.safeParse(res);
       if (parsedRes.success) {
-        expect(parsedRes.data.response.status).toBe(422);
-        expect(parsedRes.data.json).toStrictEqual({
+        expect(parsedRes.data.status).toBe(422);
+        expect(parsedRes.data.body).toStrictEqual({
           my: "error",
         });
       } else {

--- a/ui/src/api/authenticate/index.ts
+++ b/ui/src/api/authenticate/index.ts
@@ -24,7 +24,7 @@ export const checkApiKeyAgainstServer = (apiKey?: string) =>
     .catch((err) => {
       const parsedError = ApiErrorSchema.safeParse(err);
       if (parsedError.success) {
-        const { status } = parsedError.data.response;
+        const { status } = parsedError.data;
         if (status === 401 || status === 403) {
           return false;
         }

--- a/ui/src/api/errorHandling.ts
+++ b/ui/src/api/errorHandling.ts
@@ -1,12 +1,7 @@
 import { z } from "zod";
 
 /**
- * The ApiErrorSchema is a special schema we use to standardize api error handling
- * across the app. It contains the response object from the fetch api, and an
- * optional json object that may contain the error code and message. Since errors
- * are always typed as unknown, we can use the the custom type guard isApiErrorSchema
- * to check if an error conforms to the ApiErrorSchema and have typesafe way to process
- * the error.
+ * ErrorJson is the response body format used when the backend returns an error.
  */
 const ErrorJson = z
   .object({
@@ -16,13 +11,16 @@ const ErrorJson = z
   .passthrough()
   .optional();
 
+/**
+ * ApiErrorSchema is our standardized error schema used to represent api response errors
+ * throughout this app. Also see the guard function isApiErrorSchema below.
+ */
 export const ApiErrorSchema = z.object({
   status: z.number(),
   body: ErrorJson,
 });
 
 type ApiErrorSchemaType = z.infer<typeof ApiErrorSchema>;
-
 type ErrorJsonType = z.infer<typeof ErrorJson>;
 
 /**
@@ -65,9 +63,18 @@ export const createApiErrorFromResponse = async (
   };
 };
 
+/**
+ * Use isApiErrorSchema() as a guard to check if an error conforms to the ApiErrorSchema
+ * (rather than, for example, a standard JavaScript Error originating elsewhere).
+ */
 export const isApiErrorSchema = (error: unknown): error is ApiErrorSchemaType =>
   ApiErrorSchema.safeParse(error).success;
 
+/**
+ * Use getMessageFromApiError(error) to extract the human readable error message.
+ * @param error error with unknown type
+ * @returns message or undefined if the error has an incompatible format.
+ */
 export const getMessageFromApiError = (error: unknown) =>
   isApiErrorSchema(error) ? error.body?.message : undefined;
 
@@ -94,3 +101,9 @@ export const getPermissionStatus = (error: unknown): PermissionStatus => {
     isAllowed: true,
   };
 };
+
+/**
+ * Used to type useQuery methods, which may be either an ApiError or other JavaScript error
+ * in case something else goes wrong.
+ */
+export type QueryErrorType = ApiErrorSchemaType | Error;

--- a/ui/src/api/useInfiniteQueryWithPermissions.ts
+++ b/ui/src/api/useInfiniteQueryWithPermissions.ts
@@ -1,13 +1,12 @@
 import {
-  DefaultError,
   InfiniteData,
   QueryKey,
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
   useInfiniteQuery,
 } from "@tanstack/react-query";
+import { QueryErrorType, getPermissionStatus } from "./errorHandling";
 
-import { getPermissionStatus } from "./errorHandling";
 import { useTranslation } from "react-i18next";
 
 /**
@@ -28,7 +27,7 @@ type ExtendedUseInfiniteQueryReturn =
  */
 const useInfiniteQueryWithPermissions = <
   TQueryFnData = unknown,
-  TError = DefaultError,
+  TError = QueryErrorType,
   TData = InfiniteData<TQueryFnData>,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown

--- a/ui/src/api/useMutationWithPermissions.ts
+++ b/ui/src/api/useMutationWithPermissions.ts
@@ -1,10 +1,6 @@
-import {
-  DefaultError,
-  UseMutationOptions,
-  useMutation,
-} from "@tanstack/react-query";
+import { QueryErrorType, getPermissionStatus } from "./errorHandling";
+import { UseMutationOptions, useMutation } from "@tanstack/react-query";
 
-import { getPermissionStatus } from "./errorHandling";
 import { t } from "i18next";
 import { useToast } from "~/design/Toast";
 
@@ -22,7 +18,7 @@ type UseMutationParam<TData, TError, TVariables> = UseMutationOptions<
  */
 const useMutationWithPermissions = <
   TData = unknown,
-  TError = DefaultError,
+  TError = QueryErrorType,
   TVariables = void
 >(
   useMutationParams: UseMutationParam<TData, TError, TVariables>

--- a/ui/src/api/useQueryWithPermissions.ts
+++ b/ui/src/api/useQueryWithPermissions.ts
@@ -1,12 +1,11 @@
+import { QueryErrorType, getPermissionStatus } from "./errorHandling";
 import {
-  DefaultError,
   QueryKey,
   UseQueryOptions,
   UseQueryResult,
   useQuery,
 } from "@tanstack/react-query";
 
-import { getPermissionStatus } from "./errorHandling";
 import { useTranslation } from "react-i18next";
 
 type UseQueryParam<
@@ -46,7 +45,7 @@ type ExtendedUseQueryReturn =
  */
 const useQueryWithPermissions = <
   TQueryFnData = unknown,
-  TError = DefaultError,
+  TError = QueryErrorType,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 >(

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -527,7 +527,8 @@
           "title": "Failed Executions",
           "empty": "There are no recent failed executions."
         }
-      }
+      },
+      "apiError": "An error was received when fetching logs:"
     },
     "instances": {
       "list": {
@@ -1139,6 +1140,9 @@
       "header": {
         "confirm": "Confirmation required"
       }
+    },
+    "apiError": {
+      "label": "The API returned an error: "
     },
     "formErrors": {
       "fieldInvalid": "this field is invalid"

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -527,8 +527,7 @@
           "title": "Failed Executions",
           "empty": "There are no recent failed executions."
         }
-      },
-      "apiError": "An error was received when fetching logs:"
+      }
     },
     "instances": {
       "list": {
@@ -1142,7 +1141,8 @@
       }
     },
     "apiError": {
-      "label": "The API returned an error: "
+      "onlyLabel": "The API returned an unexpected error",
+      "withMessage": "The API returned an unexpected error: {{message}}"
     },
     "formErrors": {
       "fieldInvalid": "this field is invalid"

--- a/ui/src/components/ApiError/index.tsx
+++ b/ui/src/components/ApiError/index.tsx
@@ -5,20 +5,19 @@ import { useTranslation } from "react-i18next";
 
 const ApiError = ({
   error,
-  label,
   className,
 }: {
   error: QueryErrorType;
-  label?: string;
   className?: string;
 }) => {
   const { t } = useTranslation();
   const errorMessage = getMessageFromApiError(error);
-  const errorLabel = label || t("components.apiError.label");
 
   return (
     <Alert variant="error" className={className}>
-      {errorLabel} {errorMessage}
+      {errorMessage
+        ? t("components.apiError.withMessage", { message: errorMessage })
+        : t("components.apiError.onlyLabel")}
     </Alert>
   );
 };

--- a/ui/src/components/ApiError/index.tsx
+++ b/ui/src/components/ApiError/index.tsx
@@ -6,16 +6,18 @@ import { useTranslation } from "react-i18next";
 const ApiError = ({
   error,
   label,
+  className,
 }: {
   error: QueryErrorType;
   label?: string;
+  className?: string;
 }) => {
   const { t } = useTranslation();
   const errorMessage = getMessageFromApiError(error);
   const errorLabel = label || t("components.apiError.label");
 
   return (
-    <Alert variant="error">
+    <Alert variant="error" className={className}>
       {errorLabel} {errorMessage}
     </Alert>
   );

--- a/ui/src/components/ApiError/index.tsx
+++ b/ui/src/components/ApiError/index.tsx
@@ -1,0 +1,24 @@
+import { QueryErrorType, getMessageFromApiError } from "~/api/errorHandling";
+
+import Alert from "~/design/Alert";
+import { useTranslation } from "react-i18next";
+
+const ApiError = ({
+  error,
+  label,
+}: {
+  error: QueryErrorType;
+  label?: string;
+}) => {
+  const { t } = useTranslation();
+  const errorMessage = getMessageFromApiError(error);
+  const errorLabel = label || t("components.apiError.label");
+
+  return (
+    <Alert variant="error">
+      {errorLabel} {errorMessage}
+    </Alert>
+  );
+};
+
+export default ApiError;

--- a/ui/src/pages/namespace/Explorer/index.tsx
+++ b/ui/src/pages/namespace/Explorer/index.tsx
@@ -11,7 +11,7 @@ const ExplorerPage = () => {
   if (!isFetched) return null;
 
   // forward 404 errors to the routers error boundary
-  if (isError && isApiErrorSchema(error) && error.response.status === 404) {
+  if (isError && isApiErrorSchema(error) && error.status === 404) {
     throw error;
   }
 

--- a/ui/src/pages/namespace/Instances/Detail/Main/Logs/index.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/Logs/index.tsx
@@ -119,13 +119,7 @@ const LogsPanel = () => {
             </TooltipProvider>
           </ButtonBar>
         </div>
-        {error && (
-          <ApiError
-            error={error}
-            label={t("pages.monitoring.apiError")}
-            className="mb-3"
-          />
-        )}
+        {error && <ApiError error={error} className="mb-3" />}
       </div>
       <ScrollContainer />
       <div

--- a/ui/src/pages/namespace/Instances/Detail/Main/Logs/index.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/Logs/index.tsx
@@ -11,6 +11,7 @@ import {
   useLogsPreferencesVerboseLogs,
 } from "~/util/store/logs";
 
+import ApiError from "~/components/ApiError";
 import Button from "~/design/Button";
 import { ButtonBar } from "~/design/ButtonBar";
 import CopyButton from "~/design/CopyButton";
@@ -30,7 +31,7 @@ const LogsPanel = () => {
 
   const { data: instanceDetailsData } = useInstanceDetails({ instanceId });
 
-  const { data: logLines = [] } = useLogs({
+  const { data: logLines = [], error } = useLogs({
     instance: instanceId,
   });
 
@@ -116,6 +117,11 @@ const LogsPanel = () => {
             </Tooltip>
           </TooltipProvider>
         </ButtonBar>
+      </div>
+      <div className="mb-3">
+        {error && (
+          <ApiError error={error} label={t("pages.monitoring.apiError")} />
+        )}
       </div>
       <ScrollContainer />
       <div

--- a/ui/src/pages/namespace/Instances/Detail/Main/Logs/index.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/Logs/index.tsx
@@ -50,77 +50,81 @@ const LogsPanel = () => {
 
   return (
     <>
-      <div className="mb-5 flex flex-col gap-5 sm:flex-row">
-        <h3 className="flex grow items-center gap-x-2 font-medium">
-          <ScrollText className="h-5" />
-          {t("pages.instances.detail.logs.title", {
-            path: instanceDetailsData?.path,
-          })}
-        </h3>
-        <ButtonBar>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="flex grow">
-                  <Toggle
-                    size="sm"
-                    className="grow"
-                    pressed={verboseLogs}
-                    onClick={() => {
-                      setVerboseLogs(!verboseLogs);
-                    }}
-                  >
-                    <Bug />
-                  </Toggle>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>
-                {t("pages.instances.detail.logs.tooltips.verbose")}
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="flex grow">
-                  <CopyButton
-                    value={copyValue}
-                    buttonProps={{
-                      variant: "outline",
-                      size: "sm",
-                      className: "grow",
-                    }}
-                  />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>{t("components.logs.copy")}</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="flex grow">
-                  <Button
-                    icon
-                    variant="outline"
-                    size="sm"
-                    className="grow"
-                    onClick={() => {
-                      setMaximizedPanel(isMaximized ? "none" : "logs");
-                    }}
-                  >
-                    {isMaximized ? <Minimize2 /> : <Maximize2 />}
-                  </Button>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>
-                {isMaximized
-                  ? t("pages.instances.detail.logs.tooltips.minimize")
-                  : t("pages.instances.detail.logs.tooltips.maximize")}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </ButtonBar>
-      </div>
-      <div className="mb-3">
+      <div>
+        <div className="mb-3 flex flex-col gap-5 sm:flex-row">
+          <h3 className="flex grow items-center gap-x-2 font-medium">
+            <ScrollText className="h-5" />
+            {t("pages.instances.detail.logs.title", {
+              path: instanceDetailsData?.path,
+            })}
+          </h3>
+          <ButtonBar>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex grow">
+                    <Toggle
+                      size="sm"
+                      className="grow"
+                      pressed={verboseLogs}
+                      onClick={() => {
+                        setVerboseLogs(!verboseLogs);
+                      }}
+                    >
+                      <Bug />
+                    </Toggle>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t("pages.instances.detail.logs.tooltips.verbose")}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex grow">
+                    <CopyButton
+                      value={copyValue}
+                      buttonProps={{
+                        variant: "outline",
+                        size: "sm",
+                        className: "grow",
+                      }}
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{t("components.logs.copy")}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex grow">
+                    <Button
+                      icon
+                      variant="outline"
+                      size="sm"
+                      className="grow"
+                      onClick={() => {
+                        setMaximizedPanel(isMaximized ? "none" : "logs");
+                      }}
+                    >
+                      {isMaximized ? <Minimize2 /> : <Maximize2 />}
+                    </Button>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {isMaximized
+                    ? t("pages.instances.detail.logs.tooltips.minimize")
+                    : t("pages.instances.detail.logs.tooltips.maximize")}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </ButtonBar>
+        </div>
         {error && (
-          <ApiError error={error} label={t("pages.monitoring.apiError")} />
+          <ApiError
+            error={error}
+            label={t("pages.monitoring.apiError")}
+            className="mb-3"
+          />
         )}
       </div>
       <ScrollContainer />

--- a/ui/src/pages/namespace/Layout.tsx
+++ b/ui/src/pages/namespace/Layout.tsx
@@ -44,7 +44,7 @@ const Layout = () => {
   }, [namespace, setNamespace, namespaceFromUrl]);
 
   // this error will redirect to the error page, when the namespace does not exist
-  if (isError && isApiErrorSchema(error) && error.response.status === 404) {
+  if (isError && isApiErrorSchema(error) && error.status === 404) {
     throw error;
   }
 

--- a/ui/src/pages/namespace/Monitoring/Logs/index.tsx
+++ b/ui/src/pages/namespace/Monitoring/Logs/index.tsx
@@ -15,7 +15,7 @@ import { getMonitoringLogEntryForClipboard } from "~/components/Logs/utils";
 import { useLogs } from "~/api/logs/query/logs";
 import { useTranslation } from "react-i18next";
 
-const LogsPanel = () => {
+const Logs = () => {
   const { t } = useTranslation();
 
   const {
@@ -37,34 +37,38 @@ const LogsPanel = () => {
 
   return (
     <>
-      <div className="mb-3 flex flex-col gap-5 sm:flex-row">
-        <h3 className="flex grow gap-x-2 font-medium">
-          <ScrollText className="h-5" />
-          {t("components.logs.title")}
-        </h3>
-        <ButtonBar>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="flex grow">
-                  <CopyButton
-                    value={copyValue}
-                    buttonProps={{
-                      variant: "outline",
-                      size: "sm",
-                      className: "grow",
-                    }}
-                  />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>{t("components.logs.copy")}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </ButtonBar>
-      </div>
-      <div className="mb-3">
+      <div>
+        <div className="mb-3 flex flex-col gap-5 sm:flex-row">
+          <h3 className="flex grow gap-x-2 font-medium">
+            <ScrollText className="h-5" />
+            {t("components.logs.title")}
+          </h3>
+          <ButtonBar>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex grow">
+                    <CopyButton
+                      value={copyValue}
+                      buttonProps={{
+                        variant: "outline",
+                        size: "sm",
+                        className: "grow",
+                      }}
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{t("components.logs.copy")}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </ButtonBar>
+        </div>
         {error && (
-          <ApiError error={error} label={t("pages.monitoring.apiError")} />
+          <ApiError
+            error={error}
+            label={t("pages.monitoring.apiError")}
+            className="mb-3"
+          />
         )}
       </div>
       <ScrollContainer />
@@ -79,4 +83,4 @@ const LogsPanel = () => {
   );
 };
 
-export default LogsPanel;
+export default Logs;

--- a/ui/src/pages/namespace/Monitoring/Logs/index.tsx
+++ b/ui/src/pages/namespace/Monitoring/Logs/index.tsx
@@ -5,13 +5,12 @@ import {
   TooltipTrigger,
 } from "~/design/Tooltip";
 
-import Alert from "~/design/Alert";
+import ApiError from "~/components/ApiError";
 import { ButtonBar } from "~/design/ButtonBar";
 import CopyButton from "~/design/CopyButton";
 import { NoPermissions } from "~/design/Table";
 import ScrollContainer from "./Scrollcontainer";
 import { ScrollText } from "lucide-react";
-import { getMessageFromApiError } from "~/api/errorHandling";
 import { getMonitoringLogEntryForClipboard } from "~/components/Logs/utils";
 import { useLogs } from "~/api/logs/query/logs";
 import { useTranslation } from "react-i18next";
@@ -36,13 +35,10 @@ const LogsPanel = () => {
 
   if (!isAllowed) return <NoPermissions>{noPermissionMessage}</NoPermissions>;
 
-  const errorMessage = getMessageFromApiError(error);
-
   return (
     <>
-      {errorMessage && <Alert variant="error">{errorMessage}</Alert>}
-      <div className="mb-5 flex flex-col gap-5 sm:flex-row">
-        <h3 className="flex grow items-center gap-x-2 font-medium">
+      <div className="mb-3 flex flex-col gap-5 sm:flex-row">
+        <h3 className="flex grow gap-x-2 font-medium">
           <ScrollText className="h-5" />
           {t("components.logs.title")}
         </h3>
@@ -65,6 +61,11 @@ const LogsPanel = () => {
             </Tooltip>
           </TooltipProvider>
         </ButtonBar>
+      </div>
+      <div className="mb-3">
+        {error && (
+          <ApiError error={error} label={t("pages.monitoring.apiError")} />
+        )}
       </div>
       <ScrollContainer />
       <div className="flex items-center justify-center pt-2 text-sm text-gray-11 dark:text-gray-dark-11">

--- a/ui/src/pages/namespace/Monitoring/Logs/index.tsx
+++ b/ui/src/pages/namespace/Monitoring/Logs/index.tsx
@@ -63,13 +63,7 @@ const Logs = () => {
             </TooltipProvider>
           </ButtonBar>
         </div>
-        {error && (
-          <ApiError
-            error={error}
-            label={t("pages.monitoring.apiError")}
-            className="mb-3"
-          />
-        )}
+        {error && <ApiError error={error} className="mb-3" />}
       </div>
       <ScrollContainer />
       <div className="flex items-center justify-center pt-2 text-sm text-gray-11 dark:text-gray-dark-11">

--- a/ui/src/pages/namespace/Monitoring/Logs/index.tsx
+++ b/ui/src/pages/namespace/Monitoring/Logs/index.tsx
@@ -5,11 +5,13 @@ import {
   TooltipTrigger,
 } from "~/design/Tooltip";
 
+import Alert from "~/design/Alert";
 import { ButtonBar } from "~/design/ButtonBar";
 import CopyButton from "~/design/CopyButton";
 import { NoPermissions } from "~/design/Table";
 import ScrollContainer from "./Scrollcontainer";
 import { ScrollText } from "lucide-react";
+import { getMessageFromApiError } from "~/api/errorHandling";
 import { getMonitoringLogEntryForClipboard } from "~/components/Logs/utils";
 import { useLogs } from "~/api/logs/query/logs";
 import { useTranslation } from "react-i18next";
@@ -19,6 +21,7 @@ const LogsPanel = () => {
 
   const {
     data: logLines = [],
+    error,
     isFetched,
     isAllowed,
     noPermissionMessage,
@@ -33,8 +36,11 @@ const LogsPanel = () => {
 
   if (!isAllowed) return <NoPermissions>{noPermissionMessage}</NoPermissions>;
 
+  const errorMessage = getMessageFromApiError(error);
+
   return (
     <>
+      {errorMessage && <Alert variant="error">{errorMessage}</Alert>}
       <div className="mb-5 flex flex-col gap-5 sm:flex-row">
         <h3 className="flex grow items-center gap-x-2 font-medium">
           <ScrollText className="h-5" />

--- a/ui/src/util/router/ErrorPage.tsx
+++ b/ui/src/util/router/ErrorPage.tsx
@@ -17,14 +17,14 @@ const ErrorPage = ({ className }: ErrorPageProps) => {
   let errorTitle = t("pages.error.status");
   let errorMessage = t("pages.error.message");
 
+  if (isApiErrorSchema(error) && error.status === 404) {
+    errorTitle = `${error.status}`;
+    errorMessage = t("pages.error.notFound");
+  }
+
   if (isRouteErrorResponse(error)) {
     errorTitle = `${error.status}`;
     errorMessage = error.statusText;
-  }
-
-  if (isApiErrorSchema(error) && error.response.status === 404) {
-    errorTitle = `${error.response.status}`;
-    errorMessage = t("pages.error.notFound");
   }
 
   return (


### PR DESCRIPTION
## Description

Previously, the ui just didn't render any logs when fetching logs failed, e.g. with a 500 server error. With this fix, an error message is rendered when a request returns an error.

### Notes

Implementation:
* This will display error messages when an error response is received during the non-streaming request. I don't know if an error via streaming would end up being returned by useLogs() in the same way and according to Alexander, the streaming API currently will not return errors (instead, it will just terminate the connection when something fails). I have created DIR-1615 to look at this in more detail.
* I created a component ApiError that should be reusable on every page where we want to pull the `error` prop from a useQuery hook and display an error, so we don't need to implement typesafe parsing of the error etc. on every page.
* It is possible to define a custom label for the error message on every page to make it context dependent, but there is also a fallback default label if no label is provided. Additionally, the alert will render human readable error message from the API response (if present).
* I updated the ApiErrorSchema. It will now include the http status response code, and if present, the response body under "body" (previously "json"). The original response will not be included (we never used it and it would be complicated to do so). I also updated our documentation/comments in errorHandling.ts.

Test notes:
* I added a test that mocks an error response for the logs on monitoring.
* I added a test to mock an error response for instance logs as well, and added a note in DIR-1595 to integrate it with the currently broken tests when they are fixed.

Review notes:
To fake an error outside of the tests, you could hard code this in `src/pages/namespace/Monitoring/Logs/index.tsx` instead of the useQuery error:

```
  const error: QueryErrorType = {
    status: 422,
    body: { code: 422, message: "oh no!" },
  };
```

Layout notes:
In theory, it is possible to have logs as well as errors (e.g., when only one of multiple requests fails). So I covered both cases in development (but only with fake/mock errors).

Screenshot with full and empty logs below. At first glance there do not seem to be problems with the height of the virtualizer container, but I haven't tested this extensively. I see a risk that there will be problems when an error appears after the list has already loaded (but that seems like an unlikely edge case).

![image](https://github.com/direktiv/direktiv/assets/129740294/7222d203-dd70-4f88-af97-46d77f2239bd)

![image](https://github.com/direktiv/direktiv/assets/129740294/18ae23e1-6ffa-492c-bc22-1cccf835c21c)

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
