### PR TITLE
[DIR-1698] Link only to instance from instances list

### DIFF
--- a/ui/e2e/instances/list/index.spec.ts
+++ b/ui/e2e/instances/list/index.spec.ts
@@ -190,18 +190,6 @@ test("it renders the instance item correctly for failed and success status", asy
       "on hover, the absolute time should appear"
     ).toContainText(instanceDetail.endedAt ?? "no endedAt");
 
-    await instanceItemRow
-      .getByTestId("instance-column-name")
-      .getByRole("link")
-      .click();
-
-    await expect(
-      page,
-      "when the workflow name is clicked, page should navigate to the workflow page"
-    ).toHaveURL(`/n/${namespace}/explorer/workflow/edit${workflowName}`);
-
-    await page.goBack();
-
     await instanceItemRow.click();
     await expect(
       page,

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -523,7 +523,6 @@
     "monitoring": {
       "title": "Monitoring",
       "instances": {
-        "openWorkflowTooltip": "click to open workflow {{name}}",
         "successfulExecutions": {
           "title": "Successful Executions",
           "empty": "There are no recent successful executions."
@@ -560,8 +559,7 @@
         },
         "tableRow": {
           "realtiveTime": "{{relativeTime}} ago",
-          "stillRunning": "still running",
-          "openWorkflowTooltip": "click to open workflow {{name}}"
+          "stillRunning": "still running"
         },
         "filter": {
           "filterButton": "Filter",

--- a/ui/src/pages/namespace/Instances/List/Row.tsx
+++ b/ui/src/pages/namespace/Instances/List/Row.tsx
@@ -3,7 +3,6 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "~/design/HoverCard";
-import { Link, useNavigate } from "react-router-dom";
 import { TableCell, TableRow } from "~/design/Table";
 import {
   Tooltip,
@@ -21,6 +20,7 @@ import TooltipCopyBadge from "~/design/TooltipCopyBadge";
 import { decode } from "js-base64";
 import moment from "moment";
 import { statusToBadgeVariant } from "../utils";
+import { useNavigate } from "react-router-dom";
 import { usePages } from "~/util/router/pages";
 import { useTranslation } from "react-i18next";
 import useUpdatedAt from "~/hooks/useUpdatedAt";
@@ -53,28 +53,7 @@ const InstanceTableRow: FC<{
         className="cursor-pointer"
       >
         <TableCell data-testid="instance-column-name">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link
-                onClick={(e) => {
-                  e.stopPropagation(); // prevent the onClick on the row from firing when clicking the workflow link
-                }}
-                to={pages.explorer.createHref({
-                  namespace: instance.namespace,
-                  path: instance.path,
-                  subpage: "workflow",
-                })}
-                className="hover:underline"
-              >
-                {instance.path}
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent>
-              {t("pages.instances.list.tableRow.openWorkflowTooltip", {
-                name: instance.path,
-              })}
-            </TooltipContent>
-          </Tooltip>
+          {instance.path}
         </TableCell>
         <TableCell data-testid="instance-column-id">
           <TooltipCopyBadge value={instance.id} variant="outline">

--- a/ui/src/pages/namespace/Monitoring/Instances/Row.tsx
+++ b/ui/src/pages/namespace/Monitoring/Instances/Row.tsx
@@ -3,7 +3,6 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "~/design/HoverCard";
-import { Link, useNavigate } from "react-router-dom";
 import { TableCell, TableRow } from "~/design/Table";
 import {
   Tooltip,
@@ -20,6 +19,7 @@ import TooltipCopyBadge from "~/design/TooltipCopyBadge";
 import moment from "moment";
 import { statusToBadgeVariant } from "../../Instances/utils";
 import { useNamespace } from "~/util/store/namespace";
+import { useNavigate } from "react-router-dom";
 import { usePages } from "~/util/router/pages";
 import { useTranslation } from "react-i18next";
 import useUpdatedAt from "~/hooks/useUpdatedAt";
@@ -47,30 +47,7 @@ export const InstanceRow = ({ instance }: { instance: InstanceSchemaType }) => {
         }}
         className="cursor-pointer"
       >
-        <TableCell className="grid pl-5">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link
-                onClick={(e) => {
-                  e.stopPropagation(); // prevent the onClick on the row from firing when clicking the workflow link
-                }}
-                to={pages.explorer.createHref({
-                  namespace,
-                  path: instance.path,
-                  subpage: "workflow",
-                })}
-                className="overflow-hidden text-ellipsis hover:underline md:w-auto"
-              >
-                {instance.path}
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent>
-              {t("pages.monitoring.instances.openWorkflowTooltip", {
-                name: instance.path,
-              })}
-            </TooltipContent>
-          </Tooltip>
-        </TableCell>
+        <TableCell className="grid pl-5">{instance.path}</TableCell>
         <TableCell className="w-0">
           <TooltipCopyBadge value={instance.id} variant="outline">
             {instance.id.slice(0, 8)}


### PR DESCRIPTION
## Description

Clicking on an instance in the list now always navigates to the instance. The instance's workflow can still be opened from the instance detail view. The direct link to the workflow was removed from the instance list because it confused users intending to navigate to the instance.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
