### PR TITLE
add pnpm i to the the pre build checks

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -105,6 +105,7 @@
     "check:lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0 --report-unused-disable-directives --cache",
     "check:types": "tsc --tsBuildInfoFile .tsbuildinfo --incremental",
     "check:prettier": "prettier --check './{src,test,e2e}/**/*.{js,jsx,ts,tsx,json,scss,css}' --cache",
+    "check:deps": "pnpm install --frozen-lockfile",
     "check:test": "vitest run",
     "e2e:headless": "pnpm exec playwright test --project \"chromium\" --project \"firefox\"",
     "e2e:headless-chromium-only": "pnpm exec playwright test --project \"chromium\"  --reporter=line",


### PR DESCRIPTION
## Description

When someone modifies the package.json and forgets to do a pnpm install or does not push the changes from the pnpm-lock.yaml, this should be treated as an error in our ci.

Or in other words, when our CI/CD pipeline is green, we should be sure that all packages from the packages.json are reflected in the pnpm-lock.yaml.

## Checklist

- [ ] Documentation updated if required
- [ ] Test coverage is appropriate
      
## Checklist Internal

- [ ] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [ ] Has the PR been labeled
