### PR TITLE
Added environment to create "page" files

### DIFF
--- a/ui/src/api/files/schema.ts
+++ b/ui/src/api/files/schema.ts
@@ -56,6 +56,7 @@ export const fileTypes = [
   "file",
   "service",
   "workflow",
+  "page",
 ] as const;
 
 const FileTypeSchema = z.enum(fileTypes);
@@ -88,7 +89,7 @@ const CreateDirectorySchema = z.object({
 });
 
 const CreateYamlFileSchema = z.object({
-  type: z.enum(["consumer", "endpoint", "service", "workflow"]),
+  type: z.enum(["consumer", "endpoint", "service", "workflow", "page"]),
   name: z.string().nonempty(),
   mimeType: z.literal("application/yaml"),
   data: z.string(), // base64 encoded file body
@@ -110,12 +111,17 @@ const CreateWorkflowSchema = CreateYamlFileSchema.extend({
   type: z.literal("workflow"),
 });
 
+const CreatePageSchema = CreateYamlFileSchema.extend({
+  type: z.literal("page"),
+});
+
 const CreateFileSchema = z.discriminatedUnion("type", [
   CreateDirectorySchema,
   CreateConsumerSchema,
   CreateEndpointSchema,
   CreateServiceSchema,
   CreateWorkflowSchema,
+  CreatePageSchema,
 ]);
 
 const RenameFileSchema = z.object({

--- a/ui/src/api/files/utils.ts
+++ b/ui/src/api/files/utils.ts
@@ -1,4 +1,12 @@
-import { File, Folder, Layers, Play, Users, Workflow } from "lucide-react";
+import {
+  File,
+  Folder,
+  Layers,
+  PanelTop,
+  Play,
+  Users,
+  Workflow,
+} from "lucide-react";
 
 import { BaseFileSchemaType } from "./schema";
 import { ExplorerSubpages } from "~/util/router/pages";
@@ -72,6 +80,8 @@ export const fileTypeToIcon = (type: BaseFileSchemaType["type"]) => {
       return Workflow;
     case "consumer":
       return Users;
+    case "page":
+      return PanelTop;
     default:
       return File;
   }
@@ -89,6 +99,8 @@ export const fileTypeToExplorerSubpage = (
       return "endpoint";
     case "consumer":
       return "consumer";
+    case "page":
+      return "page";
     default:
       return undefined;
   }

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -96,6 +96,10 @@
               "label": "Gateway",
               "route": "New Route",
               "consumer": "New Consumer"
+            },
+            "uibuilder": {
+              "label": "UI Builder",
+              "page": "New Page"
             }
           }
         },
@@ -128,6 +132,14 @@
           "title": "Create a new consumer",
           "nameLabel": "Name",
           "namePlaceholder": "consumer-name.yaml",
+          "nameAlreadyExists": "The name already exists",
+          "cancelBtn": "Cancel",
+          "createBtn": "Create"
+        },
+        "newPage": {
+          "title": "Create a new page",
+          "nameLabel": "Name",
+          "namePlaceholder": "page-name.yaml",
           "nameAlreadyExists": "The name already exists",
           "cancelBtn": "Cancel",
           "createBtn": "Create"

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/index.tsx
@@ -1,0 +1,139 @@
+import {
+  Controller,
+  DeepPartialSkipArrayKey,
+  UseFormReturn,
+  useForm,
+} from "react-hook-form";
+import { EndpointFormSchema, EndpointFormSchemaType } from "../schema";
+
+import { AuthPluginForm } from "./plugins/Auth";
+import Badge from "~/design/Badge";
+import { Checkbox } from "~/design/Checkbox";
+import { FC } from "react";
+import { Fieldset } from "~/components/Form/Fieldset";
+import { InboundPluginForm } from "./plugins/Inbound";
+import Input from "~/design/Input";
+import { OutboundPluginForm } from "./plugins/Outbound";
+import { Switch } from "~/design/Switch";
+import { TargetPluginForm } from "./plugins/Target";
+import { routeMethods } from "~/api/gateway/schema";
+import { treatAsNumberOrUndefined } from "../../../utils";
+import { useSortedValues } from "./utils";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type FormProps = {
+  defaultConfig?: EndpointFormSchemaType;
+  onSave: (value: EndpointFormSchemaType) => void;
+  children: (args: {
+    formControls: UseFormReturn<EndpointFormSchemaType>;
+    formMarkup: JSX.Element;
+    values: DeepPartialSkipArrayKey<EndpointFormSchemaType>;
+  }) => JSX.Element;
+};
+
+export const Form: FC<FormProps> = ({ defaultConfig, children, onSave }) => {
+  const { t } = useTranslation();
+  const formControls = useForm<EndpointFormSchemaType>({
+    resolver: zodResolver(EndpointFormSchema),
+    defaultValues: {
+      ...defaultConfig,
+    },
+  });
+
+  const values = useSortedValues(formControls.control);
+  const { register, control } = formControls;
+
+  return children({
+    formControls,
+    values,
+    formMarkup: (
+      <div className="flex flex-col gap-8">
+        <div className="flex gap-3">
+          <Fieldset
+            label={t("pages.explorer.endpoint.editor.form.path")}
+            htmlFor="path"
+            className="grow"
+          >
+            <Input {...register("path")} id="path" />
+          </Fieldset>
+          <Fieldset
+            label={t("pages.explorer.endpoint.editor.form.timeout")}
+            htmlFor="timeout"
+            className="w-32"
+          >
+            <Input
+              {...register("timeout", {
+                setValueAs: treatAsNumberOrUndefined,
+              })}
+              type="number"
+              id="timeout"
+            />
+          </Fieldset>
+        </div>
+        <Fieldset label={t("pages.explorer.endpoint.editor.form.methods")}>
+          <Controller
+            control={control}
+            name="methods"
+            render={({ field }) => (
+              <div className="grid grid-cols-3 gap-5">
+                {routeMethods.map((method) => {
+                  const isChecked = field.value?.includes(method);
+                  return (
+                    <label
+                      key={method}
+                      className="flex items-center gap-2 text-sm"
+                      htmlFor={method}
+                    >
+                      <Checkbox
+                        id={method}
+                        value={method}
+                        checked={isChecked}
+                        onCheckedChange={(checked) => {
+                          if (checked === true) {
+                            field.onChange([...(field.value ?? []), method]);
+                          }
+                          if (checked === false && field.value) {
+                            field.onChange(
+                              field.value.filter((v) => v !== method)
+                            );
+                          }
+                        }}
+                      />
+                      <Badge variant={isChecked ? undefined : "secondary"}>
+                        {method}
+                      </Badge>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t("pages.explorer.endpoint.editor.form.allowAnonymous")}
+          htmlFor="allow_anonymous"
+          horizontal
+        >
+          <Controller
+            control={control}
+            name="allow_anonymous"
+            render={({ field }) => (
+              <Switch
+                defaultChecked={field.value ?? false}
+                onCheckedChange={(value) => {
+                  field.onChange(value);
+                }}
+                id="allow_anonymous"
+              />
+            )}
+          />
+        </Fieldset>
+        <TargetPluginForm form={formControls} onSave={onSave} />
+        <InboundPluginForm form={formControls} onSave={onSave} />
+        <OutboundPluginForm form={formControls} onSave={onSave} />
+        <AuthPluginForm formControls={formControls} onSave={onSave} />
+      </div>
+    ),
+  });
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Auth/BasicAuthForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Auth/BasicAuthForm.tsx
@@ -1,0 +1,119 @@
+import {
+  BasicAuthFormSchema,
+  BasicAuthFormSchemaType,
+} from "../../../schema/plugins/auth/basicAuth";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+
+import { Checkbox } from "~/design/Checkbox";
+import { Fieldset } from "~/components/Form/Fieldset";
+import { PluginWrapper } from "../components/PluginSelector";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<BasicAuthFormSchemaType["configuration"]>;
+
+const predefinedConfig: OptionalConfig = {
+  add_groups_header: false,
+  add_tags_header: false,
+  add_username_header: false,
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: BasicAuthFormSchemaType) => void;
+};
+
+export const BasicAuthForm: FC<FormProps> = ({
+  defaultConfig,
+  formId,
+  onSubmit,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    setValue,
+    getValues,
+    formState: { errors },
+  } = useForm<BasicAuthFormSchemaType>({
+    resolver: zodResolver(BasicAuthFormSchema),
+    defaultValues: {
+      type: "basic-auth",
+      configuration: {
+        ...predefinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.basciAuth.addUsernameHeader"
+          )}
+          htmlFor="add-username-header"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.add_username_header")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.add_username_header", value);
+              }
+            }}
+            id="add-username-header"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.basciAuth.addTagsHeader"
+          )}
+          htmlFor="add-tags-header"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.add_tags_header")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.add_tags_header", value);
+              }
+            }}
+            id="add-tags-header"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.basciAuth.addGroupsHeader"
+          )}
+          horizontal
+          htmlFor="add-groups-header"
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.add_groups_header")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.add_groups_header", value);
+              }
+            }}
+            id="add-groups-header"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Auth/KeyAuthForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Auth/KeyAuthForm.tsx
@@ -1,0 +1,138 @@
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  KeyAuthFormSchema,
+  KeyAuthFormSchemaType,
+} from "../../../schema/plugins/auth/keyAuth";
+
+import { Checkbox } from "~/design/Checkbox";
+import { Fieldset } from "~/components/Form/Fieldset";
+import Input from "~/design/Input";
+import { PluginWrapper } from "../components/PluginSelector";
+import { treatEmptyStringAsUndefined } from "~/pages/namespace/Explorer/utils";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<KeyAuthFormSchemaType["configuration"]>;
+
+const predefinedConfig: OptionalConfig = {
+  add_groups_header: true,
+  add_tags_header: true,
+  add_username_header: true,
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: KeyAuthFormSchemaType) => void;
+};
+
+export const KeyAuthForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    setValue,
+    getValues,
+    register,
+    formState: { errors },
+  } = useForm<KeyAuthFormSchemaType>({
+    resolver: zodResolver(KeyAuthFormSchema),
+    defaultValues: {
+      type: "key-auth",
+      configuration: {
+        ...predefinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.keyAuth.addUsernameHeader"
+          )}
+          htmlFor="add-username-header"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.add_username_header")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.add_username_header", value);
+              }
+            }}
+            id="add-username-header"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.keyAuth.addTagsHeader"
+          )}
+          htmlFor="add-tags-header"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.add_tags_header")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.add_tags_header", value);
+              }
+            }}
+            id="add-tags-header"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.keyAuth.addGroupsHeader"
+          )}
+          htmlFor="add-groups-header"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.add_groups_header")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.add_groups_header", value);
+              }
+            }}
+            id="add-groups-header"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.keyAuth.keyName"
+          )}
+          htmlFor="key-name"
+        >
+          <Input
+            {...register("configuration.key_name", {
+              setValueAs: treatEmptyStringAsUndefined,
+            })}
+            placeholder={t(
+              "pages.explorer.endpoint.editor.form.plugins.auth.keyAuth.keyNamePlaceholder"
+            )}
+            id="key-name"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Auth/WebhookAuthForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Auth/WebhookAuthForm.tsx
@@ -1,0 +1,70 @@
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  WebhookAuthFormSchema,
+  WebhookAuthFormSchemaType,
+} from "../../../schema/plugins/auth/webhookAuth";
+
+import { Fieldset } from "~/components/Form/Fieldset";
+import Input from "~/design/Input";
+import { PluginWrapper } from "../components/PluginSelector";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<WebhookAuthFormSchemaType["configuration"]>;
+
+type FormProps = {
+  defaultConfig?: OptionalConfig;
+  formId: string;
+  type: WebhookAuthFormSchemaType["type"];
+  onSubmit: (data: WebhookAuthFormSchemaType) => void;
+};
+
+export const WebhookAuthForm: FC<FormProps> = ({
+  defaultConfig,
+  formId,
+  type,
+  onSubmit,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+  } = useForm<WebhookAuthFormSchemaType>({
+    resolver: zodResolver(WebhookAuthFormSchema),
+    defaultValues: {
+      type,
+      configuration: {
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.githubWebhookAuth.secret"
+          )}
+          htmlFor="secret"
+        >
+          <Input {...register("configuration.secret")} id="secret" />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Auth/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Auth/index.tsx
@@ -1,0 +1,241 @@
+import { Dialog, DialogTrigger } from "~/design/Dialog";
+import { FC, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/design/Select";
+import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
+import { UseFormReturn, useFieldArray } from "react-hook-form";
+import {
+  WebhookAuthFormSchemaType,
+  webhookAuthPluginNames,
+} from "../../../schema/plugins/auth/webhookAuth";
+import {
+  authPluginTypes,
+  useAvailablePlugins,
+} from "../../../schema/plugins/auth";
+import {
+  getBasicAuthConfigAtIndex,
+  getKeyAuthConfigAtIndex,
+  getWebhookAuthConfigAtIndex,
+} from "../utils";
+
+import { AuthPluginFormSchemaType } from "../../../schema/plugins/auth/schema";
+import { BasicAuthForm } from "./BasicAuthForm";
+import { BasicAuthFormSchemaType } from "../../../schema/plugins/auth/basicAuth";
+import Button from "~/design/Button";
+import { Card } from "~/design/Card";
+import { EndpointFormSchemaType } from "../../../schema";
+import { KeyAuthForm } from "./KeyAuthForm";
+import { KeyAuthFormSchemaType } from "../../../schema/plugins/auth/keyAuth";
+import { ListContextMenu } from "~/components/ListContextMenu";
+import { ModalWrapper } from "~/components/ModalWrapper";
+import { PluginSelector } from "../components/PluginSelector";
+import { Plus } from "lucide-react";
+import { TableHeader } from "../components/PluginsTable";
+import { WebhookAuthForm } from "./WebhookAuthForm";
+import { useTranslation } from "react-i18next";
+
+type AuthPluginFormProps = {
+  formControls: UseFormReturn<EndpointFormSchemaType>;
+  onSave: (value: EndpointFormSchemaType) => void;
+};
+
+export const AuthPluginForm: FC<AuthPluginFormProps> = ({
+  formControls,
+  onSave,
+}) => {
+  const { t } = useTranslation();
+  const availablePlugins = useAvailablePlugins();
+  const { control, handleSubmit: handleParentSubmit } = formControls;
+  const {
+    append: addPlugin,
+    remove: deletePlugin,
+    move: movePlugin,
+    update: editPlugin,
+    fields,
+  } = useFieldArray({
+    control,
+    name: "plugins.auth",
+  });
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editIndex, setEditIndex] = useState<number>();
+
+  const [selectedPlugin, setSelectedPlugin] =
+    useState<AuthPluginFormSchemaType["type"]>();
+
+  const pluginsCount = fields.length;
+  const formId = "authPluginForm";
+
+  type PluginConfigSchema =
+    | BasicAuthFormSchemaType
+    | KeyAuthFormSchemaType
+    | WebhookAuthFormSchemaType;
+
+  const handleSubmit = (configuration: PluginConfigSchema) => {
+    setDialogOpen(false);
+    if (editIndex === undefined) {
+      addPlugin(configuration);
+    } else {
+      editPlugin(editIndex, configuration);
+    }
+    handleParentSubmit(onSave)();
+    setEditIndex(undefined);
+  };
+
+  return (
+    <Dialog
+      open={dialogOpen}
+      onOpenChange={(isOpen) => {
+        if (isOpen === false) setEditIndex(undefined);
+        setDialogOpen(isOpen);
+      }}
+    >
+      <Card noShadow>
+        <Table>
+          <TableHeader
+            title={t(
+              "pages.explorer.endpoint.editor.form.plugins.auth.table.headline",
+              {
+                count: pluginsCount,
+              }
+            )}
+          >
+            <DialogTrigger asChild>
+              <Button icon variant="outline" size="sm">
+                <Plus />
+                {t(
+                  "pages.explorer.endpoint.editor.form.plugins.auth.table.addButton"
+                )}
+              </Button>
+            </DialogTrigger>
+          </TableHeader>
+          <TableBody>
+            {fields.map(({ id, type }, index, srcArray) => {
+              const canMoveDown = index < srcArray.length - 1;
+              const canMoveUp = index > 0;
+              const onMoveUp = canMoveUp
+                ? () => {
+                    movePlugin(index, index - 1);
+                  }
+                : undefined;
+              const onMoveDown = canMoveDown
+                ? () => {
+                    movePlugin(index, index + 1);
+                  }
+                : undefined;
+              const onDelete = () => {
+                deletePlugin(index);
+              };
+
+              return (
+                <TableRow
+                  key={id}
+                  className="cursor-pointer"
+                  onClick={() => {
+                    setSelectedPlugin(type);
+                    setDialogOpen(true);
+                    setEditIndex(index);
+                  }}
+                >
+                  <TableCell>
+                    {t(
+                      `pages.explorer.endpoint.editor.form.plugins.auth.types.${type}`
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <ListContextMenu
+                      onDelete={onDelete}
+                      onMoveDown={onMoveDown}
+                      onMoveUp={onMoveUp}
+                    />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Card>
+
+      <ModalWrapper
+        formId={formId}
+        showSaveBtn={!!selectedPlugin}
+        title={
+          editIndex === undefined
+            ? t(
+                "pages.explorer.endpoint.editor.form.plugins.auth.modal.headlineAdd"
+              )
+            : t(
+                "pages.explorer.endpoint.editor.form.plugins.auth.modal.headlineEdit"
+              )
+        }
+        onCancel={() => {
+          setDialogOpen(false);
+        }}
+      >
+        <PluginSelector
+          title={t(
+            "pages.explorer.endpoint.editor.form.plugins.auth.modal.label"
+          )}
+        >
+          <Select
+            onValueChange={(e) => {
+              setSelectedPlugin(e as typeof selectedPlugin);
+            }}
+            value={selectedPlugin}
+          >
+            <SelectTrigger variant="outline" className="grow">
+              <SelectValue
+                placeholder={t(
+                  "pages.explorer.endpoint.editor.form.plugins.auth.modal.placeholder"
+                )}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {availablePlugins.map(({ name: pluginName }) => (
+                <SelectItem key={pluginName} value={pluginName}>
+                  {t(
+                    `pages.explorer.endpoint.editor.form.plugins.auth.types.${pluginName}`
+                  )}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </PluginSelector>
+        {selectedPlugin === authPluginTypes.basicAuth.name && (
+          <BasicAuthForm
+            formId={formId}
+            defaultConfig={getBasicAuthConfigAtIndex(fields, editIndex)}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === authPluginTypes.keyAuth.name && (
+          <KeyAuthForm
+            formId={formId}
+            defaultConfig={getKeyAuthConfigAtIndex(fields, editIndex)}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {webhookAuthPluginNames.map(
+          (name) =>
+            selectedPlugin === name && (
+              <WebhookAuthForm
+                key={name}
+                type={name}
+                formId={formId}
+                defaultConfig={getWebhookAuthConfigAtIndex(
+                  name,
+                  fields,
+                  editIndex
+                )}
+                onSubmit={handleSubmit}
+              />
+            )
+        )}
+      </ModalWrapper>
+    </Dialog>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/AclForm/AclArrayForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/AclForm/AclArrayForm.tsx
@@ -1,0 +1,59 @@
+import { AclFormSchemaType } from "../../../../schema/plugins/inbound/acl";
+import { ArrayForm } from "~/components/Form/Array";
+import { ControllerRenderProps } from "react-hook-form";
+import Input from "~/design/Input";
+import { useTranslation } from "react-i18next";
+
+type AclArrayFormProps = {
+  field:
+    | ControllerRenderProps<AclFormSchemaType, "configuration.allow_groups">
+    | ControllerRenderProps<AclFormSchemaType, "configuration.allow_tags">
+    | ControllerRenderProps<AclFormSchemaType, "configuration.deny_groups">
+    | ControllerRenderProps<AclFormSchemaType, "configuration.deny_tags">;
+};
+
+const fieldNameToLanguageKey = (
+  field:
+    | "configuration.allow_groups"
+    | "configuration.allow_tags"
+    | "configuration.deny_groups"
+    | "configuration.deny_tags"
+) => {
+  switch (field) {
+    case "configuration.allow_groups":
+    case "configuration.deny_groups":
+      return "groupPlaceholder";
+    case "configuration.allow_tags":
+    case "configuration.deny_tags":
+      return "tagPlaceholder";
+  }
+};
+
+export const AclArrayForm = ({ field }: AclArrayFormProps) => {
+  const { t } = useTranslation();
+  return (
+    <div className="grid gap-5 sm:grid-cols-2">
+      <ArrayForm
+        defaultValue={field.value || []}
+        onChange={field.onChange}
+        emptyItem=""
+        itemIsValid={(item) => item !== ""}
+        renderItem={({ value, setValue, handleKeyDown }) => (
+          <Input
+            placeholder={t(
+              `pages.explorer.endpoint.editor.form.plugins.inbound.acl.${fieldNameToLanguageKey(
+                field.name
+              )}`
+            )}
+            value={value}
+            onKeyDown={handleKeyDown}
+            onChange={(e) => {
+              const newValue = e.target.value;
+              setValue(newValue);
+            }}
+          />
+        )}
+      />
+    </div>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/AclForm/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/AclForm/index.tsx
@@ -1,0 +1,108 @@
+import {
+  AclFormSchema,
+  AclFormSchemaType,
+} from "../../../../schema/plugins/inbound/acl";
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+
+import { AclArrayForm } from "./AclArrayForm";
+import { Fieldset } from "~/components/Form/Fieldset";
+import { PluginWrapper } from "../../components/PluginSelector";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<AclFormSchemaType["configuration"]>;
+
+const predefinedConfig: OptionalConfig = {
+  allow_groups: [],
+  deny_groups: [],
+  allow_tags: [],
+  deny_tags: [],
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: AclFormSchemaType) => void;
+};
+
+export const AclForm: FC<FormProps> = ({ defaultConfig, onSubmit, formId }) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+  } = useForm<AclFormSchemaType>({
+    resolver: zodResolver(AclFormSchema),
+    defaultValues: {
+      type: "acl",
+      configuration: {
+        ...predefinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      {errors?.configuration && (
+        <FormErrors
+          errors={errors?.configuration as errorsType}
+          className="mb-5"
+        />
+      )}
+      <PluginWrapper>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.acl.allow_groups"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.allow_groups"
+            render={({ field }) => <AclArrayForm field={field} />}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.acl.deny_groups"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.deny_groups"
+            render={({ field }) => <AclArrayForm field={field} />}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.acl.allow_tags"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.allow_tags"
+            render={({ field }) => <AclArrayForm field={field} />}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.acl.deny_tags"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.deny_tags"
+            render={({ field }) => <AclArrayForm field={field} />}
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/EventFilterForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/EventFilterForm.tsx
@@ -1,0 +1,109 @@
+import { Controller, useForm } from "react-hook-form";
+import {
+  EventFilterFormSchema,
+  EventFilterFormSchemaType,
+} from "../../../schema/plugins/inbound/eventFilter";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+
+import { Card } from "~/design/Card";
+import { Checkbox } from "~/design/Checkbox";
+import Editor from "~/design/Editor";
+import { Fieldset } from "~/components/Form/Fieldset";
+import { PluginWrapper } from "../components/PluginSelector";
+import { useTheme } from "~/util/store/theme";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<EventFilterFormSchemaType["configuration"]>;
+
+const predefinedConfig: OptionalConfig = {
+  allow_non_events: false,
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: EventFilterFormSchemaType) => void;
+};
+
+export const EventFilterForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    setValue,
+    getValues,
+    formState: { errors },
+    control,
+  } = useForm<EventFilterFormSchemaType>({
+    resolver: zodResolver(EventFilterFormSchema),
+    defaultValues: {
+      type: "event-filter",
+      configuration: {
+        ...predefinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  const theme = useTheme();
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      {errors?.configuration && (
+        <FormErrors
+          errors={errors?.configuration as errorsType}
+          className="mb-5"
+        />
+      )}
+      <PluginWrapper>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.eventFilter.script"
+          )}
+        >
+          <Card className="h-[200px] w-full p-5" background="weight-1" noShadow>
+            <Controller
+              control={control}
+              name="configuration.script"
+              render={({ field }) => (
+                <Editor
+                  theme={theme ?? undefined}
+                  language="javascript"
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </Card>
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.eventFilter.allow_non_events"
+          )}
+          htmlFor="allow_non_events"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.allow_non_events")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.allow_non_events", value);
+              }
+            }}
+            id="allow_non_events"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/HeaderManipulationForm/HeaderArrayForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/HeaderManipulationForm/HeaderArrayForm.tsx
@@ -1,0 +1,64 @@
+import { ArrayForm } from "~/components/Form/Array";
+import { ControllerRenderProps } from "react-hook-form";
+import { HeaderManipulationFormSchemaType } from "../../../../schema/plugins/inbound/headerManipulation";
+import Input from "~/design/Input";
+import { useTranslation } from "react-i18next";
+
+type HeaderArrayFormProps = {
+  field:
+    | ControllerRenderProps<
+        HeaderManipulationFormSchemaType,
+        "configuration.headers_to_add"
+      >
+    | ControllerRenderProps<
+        HeaderManipulationFormSchemaType,
+        "configuration.headers_to_modify"
+      >
+    | ControllerRenderProps<
+        HeaderManipulationFormSchemaType,
+        "configuration.headers_to_remove"
+      >;
+};
+
+export const HeaderArrayForm = ({ field }: HeaderArrayFormProps) => {
+  const { t } = useTranslation();
+  const isHeadersToRemove = field.name === "configuration.headers_to_remove";
+  const emptyItem = isHeadersToRemove ? { name: "" } : { name: "", value: "" };
+  return (
+    <div className="grid gap-5">
+      <ArrayForm
+        defaultValue={field.value || []}
+        onChange={field.onChange}
+        emptyItem={emptyItem}
+        itemIsValid={(item) =>
+          !!item && Object.values(item).every((v) => v !== "")
+        }
+        renderItem={({ value: objectValue, setValue, handleKeyDown }) => (
+          <>
+            {Object.entries(objectValue).map(([key, value]) => {
+              const typedKey = key as keyof typeof objectValue;
+              return (
+                <Input
+                  key={key}
+                  data-testid={`env-${typedKey}`}
+                  placeholder={t(
+                    `pages.explorer.endpoint.editor.form.plugins.inbound.headerManipulation.${typedKey}Placeholder`
+                  )}
+                  value={value}
+                  onKeyDown={handleKeyDown}
+                  onChange={(e) => {
+                    const newObject = {
+                      ...objectValue,
+                      [key]: e.target.value,
+                    };
+                    setValue(newObject);
+                  }}
+                />
+              );
+            })}
+          </>
+        )}
+      />
+    </div>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/HeaderManipulationForm/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/HeaderManipulationForm/index.tsx
@@ -1,0 +1,104 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  HeaderManipulationFormSchema,
+  HeaderManipulationFormSchemaType,
+} from "../../../../schema/plugins/inbound/headerManipulation";
+
+import { Fieldset } from "~/components/Form/Fieldset";
+import { HeaderArrayForm } from "./HeaderArrayForm";
+import { PluginWrapper } from "../../components/PluginSelector";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<
+  HeaderManipulationFormSchemaType["configuration"]
+>;
+
+const predefinedConfig: OptionalConfig = {
+  headers_to_add: [],
+  headers_to_modify: [],
+  headers_to_remove: [],
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: HeaderManipulationFormSchemaType) => void;
+};
+
+export const HeaderManipulationForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+  } = useForm<HeaderManipulationFormSchemaType>({
+    resolver: zodResolver(HeaderManipulationFormSchema),
+    defaultValues: {
+      type: "header-manipulation",
+      configuration: {
+        ...predefinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      {errors?.configuration && (
+        <FormErrors
+          errors={errors?.configuration as errorsType}
+          className="mb-5"
+        />
+      )}
+      <PluginWrapper>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.headerManipulation.headers_to_add"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.headers_to_add"
+            render={({ field }) => <HeaderArrayForm field={field} />}
+          />
+        </Fieldset>
+
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.headerManipulation.headers_to_modify"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.headers_to_modify"
+            render={({ field }) => <HeaderArrayForm field={field} />}
+          />
+        </Fieldset>
+
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.headerManipulation.headers_to_remove"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.headers_to_remove"
+            render={({ field }) => <HeaderArrayForm field={field} />}
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/JsInboundForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/JsInboundForm.tsx
@@ -1,0 +1,84 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  JsInboundFormSchema,
+  JsInboundFormSchemaType,
+} from "../../../schema/plugins/inbound/jsInbound";
+
+import { Card } from "~/design/Card";
+import Editor from "~/design/Editor";
+import { Fieldset } from "~/components/Form/Fieldset";
+import { PluginWrapper } from "../components/PluginSelector";
+import { useTheme } from "~/util/store/theme";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<JsInboundFormSchemaType["configuration"]>;
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: JsInboundFormSchemaType) => void;
+};
+
+export const JsInboundForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+  } = useForm<JsInboundFormSchemaType>({
+    resolver: zodResolver(JsInboundFormSchema),
+    defaultValues: {
+      type: "js-inbound",
+      configuration: {
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  const theme = useTheme();
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      {errors?.configuration && (
+        <FormErrors
+          errors={errors?.configuration as errorsType}
+          className="mb-5"
+        />
+      )}
+      <PluginWrapper>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.jsInbound.script"
+          )}
+        >
+          <Card className="h-[200px] w-full p-5" background="weight-1" noShadow>
+            <Controller
+              control={control}
+              name="configuration.script"
+              render={({ field }) => (
+                <Editor
+                  theme={theme ?? undefined}
+                  language="javascript"
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </Card>
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/RequestConvertForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/RequestConvertForm.tsx
@@ -1,0 +1,137 @@
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  RequestConvertFormSchema,
+  RequestConvertFormSchemaType,
+} from "../../../schema/plugins/inbound/requestConvert";
+
+import { Checkbox } from "~/design/Checkbox";
+import { Fieldset } from "~/components/Form/Fieldset";
+import { PluginWrapper } from "../components/PluginSelector";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<RequestConvertFormSchemaType["configuration"]>;
+
+const predefinedConfig: OptionalConfig = {
+  omit_body: false,
+  omit_headers: false,
+  omit_consumer: false,
+  omit_queries: false,
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: RequestConvertFormSchemaType) => void;
+};
+
+export const RequestConvertForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    setValue,
+    getValues,
+    formState: { errors },
+  } = useForm<RequestConvertFormSchemaType>({
+    resolver: zodResolver(RequestConvertFormSchema),
+    defaultValues: {
+      type: "request-convert",
+      configuration: {
+        ...predefinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.requestConvert.omitHeaders"
+          )}
+          htmlFor="omit-headers"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.omit_headers")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.omit_headers", value);
+              }
+            }}
+            id="omit-headers"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.requestConvert.omitQueries"
+          )}
+          htmlFor="omit-queries"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.omit_queries")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.omit_queries", value);
+              }
+            }}
+            id="omit-queries"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.requestConvert.omitBody"
+          )}
+          htmlFor="omit-body"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.omit_body")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.omit_body", value);
+              }
+            }}
+            id="omit-body"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.requestConvert.omitConsumer"
+          )}
+          htmlFor="omit-consumer"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.omit_consumer")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.omit_consumer", value);
+              }
+            }}
+            id="omit-consumer"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Inbound/index.tsx
@@ -1,0 +1,246 @@
+import { Dialog, DialogTrigger } from "~/design/Dialog";
+import { FC, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/design/Select";
+import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
+import { UseFormReturn, useFieldArray } from "react-hook-form";
+import {
+  getAclConfigAtIndex,
+  getEventFilterConfigAtIndex,
+  getHeaderManipulationConfigAtIndex,
+  getJsInboundConfigAtIndex,
+  getRequestConvertConfigAtIndex,
+} from "../utils";
+import {
+  inboundPluginTypes,
+  useAvailablePlugins,
+} from "../../../schema/plugins/inbound";
+
+import { AclForm } from "./AclForm";
+import Button from "~/design/Button";
+import { Card } from "~/design/Card";
+import { EndpointFormSchemaType } from "../../../schema";
+import { EventFilterForm } from "./EventFilterForm";
+import { HeaderManipulationForm } from "./HeaderManipulationForm";
+import { InboundPluginFormSchemaType } from "../../../schema/plugins/inbound/schema";
+import { JsInboundForm } from "./JsInboundForm";
+import { ListContextMenu } from "~/components/ListContextMenu";
+import { ModalWrapper } from "~/components/ModalWrapper";
+import { PluginSelector } from "../components/PluginSelector";
+import { Plus } from "lucide-react";
+import { RequestConvertForm } from "./RequestConvertForm";
+import { TableHeader } from "../components/PluginsTable";
+import { useTranslation } from "react-i18next";
+
+type InboundPluginFormProps = {
+  form: UseFormReturn<EndpointFormSchemaType>;
+  onSave: (value: EndpointFormSchemaType) => void;
+};
+
+export const InboundPluginForm: FC<InboundPluginFormProps> = ({
+  form,
+  onSave,
+}) => {
+  const { t } = useTranslation();
+  const availablePlugins = useAvailablePlugins();
+  const { control, handleSubmit: handleParentSubmit } = form;
+  const {
+    append: addPlugin,
+    remove: deletePlugin,
+    move: movePlugin,
+    update: editPlugin,
+    fields,
+  } = useFieldArray({
+    control,
+    name: "plugins.inbound",
+  });
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editIndex, setEditIndex] = useState<number>();
+
+  const [selectedPlugin, setSelectedPlugin] =
+    useState<InboundPluginFormSchemaType["type"]>();
+
+  const { jsInbound, requestConvert, acl, eventFilter, headerManipulation } =
+    inboundPluginTypes;
+
+  const handleSubmit = (configuration: InboundPluginFormSchemaType) => {
+    setDialogOpen(false);
+    if (editIndex === undefined) {
+      addPlugin(configuration);
+    } else {
+      editPlugin(editIndex, configuration);
+    }
+    handleParentSubmit(onSave)();
+    setEditIndex(undefined);
+  };
+
+  const pluginsCount = fields.length;
+  const formId = "inboundPluginForm";
+
+  return (
+    <Dialog
+      open={dialogOpen}
+      onOpenChange={(isOpen) => {
+        if (isOpen === false) setEditIndex(undefined);
+        setDialogOpen(isOpen);
+      }}
+    >
+      <Card noShadow>
+        <Table>
+          <TableHeader
+            title={t(
+              "pages.explorer.endpoint.editor.form.plugins.inbound.table.headline",
+              {
+                count: pluginsCount,
+              }
+            )}
+          >
+            <DialogTrigger asChild>
+              <Button icon variant="outline" size="sm">
+                <Plus />
+                {t(
+                  "pages.explorer.endpoint.editor.form.plugins.inbound.table.addButton"
+                )}
+              </Button>
+            </DialogTrigger>
+          </TableHeader>
+          <TableBody>
+            {fields.map(({ id, type }, index, srcArray) => {
+              const canMoveDown = index < srcArray.length - 1;
+              const canMoveUp = index > 0;
+              const onMoveUp = canMoveUp
+                ? () => {
+                    movePlugin(index, index - 1);
+                  }
+                : undefined;
+              const onMoveDown = canMoveDown
+                ? () => {
+                    movePlugin(index, index + 1);
+                  }
+                : undefined;
+              const onDelete = () => {
+                deletePlugin(index);
+              };
+
+              return (
+                <TableRow
+                  key={id}
+                  className="cursor-pointer"
+                  onClick={() => {
+                    setSelectedPlugin(type);
+                    setDialogOpen(true);
+                    setEditIndex(index);
+                  }}
+                >
+                  <TableCell>
+                    {t(
+                      `pages.explorer.endpoint.editor.form.plugins.inbound.types.${type}`
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <ListContextMenu
+                      onDelete={onDelete}
+                      onMoveDown={onMoveDown}
+                      onMoveUp={onMoveUp}
+                    />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Card>
+
+      <ModalWrapper
+        formId={formId}
+        showSaveBtn={!!selectedPlugin}
+        title={
+          editIndex === undefined
+            ? t(
+                "pages.explorer.endpoint.editor.form.plugins.inbound.modal.headlineAdd"
+              )
+            : t(
+                "pages.explorer.endpoint.editor.form.plugins.inbound.modal.headlineEdit"
+              )
+        }
+        onCancel={() => {
+          setDialogOpen(false);
+        }}
+      >
+        <PluginSelector
+          title={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.modal.label"
+          )}
+        >
+          <Select
+            onValueChange={(e) => {
+              setSelectedPlugin(e as typeof selectedPlugin);
+            }}
+            value={selectedPlugin}
+          >
+            <SelectTrigger variant="outline" className="grow">
+              <SelectValue
+                placeholder={t(
+                  "pages.explorer.endpoint.editor.form.plugins.inbound.modal.placeholder"
+                )}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {availablePlugins.map(({ name: pluginName }) => (
+                <SelectItem key={pluginName} value={pluginName}>
+                  {t(
+                    `pages.explorer.endpoint.editor.form.plugins.inbound.types.${pluginName}`
+                  )}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </PluginSelector>
+        {selectedPlugin === requestConvert.name && (
+          <RequestConvertForm
+            formId={formId}
+            defaultConfig={getRequestConvertConfigAtIndex(fields, editIndex)}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === jsInbound.name && (
+          <JsInboundForm
+            formId={formId}
+            defaultConfig={getJsInboundConfigAtIndex(fields, editIndex)}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === acl.name && (
+          <AclForm
+            formId={formId}
+            defaultConfig={getAclConfigAtIndex(fields, editIndex)}
+            onSubmit={handleSubmit}
+          />
+        )}
+
+        {selectedPlugin === headerManipulation.name && (
+          <HeaderManipulationForm
+            formId={formId}
+            defaultConfig={getHeaderManipulationConfigAtIndex(
+              fields,
+              editIndex
+            )}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === eventFilter.name && (
+          <EventFilterForm
+            formId={formId}
+            defaultConfig={getEventFilterConfigAtIndex(fields, editIndex)}
+            onSubmit={handleSubmit}
+          />
+        )}
+      </ModalWrapper>
+    </Dialog>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Outbound/JsOutboundForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Outbound/JsOutboundForm.tsx
@@ -1,0 +1,84 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  JsOutboundFormSchema,
+  JsOutboundFormSchemaType,
+} from "../../../schema/plugins/outbound/jsOutbound";
+
+import { Card } from "~/design/Card";
+import Editor from "~/design/Editor";
+import { Fieldset } from "~/components/Form/Fieldset";
+import { PluginWrapper } from "../components/PluginSelector";
+import { useTheme } from "~/util/store/theme";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<JsOutboundFormSchemaType["configuration"]>;
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: JsOutboundFormSchemaType) => void;
+};
+
+export const JsOutboundForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+  } = useForm<JsOutboundFormSchemaType>({
+    resolver: zodResolver(JsOutboundFormSchema),
+    defaultValues: {
+      type: "js-outbound",
+      configuration: {
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  const theme = useTheme();
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.outbound.jsOutbound.script"
+          )}
+        >
+          <Card className="h-[200px] w-full p-5" background="weight-1" noShadow>
+            <Controller
+              control={control}
+              name="configuration.script"
+              render={({ field }) => (
+                <Editor
+                  theme={theme ?? undefined}
+                  language="javascript"
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </Card>
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Outbound/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Outbound/index.tsx
@@ -1,0 +1,199 @@
+import { Dialog, DialogTrigger } from "~/design/Dialog";
+import { FC, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/design/Select";
+import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
+import { UseFormReturn, useFieldArray } from "react-hook-form";
+import {
+  outboundPluginTypes,
+  useAvailablePlugins,
+} from "../../../schema/plugins/outbound";
+
+import Button from "~/design/Button";
+import { Card } from "~/design/Card";
+import { EndpointFormSchemaType } from "../../../schema";
+import { JsOutboundForm } from "./JsOutboundForm";
+import { ListContextMenu } from "~/components/ListContextMenu";
+import { ModalWrapper } from "~/components/ModalWrapper";
+import { OutboundPluginFormSchemaType } from "../../../schema/plugins/outbound/schema";
+import { PluginSelector } from "../components/PluginSelector";
+import { Plus } from "lucide-react";
+import { TableHeader } from "../components/PluginsTable";
+import { getJsOutboundConfigAtIndex } from "../utils";
+import { useTranslation } from "react-i18next";
+
+type OutboundPluginFormProps = {
+  form: UseFormReturn<EndpointFormSchemaType>;
+  onSave: (value: EndpointFormSchemaType) => void;
+};
+
+export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({
+  form,
+  onSave,
+}) => {
+  const availablePlugins = useAvailablePlugins();
+  const { t } = useTranslation();
+  const { control, handleSubmit: handleParentSubmit } = form;
+  const {
+    append: addPlugin,
+    remove: deletePlugin,
+    move: movePlugin,
+    update: editPlugin,
+    fields,
+  } = useFieldArray({
+    control,
+    name: "plugins.outbound",
+  });
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editIndex, setEditIndex] = useState<number>();
+
+  const [selectedPlugin, setSelectedPlugin] =
+    useState<OutboundPluginFormSchemaType["type"]>();
+
+  const pluginsCount = fields.length;
+  const formId = "outboundPluginForm";
+
+  return (
+    <Dialog
+      open={dialogOpen}
+      onOpenChange={(isOpen) => {
+        if (isOpen === false) setEditIndex(undefined);
+        setDialogOpen(isOpen);
+      }}
+    >
+      <Card noShadow>
+        <Table>
+          <TableHeader
+            title={t(
+              "pages.explorer.endpoint.editor.form.plugins.outbound.table.headline",
+              {
+                count: pluginsCount,
+              }
+            )}
+          >
+            <DialogTrigger asChild>
+              <Button icon variant="outline" size="sm">
+                <Plus />
+                {t(
+                  "pages.explorer.endpoint.editor.form.plugins.outbound.table.addButton"
+                )}
+              </Button>
+            </DialogTrigger>
+          </TableHeader>
+          <TableBody>
+            {fields.map(({ id, type }, index, srcArray) => {
+              const canMoveDown = index < srcArray.length - 1;
+              const canMoveUp = index > 0;
+              const onMoveUp = canMoveUp
+                ? () => {
+                    movePlugin(index, index - 1);
+                  }
+                : undefined;
+              const onMoveDown = canMoveDown
+                ? () => {
+                    movePlugin(index, index + 1);
+                  }
+                : undefined;
+              const onDelete = () => {
+                deletePlugin(index);
+              };
+
+              return (
+                <TableRow
+                  key={id}
+                  className="cursor-pointer"
+                  onClick={() => {
+                    setSelectedPlugin(type);
+                    setDialogOpen(true);
+                    setEditIndex(index);
+                  }}
+                >
+                  <TableCell>
+                    {t(
+                      `pages.explorer.endpoint.editor.form.plugins.outbound.types.${type}`
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <ListContextMenu
+                      onDelete={onDelete}
+                      onMoveDown={onMoveDown}
+                      onMoveUp={onMoveUp}
+                    />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Card>
+
+      <ModalWrapper
+        formId={formId}
+        showSaveBtn={!!selectedPlugin}
+        title={
+          editIndex === undefined
+            ? t(
+                "pages.explorer.endpoint.editor.form.plugins.outbound.modal.headlineAdd"
+              )
+            : t(
+                "pages.explorer.endpoint.editor.form.plugins.outbound.modal.headlineEdit"
+              )
+        }
+        onCancel={() => {
+          setDialogOpen(false);
+        }}
+      >
+        <PluginSelector
+          title={t(
+            "pages.explorer.endpoint.editor.form.plugins.outbound.modal.label"
+          )}
+        >
+          <Select
+            onValueChange={(e) => {
+              setSelectedPlugin(e as typeof selectedPlugin);
+            }}
+            value={selectedPlugin}
+          >
+            <SelectTrigger variant="outline" className="grow">
+              <SelectValue
+                placeholder={t(
+                  "pages.explorer.endpoint.editor.form.plugins.outbound.modal.placeholder"
+                )}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {availablePlugins.map(({ name: pluginName }) => (
+                <SelectItem key={pluginName} value={pluginName}>
+                  {t(
+                    `pages.explorer.endpoint.editor.form.plugins.outbound.types.${pluginName}`
+                  )}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </PluginSelector>
+        {selectedPlugin === outboundPluginTypes.jsOutbound.name && (
+          <JsOutboundForm
+            formId={formId}
+            defaultConfig={getJsOutboundConfigAtIndex(fields, editIndex)}
+            onSubmit={(configuration) => {
+              setDialogOpen(false);
+              if (editIndex === undefined) {
+                addPlugin(configuration);
+              } else {
+                editPlugin(editIndex, configuration);
+              }
+              handleParentSubmit(onSave)();
+              setEditIndex(undefined);
+            }}
+          />
+        )}
+      </ModalWrapper>
+    </Dialog>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/InstantResponseForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/InstantResponseForm.tsx
@@ -1,0 +1,122 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  InstantResponseFormSchema,
+  InstantResponseFormSchemaType,
+} from "../../../schema/plugins/target/instantResponse";
+
+import { Card } from "~/design/Card";
+import Editor from "~/design/Editor";
+import { Fieldset } from "~/components/Form/Fieldset";
+import Input from "~/design/Input";
+import { PluginWrapper } from "../components/PluginSelector";
+import { treatEmptyStringAsUndefined } from "~/pages/namespace/Explorer/utils";
+import { useTheme } from "~/util/store/theme";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<InstantResponseFormSchemaType["configuration"]>;
+
+const predefinedConfig: OptionalConfig = {
+  status_code: 200,
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: InstantResponseFormSchemaType) => void;
+};
+
+export const InstantResponseForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    control,
+  } = useForm<InstantResponseFormSchemaType>({
+    resolver: zodResolver(InstantResponseFormSchema),
+    defaultValues: {
+      type: "instant-response",
+      configuration: {
+        ...predefinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  const theme = useTheme();
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors errors={errors?.configuration as errorsType} />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.instantResponse.statusCode"
+          )}
+          htmlFor="status-code"
+        >
+          <Input
+            {...register("configuration.status_code", {
+              valueAsNumber: true,
+            })}
+            id="status-code"
+            type="number"
+            placeholder={t(
+              "pages.explorer.endpoint.editor.form.plugins.target.instantResponse.statusCodePlaceholder"
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.instantResponse.contentType"
+          )}
+          htmlFor="content-type"
+        >
+          <Input
+            {...register("configuration.content_type", {
+              setValueAs: treatEmptyStringAsUndefined,
+            })}
+            id="content-type"
+            placeholder={t(
+              "pages.explorer.endpoint.editor.form.plugins.target.instantResponse.contentTypePlaceholder"
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.instantResponse.statusMessage"
+          )}
+        >
+          <Card className="h-[200px] w-full p-5" background="weight-1" noShadow>
+            <Controller
+              control={control}
+              name="configuration.status_message"
+              render={({ field }) => (
+                <Editor
+                  theme={theme ?? undefined}
+                  language="plaintext"
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </Card>
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetEventForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetEventForm.tsx
@@ -1,0 +1,90 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  TargetEventFormSchema,
+  TargetEventFormSchemaType,
+} from "../../../schema/plugins/target/targetEvent";
+
+import { DisableNamespaceSelectNote } from "./utils/DisableNamespaceSelectNote";
+import { Fieldset } from "~/components/Form/Fieldset";
+import { NamespaceSelectorListHandler } from "./components/NamespaceSelectorListHandler";
+import { PluginWrapper } from "../components/PluginSelector";
+import { useIsSystemNamespace } from "./utils/useIsSystemNamespace";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<TargetEventFormSchemaType["configuration"]>;
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: TargetEventFormSchemaType) => void;
+};
+
+export const TargetEventForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const isSystemNamespace = useIsSystemNamespace();
+
+  const {
+    handleSubmit,
+    control,
+    setValue,
+    formState: { errors },
+  } = useForm<TargetEventFormSchemaType>({
+    resolver: zodResolver(TargetEventFormSchema),
+    defaultValues: {
+      type: "target-event",
+      configuration: {
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetEvent.namespace"
+          )}
+          htmlFor="namespace"
+        >
+          {isSystemNamespace ? (
+            <Controller
+              control={control}
+              name="configuration.namespaces"
+              render={({ field }) => (
+                <NamespaceSelectorListHandler
+                  id="namespace"
+                  value={field.value}
+                  onValueChange={(value) =>
+                    setValue("configuration.namespaces", value)
+                  }
+                />
+              )}
+            />
+          ) : (
+            <DisableNamespaceSelectNote />
+          )}
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetFlowForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetFlowForm.tsx
@@ -1,0 +1,148 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  TargetFlowFormSchema,
+  TargetFlowFormSchemaType,
+} from "../../../schema/plugins/target/targetFlow";
+
+import { Checkbox } from "~/design/Checkbox";
+import { DisableNamespaceSelectNote } from "./utils/DisableNamespaceSelectNote";
+import { Fieldset } from "~/components/Form/Fieldset";
+import FilePicker from "~/components/FilePicker";
+import Input from "~/design/Input";
+import NamespaceSelector from "~/components/NamespaceSelector";
+import { PluginWrapper } from "../components/PluginSelector";
+import { treatEmptyStringAsUndefined } from "~/pages/namespace/Explorer/utils";
+import { useIsSystemNamespace } from "./utils/useIsSystemNamespace";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<TargetFlowFormSchemaType["configuration"]>;
+
+const predefinedConfig: OptionalConfig = {
+  async: false,
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: TargetFlowFormSchemaType) => void;
+};
+
+export const TargetFlowForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    getValues,
+    watch,
+    control,
+    formState: { errors },
+  } = useForm<TargetFlowFormSchemaType>({
+    resolver: zodResolver(TargetFlowFormSchema),
+    defaultValues: {
+      type: "target-flow",
+      configuration: {
+        ...predefinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const isSystemNamespace = useIsSystemNamespace();
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlow.namespace"
+          )}
+          htmlFor="namespace"
+        >
+          {!isSystemNamespace && <DisableNamespaceSelectNote />}
+          <Controller
+            control={control}
+            name="configuration.namespace"
+            render={({ field }) => (
+              <NamespaceSelector
+                id="namespace"
+                defaultValue={field.value}
+                onValueChange={field.onChange}
+                disabled={!isSystemNamespace}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlow.workflow"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.flow"
+            render={({ field }) => (
+              <FilePicker
+                namespace={watch("configuration.namespace")}
+                onChange={field.onChange}
+                defaultPath={field.value}
+                selectable={(file) => file.type === "workflow"}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlow.asynchronous"
+          )}
+          htmlFor="async"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.async")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.async", value);
+              }
+            }}
+            id="async"
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlow.contentType"
+          )}
+          htmlFor="content-type"
+        >
+          <Input
+            {...register("configuration.content_type", {
+              setValueAs: treatEmptyStringAsUndefined,
+            })}
+            placeholder={t(
+              "pages.explorer.endpoint.editor.form.plugins.target.targetFlow.contentTypePlaceholder"
+            )}
+            id="content-type"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetFlowVarForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetFlowVarForm.tsx
@@ -1,0 +1,150 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  TargetFlowVarFormSchema,
+  TargetFlowVarFormSchemaType,
+} from "../../../schema/plugins/target/targetFlowVar";
+
+import { DisableNamespaceSelectNote } from "./utils/DisableNamespaceSelectNote";
+import { Fieldset } from "~/components/Form/Fieldset";
+import FilePicker from "~/components/FilePicker";
+import Input from "~/design/Input";
+import NamespaceSelector from "~/components/NamespaceSelector";
+import { PluginWrapper } from "../components/PluginSelector";
+import WorkflowVariablePicker from "~/components/WorkflowVariablepicker";
+import { treatEmptyStringAsUndefined } from "~/pages/namespace/Explorer/utils";
+import { useIsSystemNamespace } from "./utils/useIsSystemNamespace";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<TargetFlowVarFormSchemaType["configuration"]>;
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: TargetFlowVarFormSchemaType) => void;
+};
+
+export const TargetFlowVarForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    control,
+    register,
+    watch,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<TargetFlowVarFormSchemaType>({
+    resolver: zodResolver(TargetFlowVarFormSchema),
+    defaultValues: {
+      type: "target-flow-var",
+      configuration: {
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const isSystemNamespace = useIsSystemNamespace();
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlowVar.namespace"
+          )}
+          htmlFor="namespace"
+        >
+          {!isSystemNamespace && <DisableNamespaceSelectNote />}
+          <Controller
+            control={control}
+            name="configuration.namespace"
+            render={({ field }) => (
+              <NamespaceSelector
+                id="namespace"
+                defaultValue={field.value}
+                onValueChange={field.onChange}
+                disabled={!isSystemNamespace}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlowVar.workflow"
+          )}
+          htmlFor="workflow"
+        >
+          <Controller
+            control={control}
+            name="configuration.flow"
+            render={({ field }) => (
+              <FilePicker
+                namespace={watch("configuration.namespace")}
+                onChange={field.onChange}
+                defaultPath={field.value}
+                selectable={(file) => file.type === "workflow"}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlowVar.variable"
+          )}
+          htmlFor="variable"
+        >
+          <Controller
+            control={control}
+            name="configuration.variable"
+            render={({ field }) => (
+              <WorkflowVariablePicker
+                namespace={watch("configuration.namespace")}
+                workflowPath={watch("configuration.flow")}
+                defaultVariable={watch("configuration.variable")}
+                onChange={(name, mimeType) => {
+                  field.onChange(name);
+                  if (mimeType) {
+                    setValue("configuration.content_type", mimeType);
+                  }
+                }}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlowVar.contentType"
+          )}
+          htmlFor="content-type"
+        >
+          <Input
+            {...register("configuration.content_type", {
+              setValueAs: treatEmptyStringAsUndefined,
+            })}
+            placeholder={t(
+              "pages.explorer.endpoint.editor.form.plugins.target.targetFlowVar.contentTypePlaceholder"
+            )}
+            id="content-type"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetNamespaceFileForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetNamespaceFileForm.tsx
@@ -1,0 +1,125 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  TargetNamespaceFileFormSchema,
+  TargetNamespaceFileFormSchemaType,
+} from "../../../schema/plugins/target/targetNamespaceFile";
+
+import { DisableNamespaceSelectNote } from "./utils/DisableNamespaceSelectNote";
+import { Fieldset } from "~/components/Form/Fieldset";
+import FilePicker from "~/components/FilePicker";
+import Input from "~/design/Input";
+import NamespaceSelector from "~/components/NamespaceSelector";
+import { PluginWrapper } from "../components/PluginSelector";
+import { treatEmptyStringAsUndefined } from "~/pages/namespace/Explorer/utils";
+import { useIsSystemNamespace } from "./utils/useIsSystemNamespace";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<
+  TargetNamespaceFileFormSchemaType["configuration"]
+>;
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: TargetNamespaceFileFormSchemaType) => void;
+};
+
+export const TargetNamespaceFileForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    control,
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<TargetNamespaceFileFormSchemaType>({
+    resolver: zodResolver(TargetNamespaceFileFormSchema),
+    defaultValues: {
+      type: "target-namespace-file",
+      configuration: {
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const isSystemNamespace = useIsSystemNamespace();
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetNamespaceFile.namespace"
+          )}
+          htmlFor="namespace"
+        >
+          {!isSystemNamespace && <DisableNamespaceSelectNote />}
+          <Controller
+            control={control}
+            name="configuration.namespace"
+            render={({ field }) => (
+              <NamespaceSelector
+                id="namespace"
+                defaultValue={field.value}
+                onValueChange={field.onChange}
+                disabled={!isSystemNamespace}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetNamespaceFile.file"
+          )}
+        >
+          <Controller
+            control={control}
+            name="configuration.file"
+            render={({ field }) => (
+              <FilePicker
+                namespace={watch("configuration.namespace")}
+                onChange={field.onChange}
+                defaultPath={field.value}
+                selectable={(file) => file.type === "file"}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetNamespaceFile.contentType"
+          )}
+          htmlFor="content-type"
+        >
+          <Input
+            {...register("configuration.content_type", {
+              setValueAs: treatEmptyStringAsUndefined,
+            })}
+            placeholder={t(
+              "pages.explorer.endpoint.editor.form.plugins.target.targetNamespaceFile.contentTypePlaceholder"
+            )}
+            id="content-type"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetNamespaceVarForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/TargetNamespaceVarForm.tsx
@@ -1,0 +1,131 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/components/FormErrors";
+import {
+  TargetNamespaceVarFormSchema,
+  TargetNamespaceVarFormSchemaType,
+} from "../../../schema/plugins/target/targetNamespaceVar";
+
+import { DisableNamespaceSelectNote } from "./utils/DisableNamespaceSelectNote";
+import { Fieldset } from "~/components/Form/Fieldset";
+import Input from "~/design/Input";
+import NamespaceSelector from "~/components/NamespaceSelector";
+import NamespaceVariablePicker from "~/components/NamespaceVariablepicker";
+import { PluginWrapper } from "../components/PluginSelector";
+import { treatEmptyStringAsUndefined } from "~/pages/namespace/Explorer/utils";
+import { useIsSystemNamespace } from "./utils/useIsSystemNamespace";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<
+  TargetNamespaceVarFormSchemaType["configuration"]
+>;
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: TargetNamespaceVarFormSchemaType) => void;
+};
+
+export const TargetNamespaceVarForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    control,
+    register,
+    watch,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<TargetNamespaceVarFormSchemaType>({
+    resolver: zodResolver(TargetNamespaceVarFormSchema),
+    defaultValues: {
+      type: "target-namespace-var",
+      configuration: {
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const isSystemNamespace = useIsSystemNamespace();
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetNamespaceVariable.namespace"
+          )}
+          htmlFor="namespace"
+        >
+          {!isSystemNamespace && <DisableNamespaceSelectNote />}
+          <Controller
+            control={control}
+            name="configuration.namespace"
+            render={({ field }) => (
+              <NamespaceSelector
+                id="namespace"
+                defaultValue={field.value}
+                onValueChange={field.onChange}
+                disabled={!isSystemNamespace}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetNamespaceVariable.variable"
+          )}
+          htmlFor="variable"
+        >
+          <Controller
+            control={control}
+            name="configuration.variable"
+            render={({ field }) => (
+              <NamespaceVariablePicker
+                defaultVariable={watch("configuration.variable")}
+                namespace={watch("configuration.namespace")}
+                onChange={(name, mimeType) => {
+                  field.onChange(name);
+                  if (mimeType) {
+                    setValue("configuration.content_type", mimeType);
+                  }
+                }}
+              />
+            )}
+          />
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetNamespaceVariable.contentType"
+          )}
+          htmlFor="content-type"
+        >
+          <Input
+            {...register("configuration.content_type", {
+              setValueAs: treatEmptyStringAsUndefined,
+            })}
+            placeholder={t(
+              "pages.explorer.endpoint.editor.form.plugins.target.targetNamespaceVariable.contentTypePlaceholder"
+            )}
+            id="content-type"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/components/NamespaceSelectorListHandler.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/components/NamespaceSelectorListHandler.tsx
@@ -1,0 +1,29 @@
+import { Command } from "~/design/Command";
+import { NamespaceSelectorList } from "~/components/NamespaceSelectorList";
+
+type Props = {
+  value?: string[];
+  onValueChange: (value: string[]) => void;
+  id?: string;
+};
+
+export const NamespaceSelectorListHandler = ({
+  value: selectedNamespaces,
+  onValueChange,
+  id,
+}: Props) => (
+  <Command id={id}>
+    <NamespaceSelectorList
+      onSelectNamespace={(value) => {
+        if (selectedNamespaces?.includes(value)) {
+          return onValueChange(
+            selectedNamespaces.filter((item: string) => item !== value)
+          );
+        }
+        onValueChange([...(selectedNamespaces ?? []), value]);
+      }}
+      isMultiSelect={true}
+      selectedValues={selectedNamespaces || []}
+    />
+  </Command>
+);

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/index.tsx
@@ -1,0 +1,223 @@
+import { Dialog, DialogTrigger } from "~/design/Dialog";
+import { FC, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/design/Select";
+import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
+import { UseFormReturn, useWatch } from "react-hook-form";
+import {
+  targetPluginTypes,
+  useAvailablePlugins,
+} from "../../../schema/plugins/target";
+
+import Button from "~/design/Button";
+import { Card } from "~/design/Card";
+import { EndpointFormSchemaType } from "../../../schema";
+import { InstantResponseForm } from "./InstantResponseForm";
+import { ModalWrapper } from "~/components/ModalWrapper";
+import { PluginSelector } from "../components/PluginSelector";
+import { Settings } from "lucide-react";
+import { TableHeader } from "../components/PluginsTable";
+import { TargetEventForm } from "./TargetEventForm";
+import { TargetFlowForm } from "./TargetFlowForm";
+import { TargetFlowVarForm } from "./TargetFlowVarForm";
+import { TargetNamespaceFileForm } from "./TargetNamespaceFileForm";
+import { TargetNamespaceVarForm } from "./TargetNamespaceVarForm";
+import { TargetPluginFormSchemaType } from "../../../schema/plugins/target/schema";
+import { useTranslation } from "react-i18next";
+
+type TargetPluginFormProps = {
+  form: UseFormReturn<EndpointFormSchemaType>;
+  onSave: (value: EndpointFormSchemaType) => void;
+};
+
+export const TargetPluginForm: FC<TargetPluginFormProps> = ({
+  form,
+  onSave,
+}) => {
+  const availablePlugins = useAvailablePlugins();
+  const { control, handleSubmit: handleParentSubmit } = form;
+  const values = useWatch({ control });
+  const { t } = useTranslation();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const currentType = values.plugins?.target?.type;
+  const [selectedPlugin, setSelectedPlugin] = useState(currentType);
+
+  const handleSubmit = (configuration: TargetPluginFormSchemaType) => {
+    setDialogOpen(false);
+    form.setValue("plugins.target", configuration);
+    handleParentSubmit(onSave)();
+  };
+
+  const {
+    instantResponse,
+    targetFlow,
+    targetFlowVar,
+    targetNamespaceFile,
+    targetNamespaceVar,
+    targetEvent,
+  } = targetPluginTypes;
+
+  const currentConfiguration = values.plugins?.target;
+
+  const currentInstantResponseConfig =
+    currentConfiguration?.type === instantResponse.name
+      ? currentConfiguration.configuration
+      : undefined;
+
+  const currentTargetEventConfig =
+    currentConfiguration?.type === targetEvent.name
+      ? currentConfiguration.configuration
+      : undefined;
+
+  const currentTargetFlowConfig =
+    currentConfiguration?.type === targetFlow.name
+      ? currentConfiguration.configuration
+      : undefined;
+
+  const currentTargetFlowVarConfig =
+    currentConfiguration?.type === targetFlowVar.name
+      ? currentConfiguration.configuration
+      : undefined;
+
+  const currentTargetNamespaceFileConfig =
+    currentConfiguration?.type === targetNamespaceFile.name
+      ? currentConfiguration.configuration
+      : undefined;
+
+  const currentTargetNamespaceVarConfig =
+    currentConfiguration?.type === targetNamespaceVar.name
+      ? currentConfiguration.configuration
+      : undefined;
+
+  const formId = "targetPluginForm";
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Card noShadow>
+        <Table>
+          <TableHeader
+            title={t(
+              "pages.explorer.endpoint.editor.form.plugins.target.table.headline"
+            )}
+          />
+          <TableBody>
+            <TableRow>
+              <TableCell colSpan={2}>
+                {values.plugins?.target?.type ? (
+                  <DialogTrigger asChild>
+                    <div className="cursor-pointer">
+                      {t(
+                        `pages.explorer.endpoint.editor.form.plugins.target.types.${values.plugins?.target?.type}`
+                      )}
+                    </div>
+                  </DialogTrigger>
+                ) : (
+                  <div className="text-center">
+                    <DialogTrigger asChild>
+                      <Button icon variant="outline" size="sm">
+                        <Settings />
+                        {t(
+                          "pages.explorer.endpoint.editor.form.plugins.target.table.addButton"
+                        )}
+                      </Button>
+                    </DialogTrigger>
+                  </div>
+                )}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </Card>
+
+      <ModalWrapper
+        formId={formId}
+        showSaveBtn={!!selectedPlugin}
+        title={t(
+          "pages.explorer.endpoint.editor.form.plugins.target.modal.headline"
+        )}
+        onCancel={() => {
+          setDialogOpen(false);
+        }}
+      >
+        <PluginSelector
+          title={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.modal.label"
+          )}
+        >
+          <Select
+            onValueChange={(e) => {
+              setSelectedPlugin(e as typeof selectedPlugin);
+            }}
+            value={selectedPlugin}
+          >
+            <SelectTrigger variant="outline" className="grow">
+              <SelectValue
+                placeholder={t(
+                  "pages.explorer.endpoint.editor.form.plugins.target.modal.placeholder"
+                )}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {availablePlugins.map(({ name: pluginName }) => (
+                <SelectItem key={pluginName} value={pluginName}>
+                  {t(
+                    `pages.explorer.endpoint.editor.form.plugins.target.types.${pluginName}`
+                  )}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </PluginSelector>
+
+        {selectedPlugin === instantResponse.name && (
+          <InstantResponseForm
+            formId={formId}
+            defaultConfig={currentInstantResponseConfig}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === targetFlow.name && (
+          <TargetFlowForm
+            formId={formId}
+            defaultConfig={currentTargetFlowConfig}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === targetFlowVar.name && (
+          <TargetFlowVarForm
+            formId={formId}
+            defaultConfig={currentTargetFlowVarConfig}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === targetNamespaceFile.name && (
+          <TargetNamespaceFileForm
+            formId={formId}
+            defaultConfig={currentTargetNamespaceFileConfig}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === targetNamespaceVar.name && (
+          <TargetNamespaceVarForm
+            formId={formId}
+            defaultConfig={currentTargetNamespaceVarConfig}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {selectedPlugin === targetEvent.name && (
+          <TargetEventForm
+            formId={formId}
+            defaultConfig={currentTargetEventConfig}
+            onSubmit={handleSubmit}
+          />
+        )}
+      </ModalWrapper>
+    </Dialog>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/utils/DisableNamespaceSelectNote.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/utils/DisableNamespaceSelectNote.tsx
@@ -1,0 +1,13 @@
+import Alert from "~/design/Alert";
+import { useTranslation } from "react-i18next";
+
+export const DisableNamespaceSelectNote = () => {
+  const { t } = useTranslation();
+  return (
+    <Alert variant="info">
+      {t(
+        "pages.explorer.endpoint.editor.form.plugins.target.disableNamespaceSelectNote"
+      )}
+    </Alert>
+  );
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/utils/useIsSystemNamespace.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/Target/utils/useIsSystemNamespace.ts
@@ -1,0 +1,7 @@
+import { useNamespaceDetail } from "~/api/namespaces/query/get";
+
+export const useIsSystemNamespace = () => {
+  const { data: namespaces } = useNamespaceDetail();
+  const isSystemNamespace = !!namespaces?.isSystemNamespace;
+  return isSystemNamespace;
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/components/PluginSelector.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/components/PluginSelector.tsx
@@ -1,0 +1,23 @@
+import { FC, PropsWithChildren } from "react";
+
+import { Card } from "~/design/Card";
+
+type PluginSelectorProps = PropsWithChildren & {
+  title: string;
+};
+
+export const PluginSelector: FC<PluginSelectorProps> = ({
+  title,
+  children,
+}) => (
+  <fieldset className="flex items-center gap-5">
+    <label className="text-sm">{title}</label>
+    {children}
+  </fieldset>
+);
+
+export const PluginWrapper: FC<PropsWithChildren> = ({ children }) => (
+  <Card className="flex flex-col gap-5 p-5" noShadow>
+    {children}
+  </Card>
+);

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/components/PluginsTable.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/components/PluginsTable.tsx
@@ -1,0 +1,15 @@
+import { FC, PropsWithChildren } from "react";
+import { TableHead, TableHeaderCell, TableRow } from "~/design/Table";
+
+type TableHeaderProps = PropsWithChildren & {
+  title: string;
+};
+
+export const TableHeader: FC<TableHeaderProps> = ({ title, children }) => (
+  <TableHead>
+    <TableRow className="hover:bg-inherit dark:hover:bg-inherit">
+      <TableHeaderCell>{title}</TableHeaderCell>
+      <TableHeaderCell className="w-60 text-right">{children}</TableHeaderCell>
+    </TableRow>
+  </TableHead>
+);

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/plugins/utils.ts
@@ -1,0 +1,104 @@
+import { AclFormSchemaType } from "../../schema/plugins/inbound/acl";
+import { AuthPluginFormSchemaType } from "../../schema/plugins/auth/schema";
+import { BasicAuthFormSchemaType } from "../../schema/plugins/auth/basicAuth";
+import { EventFilterFormSchemaType } from "../../schema/plugins/inbound/eventFilter";
+import { HeaderManipulationFormSchemaType } from "../../schema/plugins/inbound/headerManipulation";
+import { InboundPluginFormSchemaType } from "../../schema/plugins/inbound/schema";
+import { JsInboundFormSchemaType } from "../../schema/plugins/inbound/jsInbound";
+import { JsOutboundFormSchemaType } from "../../schema/plugins/outbound/jsOutbound";
+import { KeyAuthFormSchemaType } from "../../schema/plugins/auth/keyAuth";
+import { OutboundPluginFormSchemaType } from "../../schema/plugins/outbound/schema";
+import { RequestConvertFormSchemaType } from "../../schema/plugins/inbound/requestConvert";
+import { WebhookAuthFormSchemaType } from "../../schema/plugins/auth/webhookAuth";
+import { authPluginTypes } from "../../schema/plugins/auth";
+import { inboundPluginTypes } from "../../schema/plugins/inbound";
+import { outboundPluginTypes } from "../../schema/plugins/outbound";
+
+export const getRequestConvertConfigAtIndex = (
+  fields: InboundPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): RequestConvertFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === inboundPluginTypes.requestConvert.name
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getJsInboundConfigAtIndex = (
+  fields: InboundPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): JsInboundFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === inboundPluginTypes.jsInbound.name
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getAclConfigAtIndex = (
+  fields: InboundPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): AclFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === inboundPluginTypes.acl.name
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getHeaderManipulationConfigAtIndex = (
+  fields: InboundPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): HeaderManipulationFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === inboundPluginTypes.headerManipulation.name
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getEventFilterConfigAtIndex = (
+  fields: InboundPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): EventFilterFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === inboundPluginTypes.eventFilter.name
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getJsOutboundConfigAtIndex = (
+  fields: OutboundPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): JsOutboundFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === outboundPluginTypes.jsOutbound.name
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getBasicAuthConfigAtIndex = (
+  fields: AuthPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): BasicAuthFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === authPluginTypes.basicAuth.name
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getKeyAuthConfigAtIndex = (
+  fields: AuthPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): KeyAuthFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === authPluginTypes.keyAuth.name
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getWebhookAuthConfigAtIndex = (
+  type: WebhookAuthFormSchemaType["type"],
+  fields: AuthPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): WebhookAuthFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === type ? plugin.configuration : undefined;
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/Form/utils.ts
@@ -1,0 +1,32 @@
+import { Control, useWatch } from "react-hook-form";
+import {
+  EndpointFormSchema,
+  EndpointFormSchemaType,
+  EndpointsPluginsSchema,
+} from "../schema";
+
+export const useSortedValues = (control: Control<EndpointFormSchemaType>) => {
+  const watchedValues = useWatch({
+    control,
+  });
+
+  const sortedRootLevelFields = EndpointFormSchema.keyof().options;
+  const sortedRootLevel = sortedRootLevelFields.reduce(
+    (object, key) => ({ ...object, [key]: watchedValues[key] }),
+    {}
+  );
+
+  const sortedPluginFields = EndpointsPluginsSchema.keyof().options;
+  const sortedPlugins = sortedPluginFields.reduce((object, pluginKey) => {
+    const pluginToAdd = watchedValues?.plugins?.[pluginKey]
+      ? { [pluginKey]: watchedValues?.plugins?.[pluginKey] }
+      : {};
+    return { ...object, ...pluginToAdd };
+  }, {});
+  const hasPlugins = Object.keys(sortedPlugins).length > 0;
+
+  return {
+    ...sortedRootLevel,
+    plugins: hasPlugins ? sortedPlugins : undefined,
+  };
+};

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/index.tsx
@@ -1,0 +1,122 @@
+import { decode, encode } from "js-base64";
+
+import Alert from "~/design/Alert";
+import Button from "~/design/Button";
+import { Card } from "~/design/Card";
+import Editor from "~/design/Editor";
+import { EndpointFormSchemaType } from "./schema";
+import { FC } from "react";
+import { FileSchemaType } from "~/api/files/schema";
+import { Form } from "./Form";
+import FormErrors from "~/components/FormErrors";
+import NavigationBlocker from "~/components/NavigationBlocker";
+import { Save } from "lucide-react";
+import { ScrollArea } from "~/design/ScrollArea";
+import { jsonToYaml } from "../../utils";
+import { serializeEndpointFile } from "./utils";
+import { useTheme } from "~/util/store/theme";
+import { useTranslation } from "react-i18next";
+import { useUpdateFile } from "~/api/files/mutate/updateFile";
+
+type PageEditorProps = {
+  data: NonNullable<FileSchemaType>;
+};
+
+const PageEditor: FC<PageEditorProps> = ({ data }) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const fileContentFromServer = decode(data.data ?? "");
+  const [endpointConfig, endpointConfigError] = serializeEndpointFile(
+    fileContentFromServer
+  );
+  const { mutate: updateRoute, isPending } = useUpdateFile();
+
+  const save = (value: EndpointFormSchemaType) => {
+    const toSave = jsonToYaml(value);
+    updateRoute({
+      path: data.path,
+      payload: { data: encode(toSave) },
+    });
+  };
+
+  return (
+    <Form defaultConfig={endpointConfig} onSave={save}>
+      {({
+        formControls: {
+          formState: { errors },
+          handleSubmit,
+        },
+        formMarkup,
+        values,
+      }) => {
+        const preview = jsonToYaml(values);
+        const parsedOriginal = endpointConfig && jsonToYaml(endpointConfig);
+        const filehasChanged = preview !== parsedOriginal;
+        const isDirty = !endpointConfigError && filehasChanged;
+        const disableButton = isPending || !!endpointConfigError;
+
+        return (
+          <form
+            onSubmit={handleSubmit(save)}
+            className="relative flex-col gap-4 p-5"
+          >
+            {isDirty && <NavigationBlocker />}
+            <div className="flex flex-col gap-4">
+              <div className="grid grow grid-cols-1 gap-5 lg:grid-cols-2">
+                <Card className="p-5 lg:h-[calc(100vh-15.5rem)] lg:overflow-y-scroll">
+                  {endpointConfigError ? (
+                    <div className="flex flex-col gap-5">
+                      <Alert variant="error">
+                        {t(
+                          "pages.explorer.endpoint.editor.form.serialisationError"
+                        )}
+                      </Alert>
+                      <ScrollArea className="size-full whitespace-nowrap">
+                        <pre className="grow text-sm text-primary-500">
+                          {JSON.stringify(endpointConfigError, null, 2)}
+                        </pre>
+                      </ScrollArea>
+                    </div>
+                  ) : (
+                    <div>
+                      <FormErrors errors={errors} className="mb-5" />
+                      {formMarkup}
+                    </div>
+                  )}
+                </Card>
+                <Card className="flex grow p-4 max-lg:h-[500px]">
+                  <Editor
+                    value={preview}
+                    theme={theme ?? undefined}
+                    options={{
+                      readOnly: true,
+                    }}
+                  />
+                </Card>
+              </div>
+              <div className="flex flex-col justify-end gap-4 sm:flex-row sm:items-center">
+                {isDirty && (
+                  <div className="text-sm text-gray-8 dark:text-gray-dark-8">
+                    <span className="text-center">
+                      {t("pages.explorer.endpoint.editor.unsavedNote")}
+                    </span>
+                  </div>
+                )}
+                <Button
+                  variant={isDirty ? "primary" : "outline"}
+                  disabled={disableButton}
+                  type="submit"
+                >
+                  <Save />
+                  {t("pages.explorer.endpoint.editor.saveBtn")}
+                </Button>
+              </div>
+            </div>
+          </form>
+        );
+      }}
+    </Form>
+  );
+};
+
+export default PageEditor;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/index.ts
@@ -1,0 +1,24 @@
+import { AuthPluginFormSchema } from "./plugins/auth/schema";
+import { InboundPluginFormSchema } from "./plugins/inbound/schema";
+import { MethodsSchema } from "~/api/gateway/schema";
+import { OutboundPluginFormSchema } from "./plugins/outbound/schema";
+import { TargetPluginFormSchema } from "./plugins/target/schema";
+import { z } from "zod";
+
+export const EndpointsPluginsSchema = z.object({
+  target: TargetPluginFormSchema,
+  inbound: z.array(InboundPluginFormSchema).optional(),
+  outbound: z.array(OutboundPluginFormSchema).optional(),
+  auth: z.array(AuthPluginFormSchema).optional(),
+});
+
+export const EndpointFormSchema = z.object({
+  direktiv_api: z.literal("endpoint/v1"),
+  allow_anonymous: z.boolean().optional(),
+  path: z.string().nonempty().optional(),
+  timeout: z.number().int().positive().optional(),
+  methods: z.array(MethodsSchema).nonempty().optional(),
+  plugins: EndpointsPluginsSchema.optional(),
+});
+
+export type EndpointFormSchemaType = z.infer<typeof EndpointFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/basicAuth.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/basicAuth.ts
@@ -1,0 +1,13 @@
+import { authPluginTypes } from ".";
+import { z } from "zod";
+
+export const BasicAuthFormSchema = z.object({
+  type: z.literal(authPluginTypes.basicAuth.name),
+  configuration: z.object({
+    add_username_header: z.boolean(),
+    add_tags_header: z.boolean(),
+    add_groups_header: z.boolean(),
+  }),
+});
+
+export type BasicAuthFormSchemaType = z.infer<typeof BasicAuthFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/index.ts
@@ -1,0 +1,15 @@
+import { isEnterprise } from "~/config/env/utils";
+import { isPluginAvailable } from "../utils";
+
+export const authPluginTypes = {
+  basicAuth: { name: "basic-auth", enterpriseOnly: false },
+  keyAuth: { name: "key-auth", enterpriseOnly: false },
+  githubWebhookAuth: { name: "github-webhook-auth", enterpriseOnly: false },
+  gitlabWebhookAuth: { name: "gitlab-webhook-auth", enterpriseOnly: false },
+  slackWebhookAuth: { name: "slack-webhook-auth", enterpriseOnly: false },
+} as const;
+
+export const useAvailablePlugins = () =>
+  Object.values(authPluginTypes).filter((plugin) =>
+    isPluginAvailable(plugin, isEnterprise())
+  );

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/keyAuth.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/keyAuth.ts
@@ -1,0 +1,14 @@
+import { authPluginTypes } from ".";
+import { z } from "zod";
+
+export const KeyAuthFormSchema = z.object({
+  type: z.literal(authPluginTypes.keyAuth.name),
+  configuration: z.object({
+    add_username_header: z.boolean(),
+    add_tags_header: z.boolean(),
+    add_groups_header: z.boolean(),
+    key_name: z.string().optional(),
+  }),
+});
+
+export type KeyAuthFormSchemaType = z.infer<typeof KeyAuthFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/schema.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/schema.ts
@@ -1,0 +1,12 @@
+import { BasicAuthFormSchema } from "./basicAuth";
+import { KeyAuthFormSchema } from "./keyAuth";
+import { WebhookAuthFormSchema } from "./webhookAuth";
+import { z } from "zod";
+
+export const AuthPluginFormSchema = z.discriminatedUnion("type", [
+  BasicAuthFormSchema,
+  WebhookAuthFormSchema,
+  KeyAuthFormSchema,
+]);
+
+export type AuthPluginFormSchemaType = z.infer<typeof AuthPluginFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/webhookAuth.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/auth/webhookAuth.ts
@@ -1,0 +1,17 @@
+import { authPluginTypes } from ".";
+import { z } from "zod";
+
+export const webhookAuthPluginNames = [
+  authPluginTypes.githubWebhookAuth.name,
+  authPluginTypes.gitlabWebhookAuth.name,
+  authPluginTypes.slackWebhookAuth.name,
+] as const;
+
+export const WebhookAuthFormSchema = z.object({
+  type: z.enum(webhookAuthPluginNames),
+  configuration: z.object({
+    secret: z.string().nonempty(),
+  }),
+});
+
+export type WebhookAuthFormSchemaType = z.infer<typeof WebhookAuthFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/acl.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/acl.ts
@@ -1,0 +1,14 @@
+import { inboundPluginTypes } from ".";
+import { z } from "zod";
+
+export const AclFormSchema = z.object({
+  type: z.literal(inboundPluginTypes.acl.name),
+  configuration: z.object({
+    allow_groups: z.array(z.string()).optional(),
+    deny_groups: z.array(z.string()).optional(),
+    allow_tags: z.array(z.string()).optional(),
+    deny_tags: z.array(z.string()).optional(),
+  }),
+});
+
+export type AclFormSchemaType = z.infer<typeof AclFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/eventFilter.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/eventFilter.ts
@@ -1,0 +1,12 @@
+import { inboundPluginTypes } from ".";
+import { z } from "zod";
+
+export const EventFilterFormSchema = z.object({
+  type: z.literal(inboundPluginTypes.eventFilter.name),
+  configuration: z.object({
+    script: z.string(),
+    allow_non_events: z.boolean(),
+  }),
+});
+
+export type EventFilterFormSchemaType = z.infer<typeof EventFilterFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/headerManipulation.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/headerManipulation.ts
@@ -1,0 +1,24 @@
+import { inboundPluginTypes } from ".";
+import { z } from "zod";
+
+const HeaderSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+});
+
+const HeaderRemoveSchema = z.object({
+  name: z.string(),
+});
+
+export const HeaderManipulationFormSchema = z.object({
+  type: z.literal(inboundPluginTypes.headerManipulation.name),
+  configuration: z.object({
+    headers_to_add: z.array(HeaderSchema).optional(),
+    headers_to_modify: z.array(HeaderSchema).optional(),
+    headers_to_remove: z.array(HeaderRemoveSchema).optional(),
+  }),
+});
+
+export type HeaderManipulationFormSchemaType = z.infer<
+  typeof HeaderManipulationFormSchema
+>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/index.ts
@@ -1,0 +1,30 @@
+import { isEnterprise } from "~/config/env/utils";
+import { isPluginAvailable } from "../utils";
+
+export const inboundPluginTypes = {
+  acl: {
+    name: "acl",
+    enterpriseOnly: false,
+  },
+  jsInbound: {
+    name: "js-inbound",
+    enterpriseOnly: false,
+  },
+  requestConvert: {
+    name: "request-convert",
+    enterpriseOnly: false,
+  },
+  headerManipulation: {
+    name: "header-manipulation",
+    enterpriseOnly: false,
+  },
+  eventFilter: {
+    name: "event-filter",
+    enterpriseOnly: true,
+  },
+} as const;
+
+export const useAvailablePlugins = () =>
+  Object.values(inboundPluginTypes).filter((plugin) =>
+    isPluginAvailable(plugin, isEnterprise())
+  );

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/jsInbound.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/jsInbound.ts
@@ -1,0 +1,11 @@
+import { inboundPluginTypes } from ".";
+import { z } from "zod";
+
+export const JsInboundFormSchema = z.object({
+  type: z.literal(inboundPluginTypes.jsInbound.name),
+  configuration: z.object({
+    script: z.string(),
+  }),
+});
+
+export type JsInboundFormSchemaType = z.infer<typeof JsInboundFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/requestConvert.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/requestConvert.ts
@@ -1,0 +1,16 @@
+import { inboundPluginTypes } from ".";
+import { z } from "zod";
+
+export const RequestConvertFormSchema = z.object({
+  type: z.literal(inboundPluginTypes.requestConvert.name),
+  configuration: z.object({
+    omit_headers: z.boolean(),
+    omit_queries: z.boolean(),
+    omit_body: z.boolean(),
+    omit_consumer: z.boolean(),
+  }),
+});
+
+export type RequestConvertFormSchemaType = z.infer<
+  typeof RequestConvertFormSchema
+>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/schema.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/inbound/schema.ts
@@ -1,0 +1,18 @@
+import { AclFormSchema } from "./acl";
+import { EventFilterFormSchema } from "./eventFilter";
+import { HeaderManipulationFormSchema } from "./headerManipulation";
+import { JsInboundFormSchema } from "./jsInbound";
+import { RequestConvertFormSchema } from "./requestConvert";
+import { z } from "zod";
+
+export const InboundPluginFormSchema = z.discriminatedUnion("type", [
+  AclFormSchema,
+  JsInboundFormSchema,
+  RequestConvertFormSchema,
+  EventFilterFormSchema,
+  HeaderManipulationFormSchema,
+]);
+
+export type InboundPluginFormSchemaType = z.infer<
+  typeof InboundPluginFormSchema
+>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/outbound/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/outbound/index.ts
@@ -1,0 +1,11 @@
+import { isEnterprise } from "~/config/env/utils";
+import { isPluginAvailable } from "../utils";
+
+export const outboundPluginTypes = {
+  jsOutbound: { name: "js-outbound", enterpriseOnly: false },
+} as const;
+
+export const useAvailablePlugins = () =>
+  Object.values(outboundPluginTypes).filter((plugin) =>
+    isPluginAvailable(plugin, isEnterprise())
+  );

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/outbound/jsOutbound.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/outbound/jsOutbound.ts
@@ -1,0 +1,11 @@
+import { outboundPluginTypes } from ".";
+import { z } from "zod";
+
+export const JsOutboundFormSchema = z.object({
+  type: z.literal(outboundPluginTypes.jsOutbound.name),
+  configuration: z.object({
+    script: z.string(),
+  }),
+});
+
+export type JsOutboundFormSchemaType = z.infer<typeof JsOutboundFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/outbound/schema.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/outbound/schema.ts
@@ -1,0 +1,10 @@
+import { JsOutboundFormSchema } from "./jsOutbound";
+import { z } from "zod";
+
+export const OutboundPluginFormSchema = z.discriminatedUnion("type", [
+  JsOutboundFormSchema,
+]);
+
+export type OutboundPluginFormSchemaType = z.infer<
+  typeof OutboundPluginFormSchema
+>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/index.ts
@@ -1,0 +1,34 @@
+import { isEnterprise } from "~/config/env/utils";
+import { isPluginAvailable } from "../utils";
+
+export const targetPluginTypes = {
+  instantResponse: {
+    name: "instant-response",
+    enterpriseOnly: false,
+  },
+  targetFlow: {
+    name: "target-flow",
+    enterpriseOnly: false,
+  },
+  targetFlowVar: {
+    name: "target-flow-var",
+    enterpriseOnly: false,
+  },
+  targetNamespaceFile: {
+    name: "target-namespace-file",
+    enterpriseOnly: false,
+  },
+  targetNamespaceVar: {
+    name: "target-namespace-var",
+    enterpriseOnly: false,
+  },
+  targetEvent: {
+    name: "target-event",
+    enterpriseOnly: true,
+  },
+} as const;
+
+export const useAvailablePlugins = () =>
+  Object.values(targetPluginTypes).filter((plugin) =>
+    isPluginAvailable(plugin, isEnterprise())
+  );

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/instantResponse.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/instantResponse.ts
@@ -1,0 +1,15 @@
+import { targetPluginTypes } from ".";
+import { z } from "zod";
+
+export const InstantResponseFormSchema = z.object({
+  type: z.literal(targetPluginTypes.instantResponse.name),
+  configuration: z.object({
+    content_type: z.string().optional(),
+    status_code: z.number().int().positive(),
+    status_message: z.string().optional(),
+  }),
+});
+
+export type InstantResponseFormSchemaType = z.infer<
+  typeof InstantResponseFormSchema
+>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/schema.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/schema.ts
@@ -1,0 +1,18 @@
+import { InstantResponseFormSchema } from "./instantResponse";
+import { TargetEventFormSchema } from "./targetEvent";
+import { TargetFlowFormSchema } from "./targetFlow";
+import { TargetFlowVarFormSchema } from "./targetFlowVar";
+import { TargetNamespaceFileFormSchema } from "./targetNamespaceFile";
+import { TargetNamespaceVarFormSchema } from "./targetNamespaceVar";
+import { z } from "zod";
+
+export const TargetPluginFormSchema = z.discriminatedUnion("type", [
+  InstantResponseFormSchema,
+  TargetFlowFormSchema,
+  TargetFlowVarFormSchema,
+  TargetNamespaceFileFormSchema,
+  TargetNamespaceVarFormSchema,
+  TargetEventFormSchema,
+]);
+
+export type TargetPluginFormSchemaType = z.infer<typeof TargetPluginFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetEvent.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetEvent.ts
@@ -1,0 +1,13 @@
+import { targetPluginTypes } from ".";
+import { z } from "zod";
+
+export const TargetEventFormSchema = z.object({
+  type: z.literal(targetPluginTypes.targetEvent.name),
+  configuration: z
+    .object({
+      namespaces: z.array(z.string()).optional(),
+    })
+    .nullable(), // since all fields are optional, we need to make the whole object optional
+});
+
+export type TargetEventFormSchemaType = z.infer<typeof TargetEventFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetFlow.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetFlow.ts
@@ -1,0 +1,14 @@
+import { targetPluginTypes } from ".";
+import { z } from "zod";
+
+export const TargetFlowFormSchema = z.object({
+  type: z.literal(targetPluginTypes.targetFlow.name),
+  configuration: z.object({
+    namespace: z.string().optional(),
+    flow: z.string().nonempty(),
+    async: z.boolean().optional(),
+    content_type: z.string().optional(),
+  }),
+});
+
+export type TargetFlowFormSchemaType = z.infer<typeof TargetFlowFormSchema>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetFlowVar.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetFlowVar.ts
@@ -1,0 +1,16 @@
+import { targetPluginTypes } from ".";
+import { z } from "zod";
+
+export const TargetFlowVarFormSchema = z.object({
+  type: z.literal(targetPluginTypes.targetFlowVar.name),
+  configuration: z.object({
+    namespace: z.string().optional(),
+    flow: z.string().nonempty(),
+    variable: z.string().nonempty(),
+    content_type: z.string().optional(),
+  }),
+});
+
+export type TargetFlowVarFormSchemaType = z.infer<
+  typeof TargetFlowVarFormSchema
+>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetNamespaceFile.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetNamespaceFile.ts
@@ -1,0 +1,15 @@
+import { targetPluginTypes } from ".";
+import { z } from "zod";
+
+export const TargetNamespaceFileFormSchema = z.object({
+  type: z.literal(targetPluginTypes.targetNamespaceFile.name),
+  configuration: z.object({
+    namespace: z.string().optional(),
+    file: z.string().nonempty(),
+    content_type: z.string().optional(),
+  }),
+});
+
+export type TargetNamespaceFileFormSchemaType = z.infer<
+  typeof TargetNamespaceFileFormSchema
+>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetNamespaceVar.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/target/targetNamespaceVar.ts
@@ -1,0 +1,15 @@
+import { targetPluginTypes } from ".";
+import { z } from "zod";
+
+export const TargetNamespaceVarFormSchema = z.object({
+  type: z.literal(targetPluginTypes.targetNamespaceVar.name),
+  configuration: z.object({
+    namespace: z.string().nonempty().optional(),
+    variable: z.string().nonempty(),
+    content_type: z.string().optional(),
+  }),
+});
+
+export type TargetNamespaceVarFormSchemaType = z.infer<
+  typeof TargetNamespaceVarFormSchema
+>;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/schema/plugins/utils.ts
@@ -1,0 +1,4 @@
+type Plugin = { name: string; enterpriseOnly?: boolean };
+
+export const isPluginAvailable = (plugin: Plugin, isEnterprise: boolean) =>
+  isEnterprise ? true : plugin.enterpriseOnly === false;

--- a/ui/src/pages/namespace/Explorer/Page/PageEditor/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/PageEditor/utils.ts
@@ -1,0 +1,25 @@
+import { EndpointFormSchema, EndpointFormSchemaType } from "./schema";
+import { jsonToYaml, yamlToJsonOrNull } from "../../utils";
+
+import { ZodError } from "zod";
+
+type SerializeReturnType =
+  | [EndpointFormSchemaType, undefined]
+  | [undefined, ZodError<EndpointFormSchemaType>];
+
+export const serializeEndpointFile = (yaml: string): SerializeReturnType => {
+  const json = yamlToJsonOrNull(yaml);
+
+  const jsonParsed = EndpointFormSchema.safeParse(json);
+  if (jsonParsed.success) {
+    return [jsonParsed.data, undefined];
+  }
+
+  return [undefined, jsonParsed.error];
+};
+
+const defaultEndpointFileJson: EndpointFormSchemaType = {
+  direktiv_api: "endpoint/v1",
+};
+
+export const defaultEndpointFileYaml = jsonToYaml(defaultEndpointFileJson);

--- a/ui/src/pages/namespace/Explorer/Page/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/index.tsx
@@ -1,0 +1,55 @@
+import { Card } from "~/design/Card";
+import { FC } from "react";
+import { NoPermissions } from "~/design/Table";
+import PageEditor from "./PageEditor";
+import { PanelTop } from "lucide-react";
+import { analyzePath } from "~/util/router/utils";
+import { useFile } from "~/api/files/query/file";
+import { useNamespace } from "~/util/store/namespace";
+import { usePages } from "~/util/router/pages";
+import { useTranslation } from "react-i18next";
+
+const UIPage: FC = () => {
+  const pages = usePages();
+  const { path } = pages.explorer.useParams();
+  const namespace = useNamespace();
+  const { segments } = analyzePath(path);
+  const filename = segments[segments.length - 1];
+  const { t } = useTranslation();
+
+  const {
+    isAllowed,
+    noPermissionMessage,
+    data: endpointData,
+    isFetched: isPermissionCheckFetched,
+  } = useFile({ path });
+
+  if (!namespace) return null;
+  if (!path) return null;
+  if (endpointData?.type !== "endpoint") return null;
+  if (!isPermissionCheckFetched) return null;
+
+  if (isAllowed === false)
+    return (
+      <Card className="m-5 flex grow">
+        <NoPermissions>{noPermissionMessage}</NoPermissions>
+      </Card>
+    );
+
+  return (
+    <>
+      <div className="border-b border-gray-5 bg-gray-1 p-5 dark:border-gray-dark-5 dark:bg-gray-dark-1">
+        <div className="flex flex-col gap-5 max-sm:space-y-4 sm:flex-row sm:items-center sm:justify-between">
+          <h3 className="flex items-center gap-x-2 font-bold text-primary-500">
+            <PanelTop className="h-5" />
+            {filename?.relative}
+          </h3>
+        </div>
+      </div>
+
+      <PageEditor data={endpointData} />
+    </>
+  );
+};
+
+export default UIPage;

--- a/ui/src/pages/namespace/Explorer/Page/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/index.tsx
@@ -7,7 +7,6 @@ import { analyzePath } from "~/util/router/utils";
 import { useFile } from "~/api/files/query/file";
 import { useNamespace } from "~/util/store/namespace";
 import { usePages } from "~/util/router/pages";
-import { useTranslation } from "react-i18next";
 
 const UIPage: FC = () => {
   const pages = usePages();
@@ -15,7 +14,6 @@ const UIPage: FC = () => {
   const namespace = useNamespace();
   const { segments } = analyzePath(path);
   const filename = segments[segments.length - 1];
-  const { t } = useTranslation();
 
   const {
     isAllowed,

--- a/ui/src/pages/namespace/Explorer/Tree/NewFile.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/NewFile.tsx
@@ -4,6 +4,7 @@ import NewFileButton, { FileTypeSelection } from "./components/NewFileButton";
 
 import NewConsumer from "./components/modals/CreateNew/Gateway/Consumer";
 import NewDirectory from "./components/modals/CreateNew/Directory";
+import NewPage from "./components/modals/CreateNew/Page";
 import NewRoute from "./components/modals/CreateNew/Gateway/Route";
 import NewService from "./components/modals/CreateNew/Service";
 import NewWorkflow from "./components/modals/CreateNew/Workflow";
@@ -70,6 +71,14 @@ export const NewFileDialog: FC<NewFileDialogProps> = ({ path }) => {
         )}
         {selectedDialog === "new-consumer" && (
           <NewConsumer
+            path={data?.path}
+            unallowedNames={existingNames}
+            close={() => setDialogOpen(false)}
+          />
+        )}
+
+        {selectedDialog === "new-page" && (
+          <NewPage
             path={data?.path}
             unallowedNames={existingNames}
             close={() => setDialogOpen(false)}

--- a/ui/src/pages/namespace/Explorer/Tree/components/NewFileButton.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/NewFileButton.tsx
@@ -14,7 +14,9 @@ import {
 import {
   Folder,
   Layers,
+  LayoutTemplate,
   Network,
+  PanelTop,
   Play,
   PlusCircle,
   Users,
@@ -32,6 +34,7 @@ export type FileTypeSelection =
   | "new-workflow"
   | "new-service"
   | "new-route"
+  | "new-page"
   | "new-consumer";
 
 type NewFileButtonProps = {
@@ -120,6 +123,27 @@ const NewFileButton: FC<NewFileButtonProps> = ({ setSelectedDialog }) => {
                     {t(
                       "pages.explorer.tree.newFileButton.items.gateway.consumer"
                     )}
+                  </DropdownMenuItem>
+                </DialogTrigger>
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <LayoutTemplate className="mr-2 size-4" />
+              UI Builder
+            </DropdownMenuSubTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent className="w-40">
+                <DialogTrigger
+                  className="w-full"
+                  onClick={() => {
+                    setSelectedDialog("new-page");
+                  }}
+                >
+                  <DropdownMenuItem>
+                    <PanelTop className="mr-2 size-4" />
+                    New Page
                   </DropdownMenuItem>
                 </DialogTrigger>
               </DropdownMenuSubContent>

--- a/ui/src/pages/namespace/Explorer/Tree/components/NewFileButton.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/NewFileButton.tsx
@@ -131,7 +131,7 @@ const NewFileButton: FC<NewFileButtonProps> = ({ setSelectedDialog }) => {
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <LayoutTemplate className="mr-2 size-4" />
-              UI Builder
+              {t("pages.explorer.tree.newFileButton.items.uibuilder.label")}
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
               <DropdownMenuSubContent className="w-40">
@@ -143,7 +143,9 @@ const NewFileButton: FC<NewFileButtonProps> = ({ setSelectedDialog }) => {
                 >
                   <DropdownMenuItem>
                     <PanelTop className="mr-2 size-4" />
-                    New Page
+                    {t(
+                      "pages.explorer.tree.newFileButton.items.uibuilder.page"
+                    )}
                   </DropdownMenuItem>
                 </DialogTrigger>
               </DropdownMenuSubContent>

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Page/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Page/index.tsx
@@ -1,0 +1,118 @@
+import {
+  DialogClose,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/design/Dialog";
+import { PanelTop, PlusCircle } from "lucide-react";
+import { SubmitHandler, useForm } from "react-hook-form";
+
+import Button from "~/design/Button";
+import { FileNameSchema } from "~/api/files/schema";
+import FormErrors from "~/components/FormErrors";
+import Input from "~/design/Input";
+import { useCreateFile } from "~/api/files/mutate/createFile";
+import { useNamespace } from "~/util/store/namespace";
+import { useNavigate } from "react-router-dom";
+import { usePages } from "~/util/router/pages";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type FormInput = {
+  name: string;
+};
+
+const NewPage = ({
+  path,
+  close,
+  unallowedNames,
+}: {
+  path?: string;
+  close: () => void;
+  unallowedNames?: string[];
+}) => {
+  const pages = usePages();
+  const { t } = useTranslation();
+  const namespace = useNamespace();
+  const navigate = useNavigate();
+
+  const resolver = zodResolver(
+    z.object({
+      name: FileNameSchema.and(
+        z
+          .string()
+          .refine((name) => !(unallowedNames ?? []).some((n) => n === name), {
+            message: t("pages.explorer.tree.newDirectory.nameAlreadyExists"),
+          })
+      ),
+    })
+  );
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isDirty, errors, isValid, isSubmitted },
+  } = useForm<FormInput>({
+    resolver,
+  });
+
+  const { mutate: createDirectory, isPending } = useCreateFile({
+    onSuccess: (data) => {
+      namespace &&
+        navigate(
+          pages.explorer.createHref({ namespace, path: data.data.path })
+        );
+      close();
+    },
+  });
+
+  const onSubmit: SubmitHandler<FormInput> = ({ name }) => {
+    createDirectory({ path, payload: { name, type: "directory" } });
+  };
+
+  // you can not submit if the form has not changed or if there are any errors and
+  // you have already submitted the form (errors will first show up after submit)
+  const disableSubmit = !isDirty || (isSubmitted && !isValid);
+
+  const formId = `new-dir-${path}`;
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          <PanelTop /> Create a new page
+        </DialogTitle>
+      </DialogHeader>
+
+      <div className="my-3">
+        <FormErrors errors={errors} className="mb-5" />
+        <form id={formId} onSubmit={handleSubmit(onSubmit)}>
+          <fieldset className="flex items-center gap-5">
+            <label className="w-[90px] text-right text-[14px]" htmlFor="name">
+              {t("pages.explorer.tree.newDirectory.nameLabel")}
+            </label>
+            <Input id="name" placeholder="page-name" {...register("name")} />
+          </fieldset>
+        </form>
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="ghost">
+            {t("pages.explorer.tree.newDirectory.cancelBtn")}
+          </Button>
+        </DialogClose>
+        <Button
+          type="submit"
+          disabled={disableSubmit}
+          loading={isPending}
+          form={formId}
+        >
+          {!isPending && <PlusCircle />}
+          {t("pages.explorer.tree.newDirectory.createBtn")}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+export default NewPage;

--- a/ui/src/util/router/pages.tsx
+++ b/ui/src/util/router/pages.tsx
@@ -43,6 +43,7 @@ import ServicesPage from "~/pages/namespace/Services";
 import SettingsPage from "~/pages/namespace/Settings";
 import TokensPage from "~/pages/namespace/Permissions/Tokens";
 import TreePage from "~/pages/namespace/Explorer/Tree";
+import UIPage from "~/pages/namespace/Explorer/Page";
 import WorkflowPage from "~/pages/namespace/Explorer/Workflow";
 import WorkflowPageActive from "~/pages/namespace/Explorer/Workflow/Edit";
 import WorkflowPageOverview from "~/pages/namespace/Explorer/Workflow/Overview";
@@ -72,7 +73,8 @@ export type ExplorerSubpages =
   | "workflow-services"
   | "service"
   | "endpoint"
-  | "consumer";
+  | "consumer"
+  | "page";
 
 type ExplorerSubpagesParams =
   | {
@@ -106,6 +108,7 @@ type ExplorerPageSetup = Record<
       isServicePage: boolean;
       isEndpointPage: boolean;
       isConsumerPage: boolean;
+      isUIPage: boolean;
       serviceId: string | undefined;
     };
   }
@@ -334,6 +337,7 @@ export const usePages = (): PageType & EnterprisePageType => {
           endpoint: "endpoint",
           consumer: "consumer",
           service: "service",
+          page: "page",
         };
 
         let searchParamsObj;
@@ -367,12 +371,15 @@ export const usePages = (): PageType & EnterprisePageType => {
         const isServicePage = checkHandler(thirdLvl, "isServicePage");
         const isEndpointPage = checkHandler(thirdLvl, "isEndpointPage");
         const isConsumerPage = checkHandler(thirdLvl, "isConsumerPage");
+        const isUIPage = checkHandler(thirdLvl, "isUIPage");
+
         const isExplorerPage =
           isTreePage ||
           isWorkflowPage ||
           isServicePage ||
           isEndpointPage ||
-          isConsumerPage;
+          isConsumerPage ||
+          isUIPage;
         const isWorkflowEditorPage = checkHandler(fourthLvl, "isEditorPage");
         const isWorkflowOverviewPage = checkHandler(
           fourthLvl,
@@ -400,6 +407,7 @@ export const usePages = (): PageType & EnterprisePageType => {
           isServicePage,
           isEndpointPage,
           isConsumerPage,
+          isUIPage,
           serviceId: searchParams.get("serviceId") ?? undefined,
         };
       },
@@ -455,6 +463,11 @@ export const usePages = (): PageType & EnterprisePageType => {
             path: "consumer/*",
             element: <ConsumerEditorPage />,
             handle: { isConsumerPage: true },
+          },
+          {
+            path: "page/*",
+            element: <UIPage />,
+            handle: { isUIPage: true },
           },
         ],
       },


### PR DESCRIPTION
## Description

- Added a submenu to create a new page under `UI Builder - New Page`
- Added a modal where you only enter the name and a yaml for the page is created 
- Added the new filetype = page
- Added a route for .../page/... as a subpage of explorer 
- Under .../page/... the component PageEditor is loaded

Currently the PageEditor is only a duplicate of the EndpointEditor.

## Checklist

- [ ] Documentation updated if required
- [ ] Test coverage is appropriate
      
## Checklist Internal

- [ ] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [ ] Has the PR been labeled
