### PR TITLE
[DIR-1645] Add UI support for creating typescript-workflows

### DIFF
--- a/ui/.env.example
+++ b/ui/.env.example
@@ -13,6 +13,9 @@ VITE_DEV_API_DOMAIN="http://api.for.development.com"
 # as the API token will be entered via the UI and saved in local storage.
 # VITE_E2E_API_TOKEN="abcde"
 
+# feature flag: enable option to create typescript-workflows in create workflow form.
+VITE_ENABLE_TS_WORKFLOWS="FALSE" # true or TRUE will evaluate to true, everything else will be false
+
 # enable react query dev tools (only for dev server, they will always be excluded in production builds)
 VITE_RQ_DEV_TOOLS="FALSE" # true or TRUE will evaluate to true, everything else will be false
 

--- a/ui/e2e/events/listeners.spec.ts
+++ b/ui/e2e/events/listeners.spec.ts
@@ -24,10 +24,10 @@ test("it renders event listeners", async ({ page }) => {
     (_, index) => `workflow${index}.yaml`
   );
 
-  const yaml = simpleListenerYaml;
+  const content = simpleListenerYaml;
 
   await Promise.all(
-    workflowNames.map((name) => createListener({ name, namespace, yaml }))
+    workflowNames.map((name) => createListener({ name, namespace, content }))
   );
 
   /* visit page and assert a list of listeners is rendered */
@@ -86,10 +86,10 @@ test("it paginates event listeners", async ({ page }) => {
     (_, index) => `workflow${index}.yaml`
   );
 
-  const yaml = simpleListenerYaml;
+  const content = simpleListenerYaml;
 
   await Promise.all(
-    workflowNames.map((name) => createListener({ name, namespace, yaml }))
+    workflowNames.map((name) => createListener({ name, namespace, content }))
   );
 
   /* visit page and assert a list of listeners is rendered */
@@ -133,11 +133,11 @@ test("it paginates event listeners", async ({ page }) => {
 
 test("it renders event context filters", async ({ page }) => {
   /* set up test data */
-  const yaml = contextFiltersListenerYaml;
+  const content = contextFiltersListenerYaml;
   await createListener({
     name: "listener.yaml",
     namespace,
-    yaml,
+    content,
   });
 
   /* visit page and assert filters rendered */

--- a/ui/e2e/events/utils.ts
+++ b/ui/e2e/events/utils.ts
@@ -33,16 +33,16 @@ states:
 export const createListener = async ({
   name,
   namespace,
-  yaml,
+  content,
 }: {
   name: string;
   namespace: string;
-  yaml: string;
+  content: string;
 }) => {
   await createFile({
     name,
     namespace,
     type: "workflow",
-    yaml,
+    content,
   });
 };

--- a/ui/e2e/explorer/route/index.spec.ts
+++ b/ui/e2e/explorer/route/index.spec.ts
@@ -138,7 +138,7 @@ test("it is possible to add plugins to a route file", async ({ page }) => {
     namespace,
     name: filename,
     type: "endpoint",
-    yaml: initialRouteYaml,
+    content: initialRouteYaml,
   });
 
   await page.goto(`/n/${namespace}/explorer/endpoint/${filename}`, {
@@ -424,7 +424,7 @@ test("it blocks navigation when there are unsaved changes", async ({
     namespace,
     name: filename,
     type: "endpoint",
-    yaml: initialRouteYaml,
+    content: initialRouteYaml,
   });
 
   /* visit page */
@@ -495,7 +495,7 @@ test("it does not block navigation when only formatting has changed", async ({
     namespace,
     name: filename,
     type: "endpoint",
-    yaml: initialRouteYaml,
+    content: initialRouteYaml,
   });
 
   /* visit page */

--- a/ui/e2e/explorer/service/utils.ts
+++ b/ui/e2e/explorer/service/utils.ts
@@ -45,12 +45,12 @@ patches: ${createPatchesYaml(patches)}
 envs: ${createEnvsYaml(envs)}`;
 
 export const createService = async (namespace: string, service: Service) => {
-  const yaml = createServiceYaml(service);
+  const content = createServiceYaml(service);
 
   await createFile({
     name: service.name,
     namespace,
     type: "service",
-    yaml,
+    content,
   });
 };

--- a/ui/e2e/explorer/workflow/diagramEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/diagramEditor.spec.ts
@@ -1,9 +1,9 @@
 import { Page, expect, test } from "@playwright/test";
 import { createNamespace, deleteNamespace } from "../../utils/namespace";
 
-import { consumeEvent as consumeEventWorkflow } from "~/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates";
 import { createFile } from "e2e/utils/files";
 import { faker } from "@faker-js/faker";
+import { workflowTemplates } from "~/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates";
 
 let namespace = "";
 let workflow = "";
@@ -33,7 +33,7 @@ test.beforeEach(async () => {
     name: workflow,
     namespace,
     type: "workflow",
-    content: consumeEventWorkflow.data,
+    content: workflowTemplates.yaml.consumeEvent,
   });
 });
 

--- a/ui/e2e/explorer/workflow/diagramEditor.spec.ts
+++ b/ui/e2e/explorer/workflow/diagramEditor.spec.ts
@@ -33,7 +33,7 @@ test.beforeEach(async () => {
     name: workflow,
     namespace,
     type: "workflow",
-    yaml: consumeEventWorkflow.data,
+    content: consumeEventWorkflow.data,
   });
 });
 

--- a/ui/e2e/explorer/workflow/run.spec.ts
+++ b/ui/e2e/explorer/workflow/run.spec.ts
@@ -33,7 +33,7 @@ test("it is possible to open and use the run workflow modal from the editor and 
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: basicWorkflow.data,
+    content: basicWorkflow.data,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -101,7 +101,7 @@ test("it is possible to run the workflow by setting an input JSON via the editor
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: basicWorkflow.data,
+    content: basicWorkflow.data,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -176,7 +176,7 @@ test("it is possible to run a workflow with input data containing special charac
     name,
     namespace,
     type: "workflow",
-    yaml: testDiacriticsWorkflow,
+    content: testDiacriticsWorkflow,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${name}`);
@@ -209,7 +209,7 @@ test("it is not possible to run the workflow when the editor has unsaved changes
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: basicWorkflow.data,
+    content: basicWorkflow.data,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -242,7 +242,7 @@ test("it is possible to provide the input via generated form", async ({
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: jsonSchemaFormWorkflow,
+    content: jsonSchemaFormWorkflow,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -360,7 +360,7 @@ test("it is possible to provide the input via generated form and resolve form er
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: jsonSchemaWithRequiredEnum,
+    content: jsonSchemaWithRequiredEnum,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -450,7 +450,7 @@ test("it is possible to provide the input via Form Input and see the same data i
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: jsonSchemaWithRequiredEnum,
+    content: jsonSchemaWithRequiredEnum,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -536,7 +536,7 @@ test("it is possible to provide the input via JSON Input and see the same data i
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: jsonSchemaWithRequiredEnum,
+    content: jsonSchemaWithRequiredEnum,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -626,7 +626,7 @@ test("the input is synchronized between tabs, but the data that is currently in 
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: jsonSchemaWithRequiredEnum,
+    content: jsonSchemaWithRequiredEnum,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -734,7 +734,7 @@ test("switching the window focus will preserve the state of the form", async ({
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: jsonSchemaWithRequiredEnum,
+    content: jsonSchemaWithRequiredEnum,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);

--- a/ui/e2e/explorer/workflow/run.spec.ts
+++ b/ui/e2e/explorer/workflow/run.spec.ts
@@ -6,13 +6,13 @@ import {
   testDiacriticsWorkflow,
 } from "./utils";
 
-import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates";
 import { createFile } from "e2e/utils/files";
 import { decode } from "js-base64";
 import { faker } from "@faker-js/faker";
 import { getInstanceInput } from "~/api/instances/query/input";
 import { headers } from "e2e/utils/testutils";
 import { prettifyJsonString } from "~/util/helpers";
+import { workflowTemplates } from "~/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates";
 
 let namespace = "";
 
@@ -33,7 +33,7 @@ test("it is possible to open and use the run workflow modal from the editor and 
     name: workflowName,
     namespace,
     type: "workflow",
-    content: basicWorkflow.data,
+    content: workflowTemplates.yaml.noop,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -101,7 +101,7 @@ test("it is possible to run the workflow by setting an input JSON via the editor
     name: workflowName,
     namespace,
     type: "workflow",
-    content: basicWorkflow.data,
+    content: workflowTemplates.yaml.noop,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);
@@ -209,7 +209,7 @@ test("it is not possible to run the workflow when the editor has unsaved changes
     name: workflowName,
     namespace,
     type: "workflow",
-    content: basicWorkflow.data,
+    content: workflowTemplates.yaml.noop,
   });
 
   await page.goto(`/n/${namespace}/explorer/workflow/edit/${workflowName}`);

--- a/ui/e2e/explorer/workflow/settings.spec.ts
+++ b/ui/e2e/explorer/workflow/settings.spec.ts
@@ -2,7 +2,6 @@ import { createNamespace, deleteNamespace } from "../../utils/namespace";
 import { expect, test } from "@playwright/test";
 import { waitForSuccessToast, workflowThatCreatesVariable } from "./utils";
 
-import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates";
 import { createFile } from "e2e/utils/files";
 import { createInstance } from "~/api/instances/mutate/create";
 import { createVar } from "~/api/variables/mutate/create";
@@ -11,6 +10,7 @@ import { encode } from "js-base64";
 import { faker } from "@faker-js/faker";
 import { forceLeadingSlash } from "~/api/files/utils";
 import { headers } from "e2e/utils/testutils";
+import { workflowTemplates } from "~/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates";
 
 let namespace = "";
 let workflow = "";
@@ -23,7 +23,7 @@ test.beforeEach(async () => {
     name: workflow,
     namespace,
     type: "workflow",
-    content: basicWorkflow.data,
+    content: workflowTemplates.yaml.noop,
   });
 });
 

--- a/ui/e2e/explorer/workflow/settings.spec.ts
+++ b/ui/e2e/explorer/workflow/settings.spec.ts
@@ -23,7 +23,7 @@ test.beforeEach(async () => {
     name: workflow,
     namespace,
     type: "workflow",
-    yaml: basicWorkflow.data,
+    content: basicWorkflow.data,
   });
 });
 
@@ -257,7 +257,7 @@ test("it is possible to rename a variable that doesn't have a mimeType", async (
     name: workflowName,
     namespace,
     type: "workflow",
-    yaml: workflowThatCreatesVariable,
+    content: workflowThatCreatesVariable,
   });
 
   await createInstance({

--- a/ui/e2e/gateway/consumers/index.spec.ts
+++ b/ui/e2e/gateway/consumers/index.spec.ts
@@ -39,7 +39,7 @@ test("Consumer list shows all available consumers", async ({ page }) => {
     name: "redis-consumer.yaml",
     namespace,
     type: "consumer",
-    yaml: createRedisConsumerFile({
+    content: createRedisConsumerFile({
       username: "userA",
       password: "password",
     }),
@@ -116,7 +116,7 @@ test("Consumer list will update the consumers when refetch button is clicked", a
     name: "consumer.yaml",
     namespace,
     type: "consumer",
-    yaml: createRedisConsumerFile({
+    content: createRedisConsumerFile({
       username: "userOld",
       password: "passwordOld",
     }),

--- a/ui/e2e/gateway/routes/details/index.spec.ts
+++ b/ui/e2e/gateway/routes/details/index.spec.ts
@@ -29,7 +29,7 @@ test("Route details page shows all important information about the route", async
     name: fileName,
     namespace,
     type: "endpoint",
-    yaml: createRouteFile({
+    content: createRouteFile({
       path,
       targetType: "instant-response",
       targetConfigurationStatus: "202",
@@ -129,7 +129,7 @@ test("Route details page shows warning if the route was not configured correctly
     name: fileName,
     namespace,
     type: "endpoint",
-    yaml: routeWithAnError,
+    content: routeWithAnError,
   });
 
   await expect

--- a/ui/e2e/gateway/routes/list/index.spec.ts
+++ b/ui/e2e/gateway/routes/list/index.spec.ts
@@ -42,7 +42,7 @@ test("Route list shows all available routes", async ({ page }) => {
     name: "my-route.yaml",
     namespace,
     type: "endpoint",
-    yaml: createRouteFile({
+    content: createRouteFile({
       path,
       targetType: "instant-response",
       targetConfigurationStatus: "202",
@@ -126,7 +126,7 @@ test("Route list shows an error on no target plugin", async ({ page }) => {
     name: "my-route.yaml",
     namespace,
     type: "endpoint",
-    yaml: routeWithAWarning,
+    content: routeWithAWarning,
   });
 
   await expect
@@ -167,7 +167,7 @@ test("Route list shows an error", async ({ page }) => {
     name: "my-route.yaml",
     namespace,
     type: "endpoint",
-    yaml: routeWithAnError,
+    content: routeWithAnError,
   });
 
   await expect
@@ -214,7 +214,7 @@ test("Route list links the file name to the route file", async ({ page }) => {
     name: "my-route.yaml",
     namespace,
     type: "endpoint",
-    yaml: createRouteFile(),
+    content: createRouteFile(),
   });
 
   await page.goto(`/n/${namespace}/gateway/routes`, {

--- a/ui/e2e/instances/details/diagram.spec.ts
+++ b/ui/e2e/instances/details/diagram.spec.ts
@@ -25,28 +25,28 @@ test.beforeEach(async ({ page }) => {
     name: simpleWorkflowName,
     namespace,
     type: "workflow",
-    yaml: simpleWorkflowContent,
+    content: simpleWorkflowContent,
   });
 
   await createFile({
     name: delayedWorkflowName,
     namespace,
     type: "workflow",
-    yaml: delayedWorkflowContent,
+    content: delayedWorkflowContent,
   });
 
   await createFile({
     name: fewLogsWorkflowName,
     namespace,
     type: "workflow",
-    yaml: fewLogsWorkflowContent,
+    content: fewLogsWorkflowContent,
   });
 
   await createFile({
     name: manyLogsWorkflowName,
     namespace,
     type: "workflow",
-    yaml: manyLogsWorkflowContent,
+    content: manyLogsWorkflowContent,
   });
 
   await mockClipboardAPI(page);

--- a/ui/e2e/instances/details/header.spec.ts
+++ b/ui/e2e/instances/details/header.spec.ts
@@ -25,28 +25,28 @@ test.beforeEach(async ({ page }) => {
     name: simpleWorkflowName,
     namespace,
     type: "workflow",
-    yaml: simpleWorkflowContent,
+    content: simpleWorkflowContent,
   });
 
   await createFile({
     name: delayedWorkflowName,
     namespace,
     type: "workflow",
-    yaml: delayedWorkflowContent,
+    content: delayedWorkflowContent,
   });
 
   await createFile({
     name: fewLogsWorkflowName,
     namespace,
     type: "workflow",
-    yaml: fewLogsWorkflowContent,
+    content: fewLogsWorkflowContent,
   });
 
   await createFile({
     name: manyLogsWorkflowName,
     namespace,
     type: "workflow",
-    yaml: manyLogsWorkflowContent,
+    content: manyLogsWorkflowContent,
   });
 
   await mockClipboardAPI(page);

--- a/ui/e2e/instances/details/inputOutput.spec.ts
+++ b/ui/e2e/instances/details/inputOutput.spec.ts
@@ -25,28 +25,28 @@ test.beforeEach(async ({ page }) => {
     name: simpleWorkflowName,
     namespace,
     type: "workflow",
-    yaml: simpleWorkflowContent,
+    content: simpleWorkflowContent,
   });
 
   await createFile({
     name: delayedWorkflowName,
     namespace,
     type: "workflow",
-    yaml: delayedWorkflowContent,
+    content: delayedWorkflowContent,
   });
 
   await createFile({
     name: fewLogsWorkflowName,
     namespace,
     type: "workflow",
-    yaml: fewLogsWorkflowContent,
+    content: fewLogsWorkflowContent,
   });
 
   await createFile({
     name: manyLogsWorkflowName,
     namespace,
     type: "workflow",
-    yaml: manyLogsWorkflowContent,
+    content: manyLogsWorkflowContent,
   });
 
   await mockClipboardAPI(page);

--- a/ui/e2e/instances/details/logs.spec.ts
+++ b/ui/e2e/instances/details/logs.spec.ts
@@ -33,7 +33,7 @@ test("the logs panel can be resized, it displays a log message from the workflow
     name: fewLogsWorkflowName,
     namespace,
     type: "workflow",
-    yaml: fewLogsWorkflowContent,
+    content: fewLogsWorkflowContent,
   });
 
   const instanceId = (
@@ -133,7 +133,7 @@ test("the logs panel can be toggled between verbose and non verbose logs", async
     name: simpleWorkflowName,
     namespace,
     type: "workflow",
-    yaml: simpleWorkflowContent,
+    content: simpleWorkflowContent,
   });
 
   const instanceId = (
@@ -195,7 +195,7 @@ test("the logs can be copied", async ({ page }) => {
     name: simpleWorkflowName,
     namespace,
     type: "workflow",
-    yaml: simpleWorkflowContent,
+    content: simpleWorkflowContent,
   });
 
   const instanceId = (
@@ -239,7 +239,7 @@ test("log entries will be automatically scrolled to the end", async ({
     name: manyLogsWorkflowName,
     namespace,
     type: "workflow",
-    yaml: manyLogsWorkflowContent,
+    content: manyLogsWorkflowContent,
   });
 
   const instanceId = (
@@ -341,7 +341,7 @@ test("it renders an error when the api response returns an error", async ({
     name: simpleWorkflowName,
     namespace,
     type: "workflow",
-    yaml: simpleWorkflowContent,
+    content: simpleWorkflowContent,
   });
 
   const instanceId = (

--- a/ui/e2e/instances/filter/index.spec.ts
+++ b/ui/e2e/instances/filter/index.spec.ts
@@ -21,14 +21,14 @@ test.beforeEach(async () => {
     name: simpleWorkflowName,
     namespace,
     type: "workflow",
-    yaml: simpleWorkflowContent,
+    content: simpleWorkflowContent,
   });
 
   await createFile({
     name: failingWorkflowName,
     namespace,
     type: "workflow",
-    yaml: workflowThatFailsContent,
+    content: workflowThatFailsContent,
   });
 });
 
@@ -54,7 +54,7 @@ const createTriggerFilterInstances = async () => {
     name: parentWorkflowName,
     namespace,
     type: "workflow",
-    yaml: parentWorkflowContent({
+    content: parentWorkflowContent({
       childPath: `/${simpleWorkflowName}`,
       children: 2,
     }),
@@ -262,7 +262,7 @@ test("it is possible to filter by AS (name)", async ({ page }) => {
   await Promise.all(
     workflowNames.map((name) =>
       createFile({
-        yaml: simpleWorkflowContent,
+        content: simpleWorkflowContent,
         namespace,
         name,
         type: "workflow",
@@ -332,7 +332,7 @@ test("it is possible to apply multiple filters", async ({ page }) => {
   await Promise.all(
     workflowNames.map((name) =>
       createFile({
-        yaml: simpleWorkflowContent,
+        content: simpleWorkflowContent,
         name,
         namespace,
         type: "workflow",

--- a/ui/e2e/instances/list/index.spec.ts
+++ b/ui/e2e/instances/list/index.spec.ts
@@ -28,21 +28,21 @@ test.beforeEach(async () => {
     name: simpleWorkflowName,
     namespace,
     type: "workflow",
-    yaml: simpleWorkflowContent,
+    content: simpleWorkflowContent,
   });
 
   await createFile({
     name: failingWorkflowName,
     namespace,
     type: "workflow",
-    yaml: workflowThatFailsContent,
+    content: workflowThatFailsContent,
   });
 
   await createFile({
     name: longRunningWorkflowName,
     namespace,
     type: "workflow",
-    yaml: workflowWithDelayContent,
+    content: workflowWithDelayContent,
   });
 });
 
@@ -248,7 +248,7 @@ test("it provides a proper pagination", async ({ page }) => {
 
   const parentWorkflow = faker.system.commonFileName("yaml");
 
-  const yaml = parentWorkflowContent({
+  const content = parentWorkflowContent({
     childPath: `/${simpleWorkflowName}`,
     children: totalCount - 1,
   });
@@ -257,7 +257,7 @@ test("it provides a proper pagination", async ({ page }) => {
     name: parentWorkflow,
     namespace,
     type: "workflow",
-    yaml,
+    content,
   });
 
   await createInstance({ namespace, path: parentWorkflow }),
@@ -340,7 +340,7 @@ test("It will display child instances as well", async ({ page }) => {
     name: parentWorkflow,
     namespace,
     type: "workflow",
-    yaml: parentWorkflowContent({
+    content: parentWorkflowContent({
       childPath: `/${simpleWorkflowName}`,
       children: 1,
     }),

--- a/ui/e2e/notificationmenu/index.spec.ts
+++ b/ui/e2e/notificationmenu/index.spec.ts
@@ -43,7 +43,7 @@ test("Notification Bell updates depending on the count of Notification Messages"
     name: "worfklow-with-secrets.yaml",
     namespace,
     type: "workflow",
-    yaml: workflowWithSecrets,
+    content: workflowWithSecrets,
   });
 
   await page.goto(`/n/${namespace}/explorer/tree`, {

--- a/ui/e2e/services/details.spec.ts
+++ b/ui/e2e/services/details.spec.ts
@@ -26,7 +26,7 @@ test("Service details page provides information about the service", async ({
     name: "request-service.yaml",
     namespace,
     type: "service",
-    yaml: createRequestServiceFile({ scale: 2 }),
+    content: createRequestServiceFile({ scale: 2 }),
   });
 
   await expect
@@ -163,7 +163,7 @@ test("Service details page renders no logs when the service did not mount", asyn
     name: "error-service.yaml",
     namespace,
     type: "service",
-    yaml: serviceWithAnError,
+    content: serviceWithAnError,
   });
 
   await expect

--- a/ui/e2e/services/list.spec.ts
+++ b/ui/e2e/services/list.spec.ts
@@ -43,7 +43,7 @@ test("Service list shows all available services", async ({ page }) => {
     name: "http-service.yaml",
     namespace,
     type: "service",
-    yaml: createHttpServiceFile(),
+    content: createHttpServiceFile(),
   });
 
   await expect
@@ -129,7 +129,7 @@ test("Service list links the file name to the service file", async ({
     name: "http-service.yaml",
     namespace,
     type: "service",
-    yaml: createHttpServiceFile(),
+    content: createHttpServiceFile(),
   });
 
   await page.goto(`/n/${namespace}/services`, {
@@ -159,7 +159,7 @@ test("Service list links the row to the service details page", async ({
     name: "http-service.yaml",
     namespace,
     type: "service",
-    yaml: createHttpServiceFile(),
+    content: createHttpServiceFile(),
   });
 
   await expect
@@ -211,7 +211,7 @@ test("Service list lets the user rebuild a service", async ({ page }) => {
     name: "http-service.yaml",
     namespace,
     type: "service",
-    yaml: createHttpServiceFile(),
+    content: createHttpServiceFile(),
   });
 
   await expect
@@ -262,7 +262,7 @@ test("Service list highlights services that have errors", async ({ page }) => {
     name: "failed-service.yaml",
     namespace,
     type: "service",
-    yaml: serviceWithAnError,
+    content: serviceWithAnError,
   });
 
   await expect
@@ -305,7 +305,7 @@ test("Service list will update the services when refetch button is clicked", asy
     name: "http-service.yaml",
     namespace,
     type: "service",
-    yaml: createHttpServiceFile({
+    content: createHttpServiceFile({
       scale: 1,
       size: "large",
     }),
@@ -377,7 +377,7 @@ test.describe("system namespace", () => {
       name: systemServiceName,
       namespace: systemNamespaceName,
       type: "service",
-      yaml: createHttpServiceFile(),
+      content: createHttpServiceFile(),
     });
   });
 

--- a/ui/e2e/utils/files.ts
+++ b/ui/e2e/utils/files.ts
@@ -8,21 +8,21 @@ import { headers } from "./testutils";
 
 export const createFile = async ({
   name,
-  yaml,
+  content,
   namespace,
   type,
   mimeType = "application/yaml",
   path = "/",
 }: {
   name: string;
-  yaml: string;
+  content: string;
   namespace: string;
   type: "workflow" | "consumer" | "endpoint" | "service";
   mimeType?: (typeof workflowMimeTypes)[number];
   path?: string;
 }) => {
   const payload = CreateFileSchema.parse({
-    data: encode(yaml),
+    data: encode(content),
     name,
     mimeType,
     type,

--- a/ui/e2e/utils/files.ts
+++ b/ui/e2e/utils/files.ts
@@ -1,3 +1,5 @@
+import { CreateFileSchema, workflowMimeTypes } from "~/api/files/schema";
+
 import { createFile as apiCreateFile } from "~/api/files/mutate/createFile";
 import { deleteFile as apiDeleteFile } from "~/api/files/mutate/deleteFile";
 import { getFile as apiGetFile } from "~/api/files/query/file";
@@ -9,21 +11,25 @@ export const createFile = async ({
   yaml,
   namespace,
   type,
+  mimeType = "application/yaml",
   path = "/",
 }: {
   name: string;
   yaml: string;
   namespace: string;
   type: "workflow" | "consumer" | "endpoint" | "service";
+  mimeType?: (typeof workflowMimeTypes)[number];
   path?: string;
-}) =>
-  await apiCreateFile({
-    payload: {
-      data: encode(yaml),
-      name,
-      mimeType: "application/yaml",
-      type,
-    },
+}) => {
+  const payload = CreateFileSchema.parse({
+    data: encode(yaml),
+    name,
+    mimeType,
+    type,
+  });
+
+  return await apiCreateFile({
+    payload,
     urlParams: {
       baseUrl: process.env.PLAYWRIGHT_UI_BASE_URL,
       namespace,
@@ -31,6 +37,7 @@ export const createFile = async ({
     },
     headers,
   });
+};
 
 export const deleteFile = async ({
   namespace,

--- a/ui/e2e/utils/files.ts
+++ b/ui/e2e/utils/files.ts
@@ -1,4 +1,3 @@
-import { CreateFileSchemaType } from "~/api/files/schema";
 import { createFile as apiCreateFile } from "~/api/files/mutate/createFile";
 import { deleteFile as apiDeleteFile } from "~/api/files/mutate/deleteFile";
 import { getFile as apiGetFile } from "~/api/files/query/file";
@@ -15,7 +14,7 @@ export const createFile = async ({
   name: string;
   yaml: string;
   namespace: string;
-  type: CreateFileSchemaType["type"];
+  type: "workflow" | "consumer" | "endpoint" | "service";
   path?: string;
 }) =>
   await apiCreateFile({

--- a/ui/e2e/utils/workflow.ts
+++ b/ui/e2e/utils/workflow.ts
@@ -14,7 +14,7 @@ export const createWorkflow = async (namespace: string, name: string) => {
     namespace,
     name,
     type: "workflow",
-    yaml: noopYaml,
+    content: noopYaml,
   });
 
   if (response.data.type !== "workflow") {

--- a/ui/src/api/files/schema.ts
+++ b/ui/src/api/files/schema.ts
@@ -109,6 +109,8 @@ const CreateServiceSchema = CreateYamlFileSchema.extend({
 
 export const workflowTypes = ["yaml", "typescript"] as const;
 
+export type WorkflowType = (typeof workflowTypes)[number];
+
 export const workflowMimeTypes = [
   "application/yaml",
   "application/x-typescript",

--- a/ui/src/api/files/schema.ts
+++ b/ui/src/api/files/schema.ts
@@ -109,9 +109,14 @@ const CreateServiceSchema = CreateYamlFileSchema.extend({
 
 export const workflowTypes = ["yaml", "typescript"] as const;
 
+export const workflowMimeTypes = [
+  "application/yaml",
+  "application/x-typescript",
+] as const;
+
 const CreateWorkflowSchema = CreateYamlFileSchema.extend({
   type: z.literal("workflow"),
-  mimeType: z.enum(workflowTypes),
+  mimeType: z.enum(workflowMimeTypes),
 });
 
 const CreateFileSchema = z.discriminatedUnion("type", [

--- a/ui/src/api/files/schema.ts
+++ b/ui/src/api/files/schema.ts
@@ -107,8 +107,11 @@ const CreateServiceSchema = CreateYamlFileSchema.extend({
   type: z.literal("service"),
 });
 
+export const workflowTypes = ["yaml", "typescript"] as const;
+
 const CreateWorkflowSchema = CreateYamlFileSchema.extend({
   type: z.literal("workflow"),
+  mimeType: z.enum(workflowTypes),
 });
 
 const CreateFileSchema = z.discriminatedUnion("type", [

--- a/ui/src/api/files/schema.ts
+++ b/ui/src/api/files/schema.ts
@@ -119,7 +119,7 @@ const CreateWorkflowSchema = CreateYamlFileSchema.extend({
   mimeType: z.enum(workflowMimeTypes),
 });
 
-const CreateFileSchema = z.discriminatedUnion("type", [
+export const CreateFileSchema = z.discriminatedUnion("type", [
   CreateDirectorySchema,
   CreateConsumerSchema,
   CreateEndpointSchema,

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -99,10 +99,13 @@
           "title": "Create a new workflow",
           "nameLabel": "Name",
           "namePlaceholder": "workflow-name.yaml",
-          "templateLabel": "Template",
           "nameAlreadyExists": "The name already exists",
           "cancelBtn": "Cancel",
           "createBtn": "Create",
+          "template": {
+            "label": "Template",
+            "placeholder": "Select template"
+          },
           "type": {
             "label": "Type",
             "yaml": "yaml",

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -102,7 +102,13 @@
           "templateLabel": "Template",
           "nameAlreadyExists": "The name already exists",
           "cancelBtn": "Cancel",
-          "createBtn": "Create"
+          "createBtn": "Create",
+          "type": {
+            "label": "Type",
+            "yaml": "yaml",
+            "typescript": "Typescript (experimental)",
+            "placeholder": "Select workflow type"
+          }
         },
         "newService": {
           "title": "Create a new service",

--- a/ui/src/config/env/schema.ts
+++ b/ui/src/config/env/schema.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
+const boolean = z
+  .string()
+  .optional()
+  .transform((value) => `${value}`.toLocaleLowerCase() === "true");
+
 export const envVariablesSchema = z.object({
   VITE_DEV_API_DOMAIN: z.string().optional(),
-  VITE_RQ_DEV_TOOLS: z
-    .string()
-    .optional()
-    .transform((value) => `${value}`.toLocaleLowerCase() === "true"),
+  VITE_RQ_DEV_TOOLS: boolean,
+  VITE_ENABLE_TS_WORKFLOWS: boolean,
 });

--- a/ui/src/hooks/useTsEditorLibs.ts
+++ b/ui/src/hooks/useTsEditorLibs.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import workflowTsDefinition from "~/assets/ts/workflow.d.ts?raw";
+
+const useTsEditorLibs = (enabled: boolean) =>
+  useMemo(
+    () =>
+      enabled
+        ? [
+            {
+              content: workflowTsDefinition,
+            },
+          ]
+        : [],
+    [enabled]
+  );
+
+export default useTsEditorLibs;

--- a/ui/src/hooks/useTsWorkflowLibs.ts
+++ b/ui/src/hooks/useTsWorkflowLibs.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import workflowTsDefinition from "~/assets/ts/workflow.d.ts?raw";
 
-const useTsEditorLibs = (enabled: boolean) =>
+const useTsWorkflowLibs = (enabled: boolean) =>
   useMemo(
     () =>
       enabled
@@ -14,4 +14,4 @@ const useTsEditorLibs = (enabled: boolean) =>
     [enabled]
   );
 
-export default useTsEditorLibs;
+export default useTsWorkflowLibs;

--- a/ui/src/pages/namespace/Explorer/Tree/__tests__/utils.test.ts
+++ b/ui/src/pages/namespace/Explorer/Tree/__tests__/utils.test.ts
@@ -1,6 +1,9 @@
+import {
+  addFileExtension,
+  addYamlFileExtension,
+  stripFileExtension,
+} from "../utils";
 import { describe, expect, test } from "vitest";
-
-import { addYamlFileExtension } from "../utils";
 
 describe("addYamlFileExtension", () => {
   test("it adds .yaml to a string that does not end on .yaml or yml", () => {
@@ -19,11 +22,58 @@ describe("addYamlFileExtension", () => {
     expect(addYamlFileExtension(" somefile.yaml ")).toBe("somefile.yaml");
   });
 
-  test("it will do nothing when the string ends with .yaml", () => {
+  test("it does nothing when the string ends with .yaml", () => {
     expect(addYamlFileExtension("some-file.yaml")).toBe("some-file.yaml");
   });
 
-  test("it will do nothing when the string ends with .yml", () => {
+  test("it does nothing when the string ends with .yml", () => {
     expect(addYamlFileExtension("some-file.yml")).toBe("some-file.yml");
+  });
+});
+
+describe("stripFileExtension", () => {
+  const subject = stripFileExtension;
+  test("it strips the provided extension from the name", () => {
+    expect(subject("name.foo.ts", "foo.ts")).toBe("name");
+  });
+  test("it strips the last segment from the file name if it matches a part of the provided extension", () => {
+    expect(subject("name.ts", "foo.ts")).toBe("name");
+    expect(subject("name.foo", "foo.ts")).toBe("name");
+  });
+});
+
+describe("addFileExtension", () => {
+  const subject = addFileExtension;
+  const extension = ".workflow.ts";
+
+  test("it adds the extension .workflow.ts", () => {
+    expect(subject("some", extension)).toBe("some.workflow.ts");
+  });
+
+  test("it does not duplicate existing partial extensions", () => {
+    expect(subject("some.ts", extension)).toBe("some.workflow.ts");
+    expect(subject("some.workflow", extension)).toBe("some.workflow.ts");
+    expect(subject("some.workflow.ts", extension)).toBe("some.workflow.ts");
+  });
+
+  test("it preserves segments separated with a dot", () => {
+    expect(subject("some.name", extension)).toBe("some.name.workflow.ts");
+    expect(subject("some.name.ts", extension)).toBe("some.name.workflow.ts");
+    expect(subject("some.name.ts", extension)).toBe("some.name.workflow.ts");
+    expect(subject("some.name.workflow", extension)).toBe(
+      "some.name.workflow.ts"
+    );
+  });
+
+  test("it trims the input before adding the extension .workflow.ts ", () => {
+    expect(subject("some ", extension)).toBe("some.workflow.ts");
+    expect(subject(" some", extension)).toBe("some.workflow.ts");
+    expect(subject(" some ", extension)).toBe("some.workflow.ts");
+  });
+
+  test("it trims the input even when extension already exists", () => {
+    expect(subject("some.workflow.ts ", extension)).toBe("some.workflow.ts");
+    expect(subject(" some.workflow.ts", extension)).toBe("some.workflow.ts");
+    expect(subject(" some.workflow.ts ", extension)).toBe("some.workflow.ts");
   });
 });

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -51,9 +51,13 @@ type FormInput = {
 const getFirstTemplateFor = (type: WorkflowType) => {
   const entry = Object.entries(workflowTemplates[type])[0];
   if (!entry) {
-    throw Error("no!");
+    throw Error(`No workflow template exists for ${type}`);
   }
-  return entry[1];
+  const [name, data] = entry;
+  return {
+    name,
+    data,
+  };
 };
 
 const NewWorkflow = ({
@@ -147,7 +151,7 @@ const NewWorkflow = ({
 
   const formId = `new-worfklow-${path}`;
 
-  const workflowType: (typeof workflowTypes)[number] = watch("workflowType");
+  const workflowType: WorkflowType = watch("workflowType");
 
   const selectedTemplateName: string = watch("selectedTemplateName");
 
@@ -188,7 +192,7 @@ const NewWorkflow = ({
             </label>
             <Select
               value={workflowType}
-              onValueChange={(value: (typeof workflowTypes)[number]) => {
+              onValueChange={(value: WorkflowType) => {
                 setValue("workflowType", value);
 
                 const match = getFirstTemplateFor(value);
@@ -229,7 +233,7 @@ const NewWorkflow = ({
                 const match = workflowTemplates[workflowType][value];
                 if (match) {
                   setValue("selectedTemplateName", value);
-                  setWorkflowData(match.data);
+                  setWorkflowData(match);
                 }
               }}
             >

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -39,6 +39,8 @@ import { workflowTemplates } from "./templates";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
+const enableTSWorkflows = process.env.VITE?.VITE_ENABLE_TS_WORKFLOWS;
+
 const defaultType: WorkflowType = "yaml";
 
 type FormInput = {
@@ -195,40 +197,45 @@ const NewWorkflow = ({
               {...register("name")}
             />
           </fieldset>
-          <fieldset className="flex items-center gap-5">
-            <label className="w-[100px] text-right text-[14px]" htmlFor="type">
-              {t("pages.explorer.tree.newWorkflow.type.label")}
-            </label>
-            <Select
-              value={workflowType}
-              onValueChange={(value: WorkflowType) => {
-                setValue("workflowType", value);
+          {enableTSWorkflows && (
+            <fieldset className="flex items-center gap-5">
+              <label
+                className="w-[100px] text-right text-[14px]"
+                htmlFor="type"
+              >
+                {t("pages.explorer.tree.newWorkflow.type.label")}
+              </label>
+              <Select
+                value={workflowType}
+                onValueChange={(value: WorkflowType) => {
+                  setValue("workflowType", value);
 
-                const match = getFirstTemplateFor(value);
-                if (match) {
-                  setValue("selectedTemplateName", match.name);
-                  setValue("fileContent", match.data);
-                  setWorkflowData(match.data);
-                }
-              }}
-            >
-              <SelectTrigger id="type" variant="outline" block>
-                <SelectValue
-                  placeholder={t(
-                    "pages.explorer.tree.newWorkflow.type.placeholder"
-                  )}
-                  defaultValue={defaultType}
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {workflowTypes.map((type) => (
-                  <SelectItem value={type} key={type}>
-                    {t(`pages.explorer.tree.newWorkflow.type.${type}`)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </fieldset>
+                  const match = getFirstTemplateFor(value);
+                  if (match) {
+                    setValue("selectedTemplateName", match.name);
+                    setValue("fileContent", match.data);
+                    setWorkflowData(match.data);
+                  }
+                }}
+              >
+                <SelectTrigger id="type" variant="outline" block>
+                  <SelectValue
+                    placeholder={t(
+                      "pages.explorer.tree.newWorkflow.type.placeholder"
+                    )}
+                    defaultValue={defaultType}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {workflowTypes.map((type) => (
+                    <SelectItem value={type} key={type}>
+                      {t(`pages.explorer.tree.newWorkflow.type.${type}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </fieldset>
+          )}
           <fieldset className="flex items-center gap-5">
             <label
               className="w-[100px] text-right text-[14px]"

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -171,6 +171,32 @@ const NewWorkflow = ({
       ? "application/x-typescript"
       : "application/yaml";
 
+  const handleTypeValueChange = (value: WorkflowType) => {
+    setValue("workflowType", value);
+
+    const match = getFirstTemplateFor(value);
+    if (match) {
+      setValue("selectedTemplateName", match.name);
+      setValue("fileContent", match.data);
+      setWorkflowData(match.data);
+    }
+  };
+
+  const handleTemplateValueChange = (value: string) => {
+    const match = currentTemplates.find((template) => template.name === value);
+    if (match) {
+      setValue("selectedTemplateName", match.name);
+      setWorkflowData(match.data);
+    }
+  };
+
+  const handleEditorOnChange = (newData: string | undefined) => {
+    if (newData) {
+      setWorkflowData(newData);
+      setValue("fileContent", newData);
+    }
+  };
+
   return (
     <>
       <DialogHeader>
@@ -207,16 +233,7 @@ const NewWorkflow = ({
               </label>
               <Select
                 value={workflowType}
-                onValueChange={(value: WorkflowType) => {
-                  setValue("workflowType", value);
-
-                  const match = getFirstTemplateFor(value);
-                  if (match) {
-                    setValue("selectedTemplateName", match.name);
-                    setValue("fileContent", match.data);
-                    setWorkflowData(match.data);
-                  }
-                }}
+                onValueChange={handleTypeValueChange}
               >
                 <SelectTrigger id="type" variant="outline" block>
                   <SelectValue
@@ -245,15 +262,7 @@ const NewWorkflow = ({
             </label>
             <Select
               value={selectedTemplateName}
-              onValueChange={(value) => {
-                const match = currentTemplates.find(
-                  (template) => template.name === value
-                );
-                if (match) {
-                  setValue("selectedTemplateName", match.name);
-                  setWorkflowData(match.data);
-                }
-              }}
+              onValueChange={handleTemplateValueChange}
             >
               <SelectTrigger id="template" variant="outline" block>
                 <SelectValue
@@ -276,12 +285,7 @@ const NewWorkflow = ({
             <Card className="h-96 w-full p-4" noShadow background="weight-1">
               <Editor
                 value={workflowData}
-                onChange={(newData) => {
-                  if (newData) {
-                    setWorkflowData(newData);
-                    setValue("fileContent", newData);
-                  }
-                }}
+                onChange={handleEditorOnChange}
                 theme={theme ?? undefined}
               />
             </Card>

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -35,8 +35,8 @@ import { useNotifications } from "~/api/notifications/query/get";
 import { usePages } from "~/util/router/pages";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
+import useTsEditorLibs from "~/hooks/useTsEditorLibs";
 import { workflowTemplates } from "./templates";
-import workflowTsDefinition from "~/assets/ts/workflow.d.ts?raw";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -168,17 +168,7 @@ const NewWorkflow = ({
     [workflowType]
   );
 
-  const tsLibs = useMemo(
-    () =>
-      workflowType === "typescript"
-        ? [
-            {
-              content: workflowTsDefinition,
-            },
-          ]
-        : [],
-    [workflowType]
-  );
+  const tsLibs = useTsEditorLibs(workflowType === "typescript");
 
   const selectedTemplateName: string = watch("selectedTemplateName");
 

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -35,7 +35,7 @@ import { useNotifications } from "~/api/notifications/query/get";
 import { usePages } from "~/util/router/pages";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
-import useTsEditorLibs from "~/hooks/useTsEditorLibs";
+import useTsWorkflowLibs from "~/hooks/useTsWorkflowLibs";
 import { workflowTemplates } from "./templates";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -168,7 +168,7 @@ const NewWorkflow = ({
     [workflowType]
   );
 
-  const tsLibs = useTsEditorLibs(workflowType === "typescript");
+  const tsLibs = useTsWorkflowLibs(workflowType === "typescript");
 
   const selectedTemplateName: string = watch("selectedTemplateName");
 

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "~/design/Select";
 import { SubmitHandler, useForm } from "react-hook-form";
+import { useMemo, useState } from "react";
 
 import Button from "~/design/Button";
 import { Card } from "~/design/Card";
@@ -32,7 +33,6 @@ import { useNamespace } from "~/util/store/namespace";
 import { useNavigate } from "react-router-dom";
 import { useNotifications } from "~/api/notifications/query/get";
 import { usePages } from "~/util/router/pages";
-import { useState } from "react";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
 import { workflowTemplates } from "./templates";
@@ -153,12 +153,13 @@ const NewWorkflow = ({
 
   const workflowType: WorkflowType = watch("workflowType");
 
-  // Todo: memoize; probably will require moving workflowType to useState()
-  const currentTemplates = Object.entries(workflowTemplates[workflowType]).map(
-    ([name, data]) => ({
-      name,
-      data,
-    })
+  const currentTemplates = useMemo(
+    () =>
+      Object.entries(workflowTemplates[workflowType]).map(([name, data]) => ({
+        name,
+        data,
+      })),
+    [workflowType]
   );
 
   const selectedTemplateName: string = watch("selectedTemplateName");

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -153,6 +153,14 @@ const NewWorkflow = ({
 
   const workflowType: WorkflowType = watch("workflowType");
 
+  // Todo: memoize; probably will require moving workflowType to useState()
+  const currentTemplates = Object.entries(workflowTemplates[workflowType]).map(
+    ([name, data]) => ({
+      name,
+      data,
+    })
+  );
+
   const selectedTemplateName: string = watch("selectedTemplateName");
 
   const workflowMimeType =
@@ -230,10 +238,12 @@ const NewWorkflow = ({
             <Select
               value={selectedTemplateName}
               onValueChange={(value) => {
-                const match = workflowTemplates[workflowType][value];
+                const match = currentTemplates.find(
+                  (template) => template.name === value
+                );
                 if (match) {
-                  setValue("selectedTemplateName", value);
-                  setWorkflowData(match);
+                  setValue("selectedTemplateName", match.name);
+                  setWorkflowData(match.data);
                 }
               }}
             >

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -37,6 +37,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type FormInput = {
   name: string;
+  selectedTemplate: string;
   workflowType: (typeof workflowTypes)[number];
   fileContent: string;
 };
@@ -91,6 +92,7 @@ const NewWorkflow = ({
   } = useForm<FormInput>({
     resolver,
     defaultValues: {
+      selectedTemplate: "noop",
       workflowType: "yaml",
       fileContent: defaultWorkflowTemplate.data,
     },
@@ -135,6 +137,8 @@ const NewWorkflow = ({
 
   const workflowType: (typeof workflowTypes)[number] = watch("workflowType");
 
+  const selectedTemplate: string = watch("selectedTemplate");
+
   const workflowMimeType =
     workflowType === "typescript"
       ? "application/x-typescript"
@@ -172,9 +176,20 @@ const NewWorkflow = ({
             </label>
             <Select
               value={workflowType}
-              onValueChange={(value: (typeof workflowTypes)[number]) =>
-                setValue("workflowType", value)
-              }
+              onValueChange={(value: (typeof workflowTypes)[number]) => {
+                setValue("workflowType", value);
+                setValue(
+                  "selectedTemplate",
+                  value === "typescript" ? "TypescriptExample" : "noop"
+                );
+                const match = workflowTemplates.find(
+                  (template) => template.type === value
+                );
+                if (match) {
+                  setValue("fileContent", match.data);
+                  setWorkflowData(match.data);
+                }
+              }}
             >
               <SelectTrigger id="type" variant="outline" block>
                 <SelectValue
@@ -201,13 +216,14 @@ const NewWorkflow = ({
               {t("pages.explorer.tree.newWorkflow.templateLabel")}
             </label>
             <Select
+              value={selectedTemplate}
               onValueChange={(value) => {
-                const matchingWf = workflowTemplates.find(
+                const match = workflowTemplates.find(
                   (template) => template.name === value
                 );
-                if (matchingWf) {
-                  setValue("fileContent", matchingWf.data);
-                  setWorkflowData(matchingWf.data);
+                if (match) {
+                  setValue("fileContent", match.data);
+                  setWorkflowData(match.data);
                 }
               }}
             >

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -31,18 +31,18 @@ import { usePages } from "~/util/router/pages";
 import { useState } from "react";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
-import workflowTemplates from "./templates";
+import { workflowTemplates } from "./templates";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 type FormInput = {
   name: string;
-  selectedTemplate: string;
+  selectedTemplateName: string;
   workflowType: (typeof workflowTypes)[number];
   fileContent: string;
 };
 
-const defaultWorkflowTemplate = workflowTemplates[0];
+const defaultWorkflowTemplate = workflowTemplates.yaml[0];
 
 const NewWorkflow = ({
   path,
@@ -92,7 +92,7 @@ const NewWorkflow = ({
   } = useForm<FormInput>({
     resolver,
     defaultValues: {
-      selectedTemplate: "noop",
+      selectedTemplateName: defaultWorkflowTemplate.name,
       workflowType: "yaml",
       fileContent: defaultWorkflowTemplate.data,
     },
@@ -137,7 +137,7 @@ const NewWorkflow = ({
 
   const workflowType: (typeof workflowTypes)[number] = watch("workflowType");
 
-  const selectedTemplate: string = watch("selectedTemplate");
+  const selectedTemplateName: string = watch("selectedTemplateName");
 
   const workflowMimeType =
     workflowType === "typescript"
@@ -178,14 +178,10 @@ const NewWorkflow = ({
               value={workflowType}
               onValueChange={(value: (typeof workflowTypes)[number]) => {
                 setValue("workflowType", value);
-                setValue(
-                  "selectedTemplate",
-                  value === "typescript" ? "TypescriptExample" : "noop"
-                );
-                const match = workflowTemplates.find(
-                  (template) => template.type === value
-                );
+
+                const match = workflowTemplates[value][0];
                 if (match) {
+                  setValue("selectedTemplateName", match.name);
                   setValue("fileContent", match.data);
                   setWorkflowData(match.data);
                 }
@@ -213,34 +209,33 @@ const NewWorkflow = ({
               className="w-[100px] text-right text-[14px]"
               htmlFor="template"
             >
-              {t("pages.explorer.tree.newWorkflow.templateLabel")}
+              {t("pages.explorer.tree.newWorkflow.template.label")}
             </label>
             <Select
-              value={selectedTemplate}
+              value={selectedTemplateName}
               onValueChange={(value) => {
-                const match = workflowTemplates.find(
+                const match = workflowTemplates[workflowType].find(
                   (template) => template.name === value
                 );
                 if (match) {
-                  setValue("fileContent", match.data);
+                  setValue("selectedTemplateName", match.name);
                   setWorkflowData(match.data);
                 }
               }}
             >
               <SelectTrigger id="template" variant="outline" block>
                 <SelectValue
-                  placeholder={defaultWorkflowTemplate.name}
-                  defaultValue={defaultWorkflowTemplate.data}
+                  placeholder={t(
+                    "pages.explorer.tree.newWorkflow.template.placeholder"
+                  )}
                 />
               </SelectTrigger>
               <SelectContent>
-                {workflowTemplates
-                  .filter((template) => workflowType === template.type)
-                  .map((template) => (
-                    <SelectItem value={template.name} key={template.name}>
-                      {template.name}
-                    </SelectItem>
-                  ))}
+                {workflowTemplates[workflowType].map((template) => (
+                  <SelectItem value={template.name} key={template.name}>
+                    {template.name}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </fieldset>

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -122,10 +122,7 @@ const NewWorkflow = ({
         name,
         data: encode(fileContent),
         type: "workflow",
-        mimeType:
-          workflowType === "typescript"
-            ? "application/x-typescript"
-            : "application/yaml",
+        mimeType: workflowMimeType,
       },
     });
   };
@@ -136,7 +133,12 @@ const NewWorkflow = ({
 
   const formId = `new-worfklow-${path}`;
 
-  const workflowType = watch("workflowType");
+  const workflowType: (typeof workflowTypes)[number] = watch("workflowType");
+
+  const workflowMimeType =
+    workflowType === "typescript"
+      ? "application/x-typescript"
+      : "application/yaml";
 
   return (
     <>
@@ -170,7 +172,9 @@ const NewWorkflow = ({
             </label>
             <Select
               value={workflowType}
-              onValueChange={(value) => setValue("workflowType", value)}
+              onValueChange={(value: (typeof workflowTypes)[number]) =>
+                setValue("workflowType", value)
+              }
             >
               <SelectTrigger id="type" variant="outline" block>
                 <SelectValue

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "~/design/Select";
 import { SubmitHandler, useForm } from "react-hook-form";
+import { addFileExtension, addYamlFileExtension } from "../../../../utils";
 import { useMemo, useState } from "react";
 
 import Button from "~/design/Button";
@@ -26,7 +27,6 @@ import Editor from "~/design/Editor";
 import FormErrors from "~/components/FormErrors";
 import Input from "~/design/Input";
 import { Textarea } from "~/design/TextArea";
-import { addYamlFileExtension } from "../../../../utils";
 import { encode } from "js-base64";
 import { useCreateFile } from "~/api/files/mutate/createFile";
 import { useNamespace } from "~/util/store/namespace";
@@ -86,7 +86,7 @@ const NewWorkflow = ({
     z.object({
       name: FileNameSchema.transform((enteredName) =>
         workflowType === "typescript"
-          ? enteredName // todo: add automatic extension like below
+          ? addFileExtension(enteredName, ".workflow.ts")
           : addYamlFileExtension(enteredName)
       ).refine(
         (nameWithExtension) =>

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/index.tsx
@@ -36,6 +36,7 @@ import { usePages } from "~/util/router/pages";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
 import { workflowTemplates } from "./templates";
+import workflowTsDefinition from "~/assets/ts/workflow.d.ts?raw";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -49,6 +50,8 @@ type FormInput = {
   workflowType: WorkflowType;
   fileContent: string;
 };
+
+type EditorLanguage = WorkflowType;
 
 const getFirstTemplateFor = (type: WorkflowType) => {
   const entry = Object.entries(workflowTemplates[type])[0];
@@ -81,6 +84,7 @@ const NewWorkflow = ({
   const [workflowData, setWorkflowData] = useState<string>(
     getFirstTemplateFor(defaultType).data
   );
+  const [editorLanguage, setEditorLanguage] = useState<EditorLanguage>("yaml");
 
   const resolver = zodResolver(
     z.object({
@@ -164,6 +168,18 @@ const NewWorkflow = ({
     [workflowType]
   );
 
+  const tsLibs = useMemo(
+    () =>
+      workflowType === "typescript"
+        ? [
+            {
+              content: workflowTsDefinition,
+            },
+          ]
+        : [],
+    [workflowType]
+  );
+
   const selectedTemplateName: string = watch("selectedTemplateName");
 
   const workflowMimeType =
@@ -178,6 +194,7 @@ const NewWorkflow = ({
     if (match) {
       setValue("selectedTemplateName", match.name);
       setValue("fileContent", match.data);
+      setEditorLanguage(value);
       setWorkflowData(match.data);
     }
   };
@@ -287,6 +304,8 @@ const NewWorkflow = ({
                 value={workflowData}
                 onChange={handleEditorOnChange}
                 theme={theme ?? undefined}
+                language={editorLanguage}
+                tsLibs={tsLibs}
               />
             </Card>
           </fieldset>

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -2,7 +2,7 @@ import { WorkflowType } from "~/api/files/schema";
 
 type WorkflowDefinition = { [key: string]: string };
 
-type WorkflowTemplates = Record<WorkflowType, WorkflowDefinition>;
+type WorkflowTemplateFormat = Record<WorkflowType, WorkflowDefinition>;
 
 export const workflowTemplates = {
   yaml: {
@@ -332,4 +332,4 @@ export const workflowTemplates = {
       })
     }`,
   },
-} satisfies WorkflowTemplates;
+} satisfies WorkflowTemplateFormat;

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -7,329 +7,329 @@ type WorkflowTemplateFormat = Record<WorkflowType, WorkflowDefinition>;
 export const workflowTemplates = {
   yaml: {
     noop: `direktiv_api: workflow/v1
-    description: A simple 'no-op' state that returns 'Hello world!'
-    states:
-    - id: helloworld
-      type: noop
-      transform:
-        result: Hello world!
-    `,
+description: A simple 'no-op' state that returns 'Hello world!'
+states:
+- id: helloworld
+  type: noop
+  transform:
+    result: Hello world!
+`,
     action: `direktiv_api: workflow/v1
-    description: A simple 'action' state that sends a get request
-    functions:
-    - id: get
-      image: direktiv/request:v4
-      type: knative-workflow
-    states:
-    - id: getter 
-      type: action
-      action:
-        function: get
-        input: 
-          method: "GET"
-          url: "https://jsonplaceholder.typicode.com/todos/1"
-    `,
+description: A simple 'action' state that sends a get request
+functions:
+- id: get
+  image: direktiv/request:v4
+  type: knative-workflow
+states:
+- id: getter 
+  type: action
+  action:
+    function: get
+    input: 
+      method: "GET"
+      url: "https://jsonplaceholder.typicode.com/todos/1"
+`,
     consumeEvent: `direktiv_api: workflow/v1
-    functions:
-    - id: greeter
-      image: direktiv/greeting:v3
-      type: knative-workflow
-    description: A simple 'consumeEvent' state that listens for the greetingcloudevent generated from the template 'generate-event'.
-    states:
-    - id: ce
-      type: consumeEvent
-      event:
-        type: greetingcloudevent
-      timeout: PT1H
-      transition: greet
-    - id: greet
-      type: action
-      action:
-        function: greeter
-        input: jq(.greetingcloudevent.data)
-      transform:
-        greeting: jq(.return.greeting)
-    `,
+functions:
+- id: greeter
+  image: direktiv/greeting:v3
+  type: knative-workflow
+description: A simple 'consumeEvent' state that listens for the greetingcloudevent generated from the template 'generate-event'.
+states:
+- id: ce
+  type: consumeEvent
+  event:
+    type: greetingcloudevent
+  timeout: PT1H
+  transition: greet
+- id: greet
+  type: action
+  action:
+    function: greeter
+    input: jq(.greetingcloudevent.data)
+  transform:
+    greeting: jq(.return.greeting)
+`,
     delay: `direktiv_api: workflow/v1
-    description: A simple 'delay' state that waits for 5 seconds
-    states:
-    - id: delay
-      type: delay
-      duration: PT5S
-    `,
+description: A simple 'delay' state that waits for 5 seconds
+states:
+- id: delay
+  type: delay
+  duration: PT5S
+`,
     error: `direktiv_api: workflow/v1
-    description: A simple 'error' state workflow that checks an email attempts to validate it.
-    states:
-    - id: data
-      type: noop
-      transform: 
-        email: "trent.hilliamdirektiv.io"
-      transition: validate-email
-    - id: validate-email
-      type: validate
-      subject: jq(.)
-      schema:
-        type: object
-        properties:
-          email:
-            type: string
-            format: email
-      catch:
-      - error: direktiv.schema.*
-        transition: email-not-valid 
-      transition: email-valid
-    - id: email-not-valid
-      type: error
-      error: direktiv.schema.*
-      message: "email '.email' is not valid"
-    - id: email-valid
-      type: noop
-      transform: 
-        result: "Email is valid."
-    `,
+description: A simple 'error' state workflow that checks an email attempts to validate it.
+states:
+- id: data
+  type: noop
+  transform: 
+    email: "trent.hilliamdirektiv.io"
+  transition: validate-email
+- id: validate-email
+  type: validate
+  subject: jq(.)
+  schema:
+    type: object
+    properties:
+      email:
+        type: string
+        format: email
+  catch:
+  - error: direktiv.schema.*
+    transition: email-not-valid 
+  transition: email-valid
+- id: email-not-valid
+  type: error
+  error: direktiv.schema.*
+  message: "email '.email' is not valid"
+- id: email-valid
+  type: noop
+  transform: 
+    result: "Email is valid."
+`,
     foreach: `direktiv_api: workflow/v1
-    description: A simple 'foreach' state that solves expressions
-    functions: 
-    - id: solve
-      image: direktiv/solve:v3
-      type: knative-workflow
-    states:
-    - id: data
-      type: noop
-      transform: 
-        expressions: ["4+10", "15-14", "100*3","200/2"] 
-      transition: solve
-    - id: solve
-      type: foreach
-      array: 'jq([.expressions[] | {expression: .}])'
-      action:
-        function: solve
-        input:
-          x: jq(.expression)
-      transform:
-        solved: jq(.return)
-    `,
+description: A simple 'foreach' state that solves expressions
+functions: 
+- id: solve
+  image: direktiv/solve:v3
+  type: knative-workflow
+states:
+- id: data
+  type: noop
+  transform: 
+    expressions: ["4+10", "15-14", "100*3","200/2"] 
+  transition: solve
+- id: solve
+  type: foreach
+  array: 'jq([.expressions[] | {expression: .}])'
+  action:
+    function: solve
+    input:
+      x: jq(.expression)
+  transform:
+    solved: jq(.return)
+`,
     generateEvent: `direktiv_api: workflow/v1
-    description: A simple 'generateEvent' state that sends data to a greeting listener.
-    states:
-    - id: generate
-      type: generateEvent
-      event:
-        type: greetingcloudevent
-        source: Direktiv
-        data: 
-          name: "Trent"
-    `,
+description: A simple 'generateEvent' state that sends data to a greeting listener.
+states:
+- id: generate
+  type: generateEvent
+  event:
+    type: greetingcloudevent
+    source: Direktiv
+    data: 
+      name: "Trent"
+`,
     generateSolveEvent: `direktiv_api: workflow/v1
-    description: A simple 'generateEvent' state that sends an expression to a solve listener.
-    states:
-    - id: generate
-      type: generateEvent
-      event:
-        type: solveexpressioncloudevent
-        source: Direktiv
-        data: 
-          x: "10+5"
-    `,
+description: A simple 'generateEvent' state that sends an expression to a solve listener.
+states:
+- id: generate
+  type: generateEvent
+  event:
+    type: solveexpressioncloudevent
+    source: Direktiv
+    data: 
+      x: "10+5"
+`,
     getAndSet: `direktiv_api: workflow/v1
-    description: "Simple Counter getter and setter variable example"
-    states:
-      - id: counter-get
-        type: getter 
-        transition: counter-set
-        variables:
-        - key: ExampleVariableCounter
-          scope: workflow
-        transform: 'jq(. += {"newCounter": (.var.ExampleVariableCounter + 1)})'
-      - id: counter-set
-        type: setter
-        variables:
-          - key: ExampleVariableCounter
-            scope: workflow 
-            value: 'jq(.newCounter)'
-    `,
+description: "Simple Counter getter and setter variable example"
+states:
+  - id: counter-get
+    type: getter 
+    transition: counter-set
+    variables:
+    - key: ExampleVariableCounter
+      scope: workflow
+    transform: 'jq(. += {"newCounter": (.var.ExampleVariableCounter + 1)})'
+  - id: counter-set
+    type: setter
+    variables:
+      - key: ExampleVariableCounter
+        scope: workflow 
+        value: 'jq(.newCounter)'
+`,
     parallel: `direktiv_api: workflow/v1
-    description: A simple 'parallel' state workflow that runs solve container to solve expressions.
-    functions: 
-    - id: solve
-      image: direktiv/solve:v3
-      type: knative-workflow
-    states:
-    - id: run
-      type: parallel
-      actions:
-      - function: solve
-        input: 
-          x: "10*2"
-      - function: solve
-        input:
-          x: "10%2"
-      - function: solve
-        input:
-          x: "10-2"
-      - function: solve
-        input:
-          x: "10+2"
-      # Mode 'and' waits for all actions to be completed
-      # Mode 'or' waits for the first action to be completed
-      mode: and
-    `,
+description: A simple 'parallel' state workflow that runs solve container to solve expressions.
+functions: 
+- id: solve
+  image: direktiv/solve:v3
+  type: knative-workflow
+states:
+- id: run
+  type: parallel
+  actions:
+  - function: solve
+    input: 
+      x: "10*2"
+  - function: solve
+    input:
+      x: "10%2"
+  - function: solve
+    input:
+      x: "10-2"
+  - function: solve
+    input:
+      x: "10+2"
+  # Mode 'and' waits for all actions to be completed
+  # Mode 'or' waits for the first action to be completed
+  mode: and
+`,
     validate: `direktiv_api: workflow/v1
-    description: A simple 'validate' state workflow that checks an email
-    states:
-    - id: data
-      type: noop
-      transform:
-        email: "trent.hilliam@direktiv.io"
-      transition: validate-email
-    - id: validate-email
-      type: validate
-      subject: jq(.)
-      schema:
-        type: object
-        properties:
-          email:
-            type: string
-            format: email
-      catch:
-      - error: direktiv.schema.*
-        transition: email-not-valid 
-      transition: email-valid
-    - id: email-not-valid
-      type: noop
-      transform:
-        result: "Email is not valid."
-    - id: email-valid
-      type: noop
-      transform:
-        result: "Email is valid."
-    `,
+description: A simple 'validate' state workflow that checks an email
+states:
+- id: data
+  type: noop
+  transform:
+    email: "trent.hilliam@direktiv.io"
+  transition: validate-email
+- id: validate-email
+  type: validate
+  subject: jq(.)
+  schema:
+    type: object
+    properties:
+      email:
+        type: string
+        format: email
+  catch:
+  - error: direktiv.schema.*
+    transition: email-not-valid 
+  transition: email-valid
+- id: email-not-valid
+  type: noop
+  transform:
+    result: "Email is not valid."
+- id: email-valid
+  type: noop
+  transform:
+    result: "Email is valid."
+`,
     switch: `direktiv_api: workflow/v1
-    description: A simple 'switch' state that checks whether the age provided is older than 18.
-    states:
-    - id: data
-      type: noop
-      transform:
-        age: 27
-      transition: check
-    - id: check
-      type: switch
-      conditions:
-      - condition: 'jq(.age > 18)'
-        transition: olderthan18
-      defaultTransition: youngerthan18
-    - id: olderthan18
-      type: noop
-      transform: 
-        result: "You are older than 18."
-    - id: youngerthan18
-      type: noop
-      transform: 
-        result: "You are younger than 18."
-    `,
+description: A simple 'switch' state that checks whether the age provided is older than 18.
+states:
+- id: data
+  type: noop
+  transform:
+    age: 27
+  transition: check
+- id: check
+  type: switch
+  conditions:
+  - condition: 'jq(.age > 18)'
+    transition: olderthan18
+  defaultTransition: youngerthan18
+- id: olderthan18
+  type: noop
+  transform: 
+    result: "You are older than 18."
+- id: youngerthan18
+  type: noop
+  transform: 
+    result: "You are younger than 18."
+`,
     eventXor: `direktiv_api: workflow/v1
-    functions:
-    - id: greeter
-      image: direktiv/greeting:v3
-      type: knative-workflow
-    - id: solve2
-      image: direktiv/solve:v3
-      type: knative-workflow
-    description: A simple 'eventXor' that waits for events to be received.
-    states:
-    - id: event-xor
-      type: eventXor
-      timeout: PT1H
-      events:
-      - event: 
-          type: solveexpressioncloudevent
-        transition: solve
-      - event: 
-          type: greetingcloudevent
-        transition: greet
-    - id: greet
-      type: action
-      action:
-        function: greeter
-        input: jq(.greetingcloudevent.data)
-      transform: 
-        greeting: jq(.return.greeting)
-    - id: solve
-      type: action
-      action:
-        function: solve2
-        input: jq(.solveexpressioncloudevent.data)
-      transform: 
-        solvedexpression: jq(.return)
-    `,
+functions:
+- id: greeter
+  image: direktiv/greeting:v3
+  type: knative-workflow
+- id: solve2
+  image: direktiv/solve:v3
+  type: knative-workflow
+description: A simple 'eventXor' that waits for events to be received.
+states:
+- id: event-xor
+  type: eventXor
+  timeout: PT1H
+  events:
+  - event: 
+      type: solveexpressioncloudevent
+    transition: solve
+  - event: 
+      type: greetingcloudevent
+    transition: greet
+- id: greet
+  type: action
+  action:
+    function: greeter
+    input: jq(.greetingcloudevent.data)
+  transform: 
+    greeting: jq(.return.greeting)
+- id: solve
+  type: action
+  action:
+    function: solve2
+    input: jq(.solveexpressioncloudevent.data)
+  transform: 
+    solvedexpression: jq(.return)
+`,
     eventAnd: `direktiv_api: workflow/v1
-    functions:
-    - id: greeter
-      image: direktiv/greeting:v3
-      type: knative-workflow
-    - id: solve
-      image: direktiv/solve:v3
-      type: knative-workflow
-    description: A simple 'eventAnd' that waits for events to be received.
-    states:
-    - id: event-and
-      type: eventsAnd
-      timeout: PT1H
-      events:
-      - type: greetingcloudevent
-      - type: solveexpressioncloudevent
-      transition: greet
-    - id: greet
-      type: action
-      action:
-        function: greeter
-        input: jq(.greetingcloudevent.data)
-      transform: 
-        greeting: jq(.return.greeting)
-        ceevent: jq(.solveexpressioncloudevent)
-      transition: solve
-    - id: solve
-      type: action
-      action:
-        function: solve
-        input: jq(.ceevent.data)
-      transform: 
-        msggreeting: jq(.greeting)
-        solvedexpression: jq(.return)
-    `,
+functions:
+- id: greeter
+  image: direktiv/greeting:v3
+  type: knative-workflow
+- id: solve
+  image: direktiv/solve:v3
+  type: knative-workflow
+description: A simple 'eventAnd' that waits for events to be received.
+states:
+- id: event-and
+  type: eventsAnd
+  timeout: PT1H
+  events:
+  - type: greetingcloudevent
+  - type: solveexpressioncloudevent
+  transition: greet
+- id: greet
+  type: action
+  action:
+    function: greeter
+    input: jq(.greetingcloudevent.data)
+  transform: 
+    greeting: jq(.return.greeting)
+    ceevent: jq(.solveexpressioncloudevent)
+  transition: solve
+- id: solve
+  type: action
+  action:
+    function: solve
+    input: jq(.ceevent.data)
+  transform: 
+    msggreeting: jq(.greeting)
+    solvedexpression: jq(.return)
+`,
   },
   typescript: {
     example: `const flow: DirektivFlow = {
-        scale: [
-          {
-            min: 1
-          }
-        ]
-      };
+  scale: [
+    {
+      min: 1
+    }
+  ]
+};
 
-    function value() {
-      const fileOne = getFile({
-        name: "/myfile.txt",
-        permission: 755,
-        scope: "shared",
-      });
+function value() {
+  const fileOne = getFile({
+    name: "/myfile.txt",
+    permission: 755,
+    scope: "shared",
+  });
 
-        var s = getSecret({ name: "hello-world"})
+    var s = getSecret({ name: "hello-world"})
 
-        var r = httpRequest(
-            {
-                method: "POST",
-                url: "http://127.0.0.1:%d"
-            }
-        )
+    var r = httpRequest(
+        {
+            method: "POST",
+            url: "http://127.0.0.1:%d"
+        }
+    )
 
-        var fn = setupFunction({
-        image: "localhost:5000/hello"
-      })
+    var fn = setupFunction({
+    image: "localhost:5000/hello"
+  })
 
-        var fn = setupFunction2({
-        image: "localhost:5000/hello"
-      })
-    }`,
+    var fn = setupFunction2({
+    image: "localhost:5000/hello"
+  })
+}`,
   },
 } satisfies WorkflowTemplateFormat;

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -1,5 +1,14 @@
-export const noop = {
+export type workflowType = (typeof workflowTypes)[number];
+
+type workflowTemplate = {
+  name: string;
+  type: workflowType;
+  data: string;
+};
+
+export const noop: workflowTemplate = {
   name: "noop",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'no-op' state that returns 'Hello world!'
 states:
@@ -10,8 +19,9 @@ states:
 `,
 };
 
-export const action = {
+export const action: workflowTemplate = {
   name: "action",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'action' state that sends a get request
 functions:
@@ -29,8 +39,9 @@ states:
 `,
 };
 
-export const consumeEvent = {
+export const consumeEvent: workflowTemplate = {
   name: "consumeEvent",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 functions:
 - id: greeter
@@ -54,8 +65,9 @@ states:
 `,
 };
 
-export const delay = {
+export const delay: workflowTemplate = {
   name: "delay",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'delay' state that waits for 5 seconds
 states:
@@ -65,8 +77,9 @@ states:
 `,
 };
 
-export const error = {
+export const error: workflowTemplate = {
   name: "error",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'error' state workflow that checks an email attempts to validate it.
 states:
@@ -99,8 +112,9 @@ states:
 `,
 };
 
-export const foreach = {
+export const foreach: workflowTemplate = {
   name: "foreach",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'foreach' state that solves expressions
 functions: 
@@ -125,8 +139,9 @@ states:
 `,
 };
 
-export const generateEvent = {
+export const generateEvent: workflowTemplate = {
   name: "generateEvent",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'generateEvent' state that sends data to a greeting listener.
 states:
@@ -140,8 +155,9 @@ states:
 `,
 };
 
-export const generateSolveEvent = {
+export const generateSolveEvent: workflowTemplate = {
   name: "generateSolveEvent",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'generateEvent' state that sends an expression to a solve listener.
 states:
@@ -155,8 +171,9 @@ states:
 `,
 };
 
-export const getAndSet = {
+export const getAndSet: workflowTemplate = {
   name: "getAndSet",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: "Simple Counter getter and setter variable example"
 states:
@@ -176,8 +193,9 @@ states:
 `,
 };
 
-export const parallel = {
+export const parallel: workflowTemplate = {
   name: "parallel",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'parallel' state workflow that runs solve container to solve expressions.
 functions: 
@@ -206,8 +224,9 @@ states:
 `,
 };
 
-export const validate = {
+export const validate: workflowTemplate = {
   name: "validate",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'validate' state workflow that checks an email
 states:
@@ -240,8 +259,9 @@ states:
 `,
 };
 
-export const switchState = {
+export const switchState: workflowTemplate = {
   name: "switch",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 description: A simple 'switch' state that checks whether the age provided is older than 18.
 states:
@@ -267,8 +287,9 @@ states:
 `,
 };
 
-export const eventXor = {
+export const eventXor: workflowTemplate = {
   name: "eventXor",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 functions:
 - id: greeter
@@ -306,8 +327,9 @@ states:
 `,
 };
 
-export const eventAnd = {
+export const eventAnd: workflowTemplate = {
   name: "eventAnd",
+  type: "yaml",
   data: `direktiv_api: workflow/v1
 functions:
 - id: greeter
@@ -345,6 +367,43 @@ states:
 `,
 };
 
+export const typescriptExample: workflowTemplate = {
+  name: "TypescriptExample",
+  type: "typescript",
+  data: `const flow: DirektivFlow = {
+		scale: [
+			{
+				min: 1
+			}
+		]
+	};
+
+function value() {
+	const fileOne = getFile({
+		name: "/myfile.txt",
+		permission: 755,
+		scope: "shared",
+	});	  
+    
+    var s = getSecret({ name: "hello-world"})
+
+    var r = httpRequest(
+        {
+            method: "POST",
+            url: "http://127.0.0.1:%d"
+        }
+    )
+
+    var fn = setupFunction({
+		image: "localhost:5000/hello"
+	})
+
+    var fn = setupFunction2({
+		image: "localhost:5000/hello"
+	})
+}`,
+};
+
 const templates = [
   noop,
   action,
@@ -360,6 +419,7 @@ const templates = [
   switchState,
   eventXor,
   eventAnd,
+  typescriptExample,
 ] as const;
 
 export default templates;

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -1,22 +1,12 @@
-import { workflowTypes } from "~/api/files/schema";
+import { WorkflowType } from "~/api/files/schema";
 
-type WorkflowTemplate = {
-  name: string;
-  type: (typeof workflowTypes)[number];
-  data: string;
-};
+type WorkflowDefinition = { [key: string]: string };
 
-type WorkflowTemplates = {
-  yaml: WorkflowTemplate[];
-  typescript: WorkflowTemplate[];
-};
+type WorkflowTemplates = Record<WorkflowType, WorkflowDefinition>;
 
 export const workflowTemplates = {
-  yaml: [
-    {
-      name: "noop",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+  yaml: {
+    noop: `direktiv_api: workflow/v1
     description: A simple 'no-op' state that returns 'Hello world!'
     states:
     - id: helloworld
@@ -24,11 +14,7 @@ export const workflowTemplates = {
       transform:
         result: Hello world!
     `,
-    },
-    {
-      name: "action",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    action: `direktiv_api: workflow/v1
     description: A simple 'action' state that sends a get request
     functions:
     - id: get
@@ -43,11 +29,7 @@ export const workflowTemplates = {
           method: "GET"
           url: "https://jsonplaceholder.typicode.com/todos/1"
     `,
-    },
-    {
-      name: "consumeEvent",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    consumeEvent: `direktiv_api: workflow/v1
     functions:
     - id: greeter
       image: direktiv/greeting:v3
@@ -68,22 +50,14 @@ export const workflowTemplates = {
       transform:
         greeting: jq(.return.greeting)
     `,
-    },
-    {
-      name: "delay",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    delay: `direktiv_api: workflow/v1
     description: A simple 'delay' state that waits for 5 seconds
     states:
     - id: delay
       type: delay
       duration: PT5S
     `,
-    },
-    {
-      name: "error",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    error: `direktiv_api: workflow/v1
     description: A simple 'error' state workflow that checks an email attempts to validate it.
     states:
     - id: data
@@ -113,11 +87,7 @@ export const workflowTemplates = {
       transform: 
         result: "Email is valid."
     `,
-    },
-    {
-      name: "foreach",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    foreach: `direktiv_api: workflow/v1
     description: A simple 'foreach' state that solves expressions
     functions: 
     - id: solve
@@ -139,11 +109,7 @@ export const workflowTemplates = {
       transform:
         solved: jq(.return)
     `,
-    },
-    {
-      name: "generateEvent",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    generateEvent: `direktiv_api: workflow/v1
     description: A simple 'generateEvent' state that sends data to a greeting listener.
     states:
     - id: generate
@@ -154,11 +120,7 @@ export const workflowTemplates = {
         data: 
           name: "Trent"
     `,
-    },
-    {
-      name: "generateSolveEvent",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    generateSolveEvent: `direktiv_api: workflow/v1
     description: A simple 'generateEvent' state that sends an expression to a solve listener.
     states:
     - id: generate
@@ -169,11 +131,7 @@ export const workflowTemplates = {
         data: 
           x: "10+5"
     `,
-    },
-    {
-      name: "getAndSet",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    getAndSet: `direktiv_api: workflow/v1
     description: "Simple Counter getter and setter variable example"
     states:
       - id: counter-get
@@ -190,11 +148,7 @@ export const workflowTemplates = {
             scope: workflow 
             value: 'jq(.newCounter)'
     `,
-    },
-    {
-      name: "parallel",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    parallel: `direktiv_api: workflow/v1
     description: A simple 'parallel' state workflow that runs solve container to solve expressions.
     functions: 
     - id: solve
@@ -220,11 +174,7 @@ export const workflowTemplates = {
       # Mode 'or' waits for the first action to be completed
       mode: and
     `,
-    },
-    {
-      name: "validate",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    validate: `direktiv_api: workflow/v1
     description: A simple 'validate' state workflow that checks an email
     states:
     - id: data
@@ -254,11 +204,7 @@ export const workflowTemplates = {
       transform:
         result: "Email is valid."
     `,
-    },
-    {
-      name: "switch",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    switch: `direktiv_api: workflow/v1
     description: A simple 'switch' state that checks whether the age provided is older than 18.
     states:
     - id: data
@@ -281,11 +227,7 @@ export const workflowTemplates = {
       transform: 
         result: "You are younger than 18."
     `,
-    },
-    {
-      name: "eventXor",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    eventXor: `direktiv_api: workflow/v1
     functions:
     - id: greeter
       image: direktiv/greeting:v3
@@ -320,11 +262,7 @@ export const workflowTemplates = {
       transform: 
         solvedexpression: jq(.return)
     `,
-    },
-    {
-      name: "eventAnd",
-      type: "yaml",
-      data: `direktiv_api: workflow/v1
+    eventAnd: `direktiv_api: workflow/v1
     functions:
     - id: greeter
       image: direktiv/greeting:v3
@@ -359,44 +297,39 @@ export const workflowTemplates = {
         msggreeting: jq(.greeting)
         solvedexpression: jq(.return)
     `,
-    },
-  ] as const,
-  typescript: [
-    {
-      name: "TypescriptExample",
-      type: "typescript",
-      data: `const flow: DirektivFlow = {
+  },
+  typescript: {
+    example: `const flow: DirektivFlow = {
         scale: [
           {
             min: 1
           }
         ]
       };
-    
+
     function value() {
       const fileOne = getFile({
         name: "/myfile.txt",
         permission: 755,
         scope: "shared",
-      });	  
-        
+      });
+
         var s = getSecret({ name: "hello-world"})
-    
+
         var r = httpRequest(
             {
                 method: "POST",
                 url: "http://127.0.0.1:%d"
             }
         )
-    
+
         var fn = setupFunction({
         image: "localhost:5000/hello"
       })
-    
+
         var fn = setupFunction2({
         image: "localhost:5000/hello"
       })
     }`,
-    },
-  ] as const,
+  },
 } satisfies WorkflowTemplates;

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -1,8 +1,8 @@
-export type workflowType = (typeof workflowTypes)[number];
+import { workflowTypes } from "~/api/files/schema";
 
 type workflowTemplate = {
   name: string;
-  type: workflowType;
+  type: (typeof workflowTypes)[number];
   data: string;
 };
 

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -1,425 +1,402 @@
 import { workflowTypes } from "~/api/files/schema";
 
-type workflowTemplate = {
+type WorkflowTemplate = {
   name: string;
   type: (typeof workflowTypes)[number];
   data: string;
 };
 
-export const noop: workflowTemplate = {
-  name: "noop",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'no-op' state that returns 'Hello world!'
-states:
-- id: helloworld
-  type: noop
-  transform:
-    result: Hello world!
-`,
+type WorkflowTemplates = {
+  yaml: WorkflowTemplate[];
+  typescript: WorkflowTemplate[];
 };
 
-export const action: workflowTemplate = {
-  name: "action",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'action' state that sends a get request
-functions:
-- id: get
-  image: direktiv/request:v4
-  type: knative-workflow
-states:
-- id: getter 
-  type: action
-  action:
-    function: get
-    input: 
-      method: "GET"
-      url: "https://jsonplaceholder.typicode.com/todos/1"
-`,
-};
-
-export const consumeEvent: workflowTemplate = {
-  name: "consumeEvent",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-functions:
-- id: greeter
-  image: direktiv/greeting:v3
-  type: knative-workflow
-description: A simple 'consumeEvent' state that listens for the greetingcloudevent generated from the template 'generate-event'.
-states:
-- id: ce
-  type: consumeEvent
-  event:
-    type: greetingcloudevent
-  timeout: PT1H
-  transition: greet
-- id: greet
-  type: action
-  action:
-    function: greeter
-    input: jq(.greetingcloudevent.data)
-  transform:
-    greeting: jq(.return.greeting)
-`,
-};
-
-export const delay: workflowTemplate = {
-  name: "delay",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'delay' state that waits for 5 seconds
-states:
-- id: delay
-  type: delay
-  duration: PT5S
-`,
-};
-
-export const error: workflowTemplate = {
-  name: "error",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'error' state workflow that checks an email attempts to validate it.
-states:
-- id: data
-  type: noop
-  transform: 
-    email: "trent.hilliamdirektiv.io"
-  transition: validate-email
-- id: validate-email
-  type: validate
-  subject: jq(.)
-  schema:
-    type: object
-    properties:
-      email:
-        type: string
-        format: email
-  catch:
-  - error: direktiv.schema.*
-    transition: email-not-valid 
-  transition: email-valid
-- id: email-not-valid
-  type: error
-  error: direktiv.schema.*
-  message: "email '.email' is not valid"
-- id: email-valid
-  type: noop
-  transform: 
-    result: "Email is valid."
-`,
-};
-
-export const foreach: workflowTemplate = {
-  name: "foreach",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'foreach' state that solves expressions
-functions: 
-- id: solve
-  image: direktiv/solve:v3
-  type: knative-workflow
-states:
-- id: data
-  type: noop
-  transform: 
-    expressions: ["4+10", "15-14", "100*3","200/2"] 
-  transition: solve
-- id: solve
-  type: foreach
-  array: 'jq([.expressions[] | {expression: .}])'
-  action:
-    function: solve
-    input:
-      x: jq(.expression)
-  transform:
-    solved: jq(.return)
-`,
-};
-
-export const generateEvent: workflowTemplate = {
-  name: "generateEvent",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'generateEvent' state that sends data to a greeting listener.
-states:
-- id: generate
-  type: generateEvent
-  event:
-    type: greetingcloudevent
-    source: Direktiv
-    data: 
-      name: "Trent"
-`,
-};
-
-export const generateSolveEvent: workflowTemplate = {
-  name: "generateSolveEvent",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'generateEvent' state that sends an expression to a solve listener.
-states:
-- id: generate
-  type: generateEvent
-  event:
-    type: solveexpressioncloudevent
-    source: Direktiv
-    data: 
-      x: "10+5"
-`,
-};
-
-export const getAndSet: workflowTemplate = {
-  name: "getAndSet",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: "Simple Counter getter and setter variable example"
-states:
-  - id: counter-get
-    type: getter 
-    transition: counter-set
-    variables:
-    - key: ExampleVariableCounter
-      scope: workflow
-    transform: 'jq(. += {"newCounter": (.var.ExampleVariableCounter + 1)})'
-  - id: counter-set
-    type: setter
-    variables:
-      - key: ExampleVariableCounter
-        scope: workflow 
-        value: 'jq(.newCounter)'
-`,
-};
-
-export const parallel: workflowTemplate = {
-  name: "parallel",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'parallel' state workflow that runs solve container to solve expressions.
-functions: 
-- id: solve
-  image: direktiv/solve:v3
-  type: knative-workflow
-states:
-- id: run
-  type: parallel
-  actions:
-  - function: solve
-    input: 
-      x: "10*2"
-  - function: solve
-    input:
-      x: "10%2"
-  - function: solve
-    input:
-      x: "10-2"
-  - function: solve
-    input:
-      x: "10+2"
-  # Mode 'and' waits for all actions to be completed
-  # Mode 'or' waits for the first action to be completed
-  mode: and
-`,
-};
-
-export const validate: workflowTemplate = {
-  name: "validate",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'validate' state workflow that checks an email
-states:
-- id: data
-  type: noop
-  transform:
-    email: "trent.hilliam@direktiv.io"
-  transition: validate-email
-- id: validate-email
-  type: validate
-  subject: jq(.)
-  schema:
-    type: object
-    properties:
-      email:
-        type: string
-        format: email
-  catch:
-  - error: direktiv.schema.*
-    transition: email-not-valid 
-  transition: email-valid
-- id: email-not-valid
-  type: noop
-  transform:
-    result: "Email is not valid."
-- id: email-valid
-  type: noop
-  transform:
-    result: "Email is valid."
-`,
-};
-
-export const switchState: workflowTemplate = {
-  name: "switch",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-description: A simple 'switch' state that checks whether the age provided is older than 18.
-states:
-- id: data
-  type: noop
-  transform:
-    age: 27
-  transition: check
-- id: check
-  type: switch
-  conditions:
-  - condition: 'jq(.age > 18)'
-    transition: olderthan18
-  defaultTransition: youngerthan18
-- id: olderthan18
-  type: noop
-  transform: 
-    result: "You are older than 18."
-- id: youngerthan18
-  type: noop
-  transform: 
-    result: "You are younger than 18."
-`,
-};
-
-export const eventXor: workflowTemplate = {
-  name: "eventXor",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-functions:
-- id: greeter
-  image: direktiv/greeting:v3
-  type: knative-workflow
-- id: solve2
-  image: direktiv/solve:v3
-  type: knative-workflow
-description: A simple 'eventXor' that waits for events to be received.
-states:
-- id: event-xor
-  type: eventXor
-  timeout: PT1H
-  events:
-  - event: 
-      type: solveexpressioncloudevent
-    transition: solve
-  - event: 
-      type: greetingcloudevent
-    transition: greet
-- id: greet
-  type: action
-  action:
-    function: greeter
-    input: jq(.greetingcloudevent.data)
-  transform: 
-    greeting: jq(.return.greeting)
-- id: solve
-  type: action
-  action:
-    function: solve2
-    input: jq(.solveexpressioncloudevent.data)
-  transform: 
-    solvedexpression: jq(.return)
-`,
-};
-
-export const eventAnd: workflowTemplate = {
-  name: "eventAnd",
-  type: "yaml",
-  data: `direktiv_api: workflow/v1
-functions:
-- id: greeter
-  image: direktiv/greeting:v3
-  type: knative-workflow
-- id: solve
-  image: direktiv/solve:v3
-  type: knative-workflow
-description: A simple 'eventAnd' that waits for events to be received.
-states:
-- id: event-and
-  type: eventsAnd
-  timeout: PT1H
-  events:
-  - type: greetingcloudevent
-  - type: solveexpressioncloudevent
-  transition: greet
-- id: greet
-  type: action
-  action:
-    function: greeter
-    input: jq(.greetingcloudevent.data)
-  transform: 
-    greeting: jq(.return.greeting)
-    ceevent: jq(.solveexpressioncloudevent)
-  transition: solve
-- id: solve
-  type: action
-  action:
-    function: solve
-    input: jq(.ceevent.data)
-  transform: 
-    msggreeting: jq(.greeting)
-    solvedexpression: jq(.return)
-`,
-};
-
-export const typescriptExample: workflowTemplate = {
-  name: "TypescriptExample",
-  type: "typescript",
-  data: `const flow: DirektivFlow = {
-		scale: [
-			{
-				min: 1
-			}
-		]
-	};
-
-function value() {
-	const fileOne = getFile({
-		name: "/myfile.txt",
-		permission: 755,
-		scope: "shared",
-	});	  
+export const workflowTemplates = {
+  yaml: [
+    {
+      name: "noop",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'no-op' state that returns 'Hello world!'
+    states:
+    - id: helloworld
+      type: noop
+      transform:
+        result: Hello world!
+    `,
+    },
+    {
+      name: "action",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'action' state that sends a get request
+    functions:
+    - id: get
+      image: direktiv/request:v4
+      type: knative-workflow
+    states:
+    - id: getter 
+      type: action
+      action:
+        function: get
+        input: 
+          method: "GET"
+          url: "https://jsonplaceholder.typicode.com/todos/1"
+    `,
+    },
+    {
+      name: "consumeEvent",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    functions:
+    - id: greeter
+      image: direktiv/greeting:v3
+      type: knative-workflow
+    description: A simple 'consumeEvent' state that listens for the greetingcloudevent generated from the template 'generate-event'.
+    states:
+    - id: ce
+      type: consumeEvent
+      event:
+        type: greetingcloudevent
+      timeout: PT1H
+      transition: greet
+    - id: greet
+      type: action
+      action:
+        function: greeter
+        input: jq(.greetingcloudevent.data)
+      transform:
+        greeting: jq(.return.greeting)
+    `,
+    },
+    {
+      name: "delay",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'delay' state that waits for 5 seconds
+    states:
+    - id: delay
+      type: delay
+      duration: PT5S
+    `,
+    },
+    {
+      name: "error",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'error' state workflow that checks an email attempts to validate it.
+    states:
+    - id: data
+      type: noop
+      transform: 
+        email: "trent.hilliamdirektiv.io"
+      transition: validate-email
+    - id: validate-email
+      type: validate
+      subject: jq(.)
+      schema:
+        type: object
+        properties:
+          email:
+            type: string
+            format: email
+      catch:
+      - error: direktiv.schema.*
+        transition: email-not-valid 
+      transition: email-valid
+    - id: email-not-valid
+      type: error
+      error: direktiv.schema.*
+      message: "email '.email' is not valid"
+    - id: email-valid
+      type: noop
+      transform: 
+        result: "Email is valid."
+    `,
+    },
+    {
+      name: "foreach",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'foreach' state that solves expressions
+    functions: 
+    - id: solve
+      image: direktiv/solve:v3
+      type: knative-workflow
+    states:
+    - id: data
+      type: noop
+      transform: 
+        expressions: ["4+10", "15-14", "100*3","200/2"] 
+      transition: solve
+    - id: solve
+      type: foreach
+      array: 'jq([.expressions[] | {expression: .}])'
+      action:
+        function: solve
+        input:
+          x: jq(.expression)
+      transform:
+        solved: jq(.return)
+    `,
+    },
+    {
+      name: "generateEvent",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'generateEvent' state that sends data to a greeting listener.
+    states:
+    - id: generate
+      type: generateEvent
+      event:
+        type: greetingcloudevent
+        source: Direktiv
+        data: 
+          name: "Trent"
+    `,
+    },
+    {
+      name: "generateSolveEvent",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'generateEvent' state that sends an expression to a solve listener.
+    states:
+    - id: generate
+      type: generateEvent
+      event:
+        type: solveexpressioncloudevent
+        source: Direktiv
+        data: 
+          x: "10+5"
+    `,
+    },
+    {
+      name: "getAndSet",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: "Simple Counter getter and setter variable example"
+    states:
+      - id: counter-get
+        type: getter 
+        transition: counter-set
+        variables:
+        - key: ExampleVariableCounter
+          scope: workflow
+        transform: 'jq(. += {"newCounter": (.var.ExampleVariableCounter + 1)})'
+      - id: counter-set
+        type: setter
+        variables:
+          - key: ExampleVariableCounter
+            scope: workflow 
+            value: 'jq(.newCounter)'
+    `,
+    },
+    {
+      name: "parallel",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'parallel' state workflow that runs solve container to solve expressions.
+    functions: 
+    - id: solve
+      image: direktiv/solve:v3
+      type: knative-workflow
+    states:
+    - id: run
+      type: parallel
+      actions:
+      - function: solve
+        input: 
+          x: "10*2"
+      - function: solve
+        input:
+          x: "10%2"
+      - function: solve
+        input:
+          x: "10-2"
+      - function: solve
+        input:
+          x: "10+2"
+      # Mode 'and' waits for all actions to be completed
+      # Mode 'or' waits for the first action to be completed
+      mode: and
+    `,
+    },
+    {
+      name: "validate",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'validate' state workflow that checks an email
+    states:
+    - id: data
+      type: noop
+      transform:
+        email: "trent.hilliam@direktiv.io"
+      transition: validate-email
+    - id: validate-email
+      type: validate
+      subject: jq(.)
+      schema:
+        type: object
+        properties:
+          email:
+            type: string
+            format: email
+      catch:
+      - error: direktiv.schema.*
+        transition: email-not-valid 
+      transition: email-valid
+    - id: email-not-valid
+      type: noop
+      transform:
+        result: "Email is not valid."
+    - id: email-valid
+      type: noop
+      transform:
+        result: "Email is valid."
+    `,
+    },
+    {
+      name: "switch",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    description: A simple 'switch' state that checks whether the age provided is older than 18.
+    states:
+    - id: data
+      type: noop
+      transform:
+        age: 27
+      transition: check
+    - id: check
+      type: switch
+      conditions:
+      - condition: 'jq(.age > 18)'
+        transition: olderthan18
+      defaultTransition: youngerthan18
+    - id: olderthan18
+      type: noop
+      transform: 
+        result: "You are older than 18."
+    - id: youngerthan18
+      type: noop
+      transform: 
+        result: "You are younger than 18."
+    `,
+    },
+    {
+      name: "eventXor",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    functions:
+    - id: greeter
+      image: direktiv/greeting:v3
+      type: knative-workflow
+    - id: solve2
+      image: direktiv/solve:v3
+      type: knative-workflow
+    description: A simple 'eventXor' that waits for events to be received.
+    states:
+    - id: event-xor
+      type: eventXor
+      timeout: PT1H
+      events:
+      - event: 
+          type: solveexpressioncloudevent
+        transition: solve
+      - event: 
+          type: greetingcloudevent
+        transition: greet
+    - id: greet
+      type: action
+      action:
+        function: greeter
+        input: jq(.greetingcloudevent.data)
+      transform: 
+        greeting: jq(.return.greeting)
+    - id: solve
+      type: action
+      action:
+        function: solve2
+        input: jq(.solveexpressioncloudevent.data)
+      transform: 
+        solvedexpression: jq(.return)
+    `,
+    },
+    {
+      name: "eventAnd",
+      type: "yaml",
+      data: `direktiv_api: workflow/v1
+    functions:
+    - id: greeter
+      image: direktiv/greeting:v3
+      type: knative-workflow
+    - id: solve
+      image: direktiv/solve:v3
+      type: knative-workflow
+    description: A simple 'eventAnd' that waits for events to be received.
+    states:
+    - id: event-and
+      type: eventsAnd
+      timeout: PT1H
+      events:
+      - type: greetingcloudevent
+      - type: solveexpressioncloudevent
+      transition: greet
+    - id: greet
+      type: action
+      action:
+        function: greeter
+        input: jq(.greetingcloudevent.data)
+      transform: 
+        greeting: jq(.return.greeting)
+        ceevent: jq(.solveexpressioncloudevent)
+      transition: solve
+    - id: solve
+      type: action
+      action:
+        function: solve
+        input: jq(.ceevent.data)
+      transform: 
+        msggreeting: jq(.greeting)
+        solvedexpression: jq(.return)
+    `,
+    },
+  ] as const,
+  typescript: [
+    {
+      name: "TypescriptExample",
+      type: "typescript",
+      data: `const flow: DirektivFlow = {
+        scale: [
+          {
+            min: 1
+          }
+        ]
+      };
     
-    var s = getSecret({ name: "hello-world"})
-
-    var r = httpRequest(
-        {
-            method: "POST",
-            url: "http://127.0.0.1:%d"
-        }
-    )
-
-    var fn = setupFunction({
-		image: "localhost:5000/hello"
-	})
-
-    var fn = setupFunction2({
-		image: "localhost:5000/hello"
-	})
-}`,
-};
-
-const templates = [
-  noop,
-  action,
-  consumeEvent,
-  delay,
-  error,
-  foreach,
-  generateEvent,
-  generateSolveEvent,
-  getAndSet,
-  parallel,
-  validate,
-  switchState,
-  eventXor,
-  eventAnd,
-  typescriptExample,
-] as const;
-
-export default templates;
+    function value() {
+      const fileOne = getFile({
+        name: "/myfile.txt",
+        permission: 755,
+        scope: "shared",
+      });	  
+        
+        var s = getSecret({ name: "hello-world"})
+    
+        var r = httpRequest(
+            {
+                method: "POST",
+                url: "http://127.0.0.1:%d"
+            }
+        )
+    
+        var fn = setupFunction({
+        image: "localhost:5000/hello"
+      })
+    
+        var fn = setupFunction2({
+        image: "localhost:5000/hello"
+      })
+    }`,
+    },
+  ] as const,
+} satisfies WorkflowTemplates;

--- a/ui/src/pages/namespace/Explorer/Tree/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Tree/utils.ts
@@ -10,3 +10,35 @@ export const addYamlFileExtension = (name: string) => {
   }
   return `${newName}${yamlExtensions[0]}`;
 };
+
+/**
+ * Intended use: remove partial or full existing extension from a file name
+ * before adding automatic extension to avoid duplicating it.
+ * @param name
+ * @param extension
+ * @returns name without extension (or partial matches)
+ */
+export const stripFileExtension = (name: string, extension: string) => {
+  const nameSegments = name.split(".");
+  const partials = extension?.split(".");
+
+  partials?.reverse().forEach((partial) => {
+    if (nameSegments[nameSegments.length - 1] === partial) {
+      nameSegments.pop();
+    }
+  });
+
+  return nameSegments.join(".");
+};
+
+/**
+ * Will add the provided extension to the name. Will strip (partial) matches
+ * of the extension first to avoid duplicating them.
+ * @param name
+ * @param extension
+ * @returns name with extension
+ */
+export const addFileExtension = (name: string, extension: string) => {
+  const baseName = stripFileExtension(name.trim(), extension);
+  return `${baseName}${extension}`;
+};

--- a/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
@@ -19,7 +19,7 @@ import { useNamespace } from "~/util/store/namespace";
 import { useNotifications } from "~/api/notifications/query/get";
 import { useTranslation } from "react-i18next";
 import { useUpdateFile } from "~/api/files/mutate/updateFile";
-import workflowTypes from "~/assets/ts/workflow.d.ts?raw";
+import workflowTsDefinition from "~/assets/ts/workflow.d.ts?raw";
 
 const WorkflowEditor: FC<{
   data: NonNullable<FileSchemaType>;
@@ -74,7 +74,7 @@ const WorkflowEditor: FC<{
   const tsLibs = isTsWorkflow
     ? [
         {
-          content: workflowTypes,
+          content: workflowTsDefinition,
         },
       ]
     : [];

--- a/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
@@ -18,8 +18,8 @@ import { useEditorLayout } from "~/util/store/editor";
 import { useNamespace } from "~/util/store/namespace";
 import { useNotifications } from "~/api/notifications/query/get";
 import { useTranslation } from "react-i18next";
+import useTsEditorLibs from "~/hooks/useTsEditorLibs";
 import { useUpdateFile } from "~/api/files/mutate/updateFile";
-import workflowTsDefinition from "~/assets/ts/workflow.d.ts?raw";
 
 const WorkflowEditor: FC<{
   data: NonNullable<FileSchemaType>;
@@ -51,6 +51,13 @@ const WorkflowEditor: FC<{
 
   const [editorContent, setEditorContent] = useState(workflowDataFromServer);
 
+  const isTsWorkflow = data.mimeType === "application/x-typescript";
+  const language = isTsWorkflow ? "typescript" : "yaml";
+
+  const tsLibs = useTsEditorLibs(isTsWorkflow);
+
+  const localLayout = isTsWorkflow ? "code" : storedEditorLayout;
+
   const onEditorContentUpdate = (newData: string) => {
     setHasUnsavedChanges(workflowDataFromServer !== newData);
     setEditorContent(newData ?? "");
@@ -67,19 +74,6 @@ const WorkflowEditor: FC<{
   };
 
   if (!namespace) return null;
-
-  const isTsWorkflow = data.mimeType === "application/x-typescript";
-  const language = isTsWorkflow ? "typescript" : "yaml";
-
-  const tsLibs = isTsWorkflow
-    ? [
-        {
-          content: workflowTsDefinition,
-        },
-      ]
-    : [];
-
-  const localLayout = isTsWorkflow ? "code" : storedEditorLayout;
 
   return (
     <div className="relative flex grow flex-col space-y-4 p-5">

--- a/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
@@ -18,7 +18,7 @@ import { useEditorLayout } from "~/util/store/editor";
 import { useNamespace } from "~/util/store/namespace";
 import { useNotifications } from "~/api/notifications/query/get";
 import { useTranslation } from "react-i18next";
-import useTsEditorLibs from "~/hooks/useTsEditorLibs";
+import useTsWorkflowLibs from "~/hooks/useTsWorkflowLibs";
 import { useUpdateFile } from "~/api/files/mutate/updateFile";
 
 const WorkflowEditor: FC<{
@@ -54,7 +54,7 @@ const WorkflowEditor: FC<{
   const isTsWorkflow = data.mimeType === "application/x-typescript";
   const language = isTsWorkflow ? "typescript" : "yaml";
 
-  const tsLibs = useTsEditorLibs(isTsWorkflow);
+  const tsLibs = useTsWorkflowLibs(isTsWorkflow);
 
   const localLayout = isTsWorkflow ? "code" : storedEditorLayout;
 


### PR DESCRIPTION
## Description

This adds a "type" selector to the modal for creating a new workflow.

![image](https://github.com/direktiv/direktiv/assets/129740294/2617ebbe-0bf8-42d5-b1ad-9cb2a105c694)

In theory, it will then be possible to chose from a list of typescript templates. In practice, the list only contains one template yet.

The type selector is disabled unless this ENV feature flag is set to true:

```
# feature flag: enable option to create typescript-workflows in create workflow form.
VITE_ENABLE_TS_WORKFLOWS="TRUE" # true or TRUE will evaluate to true, everything else will be false
```

The feature flag is also found in `.env.example`. All it does is show/hide the select element. So TS workflows are supported all the time, but it won't be possible to create one in the form.

Typescript-Workflows must have the extension `.workflow.ts` (expected by the backend). The UI will check / automatically add this extension. I added a universal method that can also be used with other extensions, but it is not compatible with the method for `yaml` extensions where multiple valid extensions exist.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
