### PR TITLE
[DIR-1726] make preview overlay work with long path names

### DIFF
--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/FileViewer.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/FileViewer.tsx
@@ -10,6 +10,7 @@ import Button from "~/design/Button";
 import { Card } from "~/design/Card";
 import Editor from "~/design/Editor";
 import { File } from "lucide-react";
+import { analyzePath } from "~/util/router/utils";
 import { decode } from "js-base64";
 import { mimeTypeToEditorSyntax } from "~/design/Editor/utils";
 import { useFile } from "~/api/files/query/file";
@@ -39,6 +40,9 @@ const FileViewer = ({ file }: { file: BaseFileSchemaType }) => {
 
   if (data?.type === "directory") return null;
 
+  const path = analyzePath(file.path);
+  const filename = path.segments.at(-1)?.relative;
+
   const fileContent = decode(data?.data ?? "");
   const mimeType = data?.mimeType;
 
@@ -54,7 +58,7 @@ const FileViewer = ({ file }: { file: BaseFileSchemaType }) => {
     <>
       <DialogHeader>
         <DialogTitle>
-          <File /> {t("pages.explorer.tree.fileViewer.title")} {file.path}
+          <File /> {t("pages.explorer.tree.fileViewer.title")} {filename}
         </DialogTitle>
       </DialogHeader>
       <Card className="grow p-4" background="weight-1">


### PR DESCRIPTION
## Description

Previewing files could destroy the overlay if the path was very long. I fixed this by only showing the filename and not the path. There is still a possibility that this problem could occur if the filename is very long, but I went for an easy and quick fix for now. Extremely long filenames will also need some more love in other parts of the app. 

Before

![CleanShot 2024-08-26 at 09 15 45@2x](https://github.com/user-attachments/assets/fa90d7d3-b325-446d-809d-6b9da5a3612c)

After

![CleanShot 2024-08-26 at 09 15 22@2x](https://github.com/user-attachments/assets/f1fcec4d-4fb6-4b2c-94d3-1c528a5652da)

---
It is not possible to have previewable files in the file tree without a git repository. To easily test the bug locally locally, I made this change to make all workflow files previewable.

**src/api/files/utils.ts**
```
export const isPreviewable = (type: BaseFileSchemaType["type"]) =>
  type === "file" || type === "workflow";
```

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
