### PR TITLE
[DIR-1807] - Add ability to select and delete multiple workflow variables

### DIFF
--- a/ui/e2e/explorer/workflow/variables.spec.ts
+++ b/ui/e2e/explorer/workflow/variables.spec.ts
@@ -26,7 +26,7 @@ test.afterEach(async () => {
 
 test("bulk delete workflow variables", async ({ page }) => {
   // Create 3 test variables
-  await createWorkflowVariables(namespace, workflow, 3);
+  await createWorkflowVariables(namespace, workflow, 4);
 
   await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflow}`);
 
@@ -36,7 +36,9 @@ test("bulk delete workflow variables", async ({ page }) => {
   await expect(
     page.getByText(`Are you sure you want to delete variable`, { exact: false })
   ).toBeVisible();
-  await page.getByRole("button", { name: "Cancel" }).click();
+  await page.getByRole("button", { name: "Delete" }).click();
+  await waitForSuccessToast(page);
+  await expect(page.getByTestId("item-name")).toHaveCount(3);
 
   // Check second checkbox and click delete
   await page.getByTestId("item-name").getByRole("checkbox").nth(0).check();

--- a/ui/e2e/explorer/workflow/variables.spec.ts
+++ b/ui/e2e/explorer/workflow/variables.spec.ts
@@ -1,0 +1,68 @@
+import { createNamespace, deleteNamespace } from "../../utils/namespace";
+import { expect, test } from "@playwright/test";
+
+import { createFile } from "e2e/utils/files";
+import { createWorkflowVariables } from "../../utils/variables";
+import { faker } from "@faker-js/faker";
+import { waitForSuccessToast } from "./utils";
+
+let namespace = "";
+let workflow = "";
+
+test.beforeEach(async () => {
+  namespace = await createNamespace();
+  workflow = faker.system.commonFileName("yaml");
+  await createFile({
+    name: workflow,
+    namespace,
+    type: "workflow",
+    yaml: "direktiv_api: workflow/v1\nstates:\n- id: noop\n  type: noop",
+  });
+});
+
+test.afterEach(async () => {
+  await deleteNamespace(namespace);
+});
+
+test("bulk delete workflow variables", async ({ page }) => {
+  // Create 3 test variables
+  await createWorkflowVariables(namespace, workflow, 3);
+
+  await page.goto(`/n/${namespace}/explorer/workflow/settings/${workflow}`);
+
+  // Check first checkbox and click delete
+  await page.getByTestId("item-name").getByRole("checkbox").first().check();
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(
+    page.getByText(`Are you sure you want to delete variable`, { exact: false })
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+
+  // Check second checkbox and click delete
+  await page.getByTestId("item-name").getByRole("checkbox").nth(0).check();
+  await page.getByTestId("item-name").getByRole("checkbox").nth(1).check();
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(
+    page.getByText("Are you sure you want to delete 2 variables?", {
+      exact: true,
+    })
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+
+  // Check third checkbox and click delete
+  await page.getByTestId("item-name").getByRole("checkbox").nth(0).check();
+  await page.getByTestId("item-name").getByRole("checkbox").nth(1).check();
+  await page.getByTestId("item-name").getByRole("checkbox").nth(2).check();
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(
+    page.getByText("Are you sure you want to delete all variables?", {
+      exact: true,
+    })
+  ).toBeVisible();
+
+  // Confirm deletion
+  await page.getByRole("button", { name: "Delete" }).click();
+  await waitForSuccessToast(page);
+
+  await expect(page.getByTestId("item-name")).toHaveCount(0);
+});

--- a/ui/src/api/variables/mutate/delete.ts
+++ b/ui/src/api/variables/mutate/delete.ts
@@ -61,10 +61,10 @@ export const useDeleteVar = ({
       toast({
         title: t("api.variables.mutate.deleteVariable.success.title"),
         description: t(
-          input.length === 1
-            ? "api.variables.mutate.deleteVariable.success.description_one"
-            : "api.variables.mutate.deleteVariable.success.description",
-          { count: input.length }
+          "api.variables.mutate.deleteVariable.success.description",
+          {
+            count: input.length,
+          }
         ),
         variant: "success",
       });

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -149,7 +149,8 @@
                 "title": "Workflow variables",
                 "createBtn": "Add variable",
                 "emptySearch": "No variable matches your search",
-                "empty": "No variable found"
+                "empty": "No variable found",
+                "deleteSelected": "Delete selected"
               }
             }
           },
@@ -1442,6 +1443,9 @@
           }
         },
         "deleteVariable": {
+          "allItemsMsg": "Are you sure you want to delete <b>all</b> variables?",
+          "multipleItemsMsg": "Are you sure you want to delete <b>{{count}}</b> variables?",
+          "singleItemMsg": "Are you sure you want to delete variable <b>'{{name}}'</b>?",
           "success": {
             "title": "Variable deleted",
             "description": "Variable {{name}} was deleted."

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -1448,7 +1448,8 @@
           "singleItemMsg": "Are you sure you want to delete variable <b>'{{name}}'</b>?",
           "success": {
             "title": "Variable deleted",
-            "description": "Variable {{name}} was deleted."
+            "description": "{{count}} variables have been deleted.",
+            "description_one": "{{count}} variable has been deleted."
           },
           "error": {
             "description": "Could not delete variable 😢"

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -167,14 +167,11 @@ const VariablesList = ({ path }: { path: string }) => {
                         onEdit={() => setEditItem(item)}
                         onDownload={() => downloadVar(item.id)}
                         onDelete={() => undefined}
+                        onSelect={() => handleCheckboxChange(item)}
+                        isSelected={selectedItems.some(
+                          (selected) => selected.id === item.id
+                        )}
                       >
-                        <Checkbox
-                          className="mr-2"
-                          checked={selectedItems.some(
-                            (selected) => selected.id === item.id
-                          )}
-                          onCheckedChange={() => handleCheckboxChange(item)}
-                        />
                         {item.name}
                       </ItemRow>
                     ))}

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, FileJson, Trash } from "lucide-react";
+import { FileJson, Trash } from "lucide-react";
 import { NoResult, Table, TableBody } from "~/design/Table";
 import { Pagination, PaginationLink } from "~/design/Pagination";
 import { useEffect, useMemo, useState } from "react";
@@ -104,59 +104,60 @@ const VariablesList = ({ path }: { path: string }) => {
         }) => (
           <>
             <div className="mb-4 flex flex-col gap-4 sm:flex-row items-center">
-              <div className="flex items-center">
-                <Checkbox
-                  className="ml-3"
-                  onCheckedChange={handleSelectAll}
-                  disabled={filteredItems.length === 0}
-                  checked={
-                    selectedItems.length === filteredItems.length &&
-                    filteredItems.length > 0
-                  }
-                />
-                <ChevronDown className=" mr-2 ml-1 size-4" />
-              </div>
               <h3 className="flex grow items-center gap-x-2 pb-2 pt-1 font-bold">
                 <FileJson className="h-5" />
                 {t(
                   "pages.explorer.tree.workflow.settings.variables.list.title"
                 )}
               </h3>
-              <Input
-                className="sm:w-60"
-                value={search}
-                onChange={(e) => {
-                  setSearch(e.target.value);
-                  goToFirstPage();
-                }}
-                placeholder={t(
-                  "pages.settings.variables.list.searchPlaceholder"
-                )}
-              />
-              <CreateItemButton
-                data-testid="variable-create"
-                onClick={() => setCreateItem(true)}
-              >
-                {t(
-                  "pages.explorer.tree.workflow.settings.variables.list.createBtn"
-                )}
-              </CreateItemButton>
-              <div className="ml-auto">
-                <Button
-                  variant="destructive"
-                  disabled={selectedItems.length === 0}
-                  onClick={() => {
-                    setDialogOpen(true);
-                  }}
-                >
-                  {t(
-                    "pages.explorer.tree.workflow.settings.variables.list.deleteSelected"
-                  )}
-                  <Trash className="ml-2 size-4" />
-                </Button>
-              </div>
             </div>
             <Card className="mb-4">
+              <div className="flex justify-between gap-5 p-2 border-b border-gray-5 dark:border-gray-dark-5">
+                <div className="flex items-center">
+                  <Checkbox
+                    className="ml-1"
+                    onCheckedChange={handleSelectAll}
+                    disabled={filteredItems.length === 0}
+                    checked={
+                      selectedItems.length === filteredItems.length &&
+                      filteredItems.length > 0
+                    }
+                  />
+                </div>
+                <div className="mr-auto">
+                  <Button
+                    variant="destructive"
+                    disabled={selectedItems.length === 0}
+                    onClick={() => {
+                      setDialogOpen(true);
+                    }}
+                  >
+                    {t(
+                      "pages.explorer.tree.workflow.settings.variables.list.deleteSelected"
+                    )}
+                    <Trash className="ml-2 size-4" />
+                  </Button>
+                </div>
+                <Input
+                  className="sm:w-60"
+                  value={search}
+                  onChange={(e) => {
+                    setSearch(e.target.value);
+                    goToFirstPage();
+                  }}
+                  placeholder={t(
+                    "pages.settings.variables.list.searchPlaceholder"
+                  )}
+                />
+                <CreateItemButton
+                  data-testid="variable-create"
+                  onClick={() => setCreateItem(true)}
+                >
+                  {t(
+                    "pages.explorer.tree.workflow.settings.variables.list.createBtn"
+                  )}
+                </CreateItemButton>
+              </div>
               {currentItems.length ? (
                 <Table>
                   <TableBody>

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -222,7 +222,7 @@ const VariablesList = ({ path }: { path: string }) => {
           items={selectedItems}
           totalItems={(variables?.data || []).length}
           onConfirm={() => {
-            deleteWorkflowVar({ variables: selectedItems });
+            deleteWorkflowVar(selectedItems);
             setSelectedItems([]);
             setDialogOpen(false);
           }}

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -125,19 +125,20 @@ const VariablesList = ({ path }: { path: string }) => {
                   />
                 </div>
                 <div className="mr-auto">
-                  <Button
-                    className="hover:bg-red-500 hover:text-white"
-                    variant="outline"
-                    disabled={selectedItems.length === 0}
-                    onClick={() => {
-                      setDialogOpen(true);
-                    }}
-                  >
-                    <Trash className=" size-4" />
-                    {t(
-                      "pages.explorer.tree.workflow.settings.variables.list.deleteSelected"
-                    )}
-                  </Button>
+                  {selectedItems.length > 0 && (
+                    <Button
+                      variant="destructive"
+                      disabled={selectedItems.length === 0}
+                      onClick={() => {
+                        setDialogOpen(true);
+                      }}
+                    >
+                      <Trash className=" size-4" />
+                      {t(
+                        "pages.explorer.tree.workflow.settings.variables.list.deleteSelected"
+                      )}
+                    </Button>
+                  )}
                 </div>
                 <Input
                   className="sm:w-60"

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -125,7 +125,7 @@ const VariablesList = ({ path }: { path: string }) => {
                   />
                 </div>
                 <div className="mr-auto">
-                  {selectedItems.length > 0 && (
+                  {selectedItems.length > 0 && !dialogOpen && (
                     <Button
                       variant="destructive"
                       disabled={selectedItems.length === 0}

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -35,7 +35,7 @@ const VariablesList = ({ path }: { path: string }) => {
 
   const { data: variables, isFetched } = useVars({ workflowPath: path });
 
-  const { mutate: deleteWorkflowVariable } = useDeleteVar({
+  const { mutate: deleteWorkflowVar } = useDeleteVar({
     onSuccess: () => {
       setDialogOpen(false);
       setSelectedItems([]);
@@ -108,6 +108,7 @@ const VariablesList = ({ path }: { path: string }) => {
                 <Checkbox
                   className="ml-3"
                   onCheckedChange={handleSelectAll}
+                  disabled={filteredItems.length === 0}
                   checked={
                     selectedItems.length === filteredItems.length &&
                     filteredItems.length > 0
@@ -221,7 +222,7 @@ const VariablesList = ({ path }: { path: string }) => {
           items={selectedItems}
           totalItems={(variables?.data || []).length}
           onConfirm={() => {
-            deleteWorkflowVariable({ variables: selectedItems });
+            deleteWorkflowVar({ variables: selectedItems });
             setSelectedItems([]);
             setDialogOpen(false);
           }}

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -126,16 +126,17 @@ const VariablesList = ({ path }: { path: string }) => {
                 </div>
                 <div className="mr-auto">
                   <Button
-                    variant="destructive"
+                    className="hover:bg-red-500 hover:text-white"
+                    variant="outline"
                     disabled={selectedItems.length === 0}
                     onClick={() => {
                       setDialogOpen(true);
                     }}
                   >
+                    <Trash className=" size-4" />
                     {t(
                       "pages.explorer.tree.workflow.settings.variables.list.deleteSelected"
                     )}
-                    <Trash className="ml-2 size-4" />
                   </Button>
                 </div>
                 <Input

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -166,7 +166,7 @@ const VariablesList = ({ path }: { path: string }) => {
                         key={i}
                         onEdit={() => setEditItem(item)}
                         onDownload={() => downloadVar(item.id)}
-                        onDelete={() => undefined}
+                        onDelete={() => handleCheckboxChange(item)}
                         onSelect={() => handleCheckboxChange(item)}
                         isSelected={selectedItems.some(
                           (selected) => selected.id === item.id

--- a/ui/src/pages/namespace/Settings/Variables/Delete.tsx
+++ b/ui/src/pages/namespace/Settings/Variables/Delete.tsx
@@ -20,10 +20,10 @@ type DeleteProps = {
 const Delete = ({ items, totalItems, onConfirm }: DeleteProps) => {
   const { t } = useTranslation();
 
-  const isSingleItem = items.length === 1;
-  const isAllItems = totalItems > 1 && items.length === totalItems;
-
   const deleteMessage = () => {
+    const isSingleItem = items.length === 1;
+    const isAllItems = totalItems > 1 && items.length === totalItems;
+
     if (isSingleItem) {
       return (
         <Trans

--- a/ui/src/pages/namespace/Settings/Variables/Delete.tsx
+++ b/ui/src/pages/namespace/Settings/Variables/Delete.tsx
@@ -13,10 +13,65 @@ import { Trash } from "lucide-react";
 type DeleteProps = {
   name: string;
   onConfirm: () => void;
+  items?: string[];
+  totalItems?: number;
 };
 
-const Delete = ({ name, onConfirm }: DeleteProps) => {
+const Delete = ({ name, onConfirm, items, totalItems }: DeleteProps) => {
   const { t } = useTranslation();
+
+  if (items?.length) {
+    const isSingleItem = items.length === 1;
+    const isAllItems =
+      totalItems && totalItems > 1 && items.length === totalItems;
+
+    const deleteMessage = () => {
+      if (isSingleItem) {
+        return (
+          <Trans
+            i18nKey="api.variables.mutate.deleteVariable.singleItemMsg"
+            values={{ name }}
+          />
+        );
+      } else if (isAllItems) {
+        return (
+          <Trans i18nKey="api.variables.mutate.deleteVariable.allItemsMsg" />
+        );
+      } else {
+        return (
+          <Trans
+            i18nKey="api.variables.mutate.deleteVariable.multipleItemsMsg"
+            values={{ count: items.length }}
+          />
+        );
+      }
+    };
+
+    return (
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            <Trash /> {t("components.dialog.header.confirm")}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="my-3">{deleteMessage()}</div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">
+              {t("components.button.label.cancel")}
+            </Button>
+          </DialogClose>
+          <Button
+            data-testid="registry-delete-confirm"
+            onClick={onConfirm}
+            variant="destructive"
+          >
+            {t("components.button.label.delete")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    );
+  }
 
   return (
     <DialogContent>
@@ -27,7 +82,7 @@ const Delete = ({ name, onConfirm }: DeleteProps) => {
       </DialogHeader>
       <div className="my-3">
         <Trans
-          i18nKey="pages.settings.registries.delete.description"
+          i18nKey="api.variables.mutate.deleteVariable.singleItemMsg"
           values={{ name }}
         />
       </div>

--- a/ui/src/pages/namespace/Settings/Variables/Delete.tsx
+++ b/ui/src/pages/namespace/Settings/Variables/Delete.tsx
@@ -9,69 +9,41 @@ import { Trans, useTranslation } from "react-i18next";
 
 import Button from "~/design/Button";
 import { Trash } from "lucide-react";
+import { VarSchemaType } from "~/api/variables/schema";
 
 type DeleteProps = {
-  name: string;
+  items: VarSchemaType[];
+  totalItems: number;
   onConfirm: () => void;
-  items?: string[];
-  totalItems?: number;
 };
 
-const Delete = ({ name, onConfirm, items, totalItems }: DeleteProps) => {
+const Delete = ({ items, totalItems, onConfirm }: DeleteProps) => {
   const { t } = useTranslation();
 
-  if (items?.length) {
-    const isSingleItem = items.length === 1;
-    const isAllItems =
-      totalItems && totalItems > 1 && items.length === totalItems;
+  const isSingleItem = items.length === 1;
+  const isAllItems = totalItems > 1 && items.length === totalItems;
 
-    const deleteMessage = () => {
-      if (isSingleItem) {
-        return (
-          <Trans
-            i18nKey="api.variables.mutate.deleteVariable.singleItemMsg"
-            values={{ name }}
-          />
-        );
-      } else if (isAllItems) {
-        return (
-          <Trans i18nKey="api.variables.mutate.deleteVariable.allItemsMsg" />
-        );
-      } else {
-        return (
-          <Trans
-            i18nKey="api.variables.mutate.deleteVariable.multipleItemsMsg"
-            values={{ count: items.length }}
-          />
-        );
-      }
-    };
-
-    return (
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            <Trash /> {t("components.dialog.header.confirm")}
-          </DialogTitle>
-        </DialogHeader>
-        <div className="my-3">{deleteMessage()}</div>
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button variant="ghost">
-              {t("components.button.label.cancel")}
-            </Button>
-          </DialogClose>
-          <Button
-            data-testid="registry-delete-confirm"
-            onClick={onConfirm}
-            variant="destructive"
-          >
-            {t("components.button.label.delete")}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    );
-  }
+  const deleteMessage = () => {
+    if (isSingleItem) {
+      return (
+        <Trans
+          i18nKey="api.variables.mutate.deleteVariable.singleItemMsg"
+          values={{ name: items[0]?.name || "" }}
+        />
+      );
+    } else if (isAllItems) {
+      return (
+        <Trans i18nKey="api.variables.mutate.deleteVariable.allItemsMsg" />
+      );
+    } else {
+      return (
+        <Trans
+          i18nKey="api.variables.mutate.deleteVariable.multipleItemsMsg"
+          values={{ count: items.length }}
+        />
+      );
+    }
+  };
 
   return (
     <DialogContent>
@@ -80,12 +52,7 @@ const Delete = ({ name, onConfirm, items, totalItems }: DeleteProps) => {
           <Trash /> {t("components.dialog.header.confirm")}
         </DialogTitle>
       </DialogHeader>
-      <div className="my-3">
-        <Trans
-          i18nKey="api.variables.mutate.deleteVariable.singleItemMsg"
-          values={{ name }}
-        />
-      </div>
+      <div className="my-3">{deleteMessage()}</div>
       <DialogFooter>
         <DialogClose asChild>
           <Button variant="ghost">{t("components.button.label.cancel")}</Button>

--- a/ui/src/pages/namespace/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Settings/Variables/index.tsx
@@ -175,7 +175,7 @@ const VariablesList: FC = () => {
           items={[deleteItem]}
           totalItems={variables?.data?.length ?? 0}
           onConfirm={() => {
-            deleteVar({ variable: deleteItem });
+            deleteVar([deleteItem]);
           }}
         />
       )}

--- a/ui/src/pages/namespace/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Settings/Variables/index.tsx
@@ -172,7 +172,8 @@ const VariablesList: FC = () => {
 
       {deleteItem && (
         <Delete
-          name={deleteItem.name}
+          items={[deleteItem]}
+          totalItems={variables?.data?.length ?? 0}
           onConfirm={() => {
             deleteVar({ variable: deleteItem });
           }}

--- a/ui/src/pages/namespace/Settings/components/ItemRow.tsx
+++ b/ui/src/pages/namespace/Settings/components/ItemRow.tsx
@@ -10,6 +10,7 @@ import {
 import { TableCell, TableRow } from "~/design/Table";
 
 import Button from "~/design/Button";
+import { Checkbox } from "~/design/Checkbox";
 import { DialogTrigger } from "~/design/Dialog";
 import { useTranslation } from "react-i18next";
 
@@ -18,6 +19,8 @@ type ItemRowProps<TItem> = {
   onDelete: (item: TItem) => void;
   onEdit?: () => void;
   onDownload?: () => void;
+  onSelect?: (checked: boolean) => void;
+  isSelected?: boolean;
   children?: React.ReactNode;
 };
 
@@ -26,13 +29,25 @@ const ItemRow = <ItemType,>({
   onDelete,
   onDownload,
   onEdit,
+  onSelect,
+  isSelected,
   children,
 }: ItemRowProps<ItemType & { name: string }>) => {
   const { t } = useTranslation();
 
   return (
     <TableRow data-testid="variable-row">
-      <TableCell data-testid="item-name">{children}</TableCell>
+      <TableCell data-testid="item-name" className="flex items-center">
+        {onSelect && (
+          <Checkbox
+            className="mr-3"
+            data-testid="variable-checkbox"
+            checked={isSelected}
+            onCheckedChange={onSelect}
+          />
+        )}
+        {children}
+      </TableCell>
       <TableCell className="w-0">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>


### PR DESCRIPTION
# Add Bulk Delete for Variables

## Changes
- Added multi-select functionality for variables using checkboxes
- Implemented "Select All" feature with dropdown indicator
- Enhanced delete dialog to handle single/multiple/all item scenarios with appropriate messaging
- Added a dedicated delete button in the toolbar for selected items

- There is a problem with not implementing the multiple delete functionality in both Settings and Explorer since, the same ItemRow, Delete components and delete.ts mutation file is used. So the old delete btn is not working at the moment in explorer view, but I couldn't remove it since it is used in the Settings section. 
This will be cleaner after we implement it in both places. :)

https://github.com/user-attachments/assets/2a98d761-d6f0-41dd-98d7-5adf9cbb1464


## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
