### PR TITLE
[DIR-1897] Made pagination always visible and show page number 1 for an empty list

### DIFF
--- a/ui/e2e/events/history.spec.ts
+++ b/ui/e2e/events/history.spec.ts
@@ -166,8 +166,6 @@ test("it renders, filters, and paginates events", async ({ page }) => {
     "when filtering by event type, it shows the correct number of events"
   ).toHaveCount(7);
 
-  await expect(page.getByTestId("pagination-wrapper")).not.toBeVisible();
-
   /**
    * Additionally filter by content, expect a smaller subset of results.
    * The content filter will search everywhere in the event, so in this case,

--- a/ui/src/components/Pagination/index.tsx
+++ b/ui/src/components/Pagination/index.tsx
@@ -23,7 +23,7 @@ export const Pagination = ({
     (pageNumber - 1) * itemsPerPage;
 
   const numberOfItems = totalItems ?? 0;
-  const pages = Math.ceil(numberOfItems / itemsPerPage);
+  const pages = Math.max(1, Math.ceil(numberOfItems / itemsPerPage));
   const currentPage = Math.ceil(offset / itemsPerPage) + 1;
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage === pages;
@@ -55,7 +55,7 @@ export const Pagination = ({
                 !isActive &&
                 setOffset(setOffsetByPageNumber(page));
             }}
-            disabled={isEllipsis}
+            disabled={(isFirstPage && isLastPage) || isEllipsis}
             data-testid={`pagination-btn-page-${page}`}
           >
             {page}

--- a/ui/src/components/PaginationProvider/index.tsx
+++ b/ui/src/components/PaginationProvider/index.tsx
@@ -24,7 +24,7 @@ const PaginationProvider = <TArrayItem,>({
   const firstPage = 1;
   const [currentPage, setCurrentPage] = useState(firstPage);
   const pageSize = pageSizeProp || 10;
-  const totalPages = Math.ceil(items.length / pageSize);
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
   const isLastPage = currentPage === totalPages;
   const isFirstPage = currentPage === firstPage;
 

--- a/ui/src/pages/namespace/Events/History/EventsList.tsx
+++ b/ui/src/pages/namespace/Events/History/EventsList.tsx
@@ -113,12 +113,14 @@ const EventsList = ({
                 <SelectPageSize onChange={() => goToPage(1)} />
                 <Pagination>
                   <PaginationLink
+                    disabled={pagesList.length === 1}
                     data-testid="pagination-btn-left"
                     icon="left"
                     onClick={() => goToPreviousPage()}
                   />
                   {pagesList.map((page) => (
                     <PaginationLink
+                      disabled={pagesList.length === 1}
                       active={currentPage === page}
                       key={`${page}`}
                       onClick={() => goToPage(page)}
@@ -127,6 +129,7 @@ const EventsList = ({
                     </PaginationLink>
                   ))}
                   <PaginationLink
+                    disabled={pagesList.length === 1}
                     data-testid="pagination-btn-right"
                     icon="right"
                     onClick={() => goToNextPage()}

--- a/ui/src/pages/namespace/Events/History/EventsList.tsx
+++ b/ui/src/pages/namespace/Events/History/EventsList.tsx
@@ -57,7 +57,6 @@ const EventsList = ({
             goToPreviousPage,
             currentPage,
             pagesList,
-            totalPages,
           }) => (
             <>
               <Card>
@@ -112,29 +111,27 @@ const EventsList = ({
               </Card>
               <div className="flex items-center justify-end gap-2">
                 <SelectPageSize onChange={() => goToPage(1)} />
-                {totalPages > 1 && (
-                  <Pagination>
+                <Pagination>
+                  <PaginationLink
+                    data-testid="pagination-btn-left"
+                    icon="left"
+                    onClick={() => goToPreviousPage()}
+                  />
+                  {pagesList.map((page) => (
                     <PaginationLink
-                      data-testid="pagination-btn-left"
-                      icon="left"
-                      onClick={() => goToPreviousPage()}
-                    />
-                    {pagesList.map((page) => (
-                      <PaginationLink
-                        active={currentPage === page}
-                        key={`${page}`}
-                        onClick={() => goToPage(page)}
-                      >
-                        {page}
-                      </PaginationLink>
-                    ))}
-                    <PaginationLink
-                      data-testid="pagination-btn-right"
-                      icon="right"
-                      onClick={() => goToNextPage()}
-                    />
-                  </Pagination>
-                )}
+                      active={currentPage === page}
+                      key={`${page}`}
+                      onClick={() => goToPage(page)}
+                    >
+                      {page}
+                    </PaginationLink>
+                  ))}
+                  <PaginationLink
+                    data-testid="pagination-btn-right"
+                    icon="right"
+                    onClick={() => goToNextPage()}
+                  />
+                </Pagination>
               </div>
             </>
           )}

--- a/ui/src/pages/namespace/Events/Listeners/index.tsx
+++ b/ui/src/pages/namespace/Events/Listeners/index.tsx
@@ -23,7 +23,6 @@ const ListenersList = () => {
 
   const numberOfResults = data?.meta?.total ?? 0;
   const noResults = isFetched && numberOfResults === 0;
-  const showPagination = numberOfResults > pageSize;
 
   return (
     <div className="flex grow flex-col gap-y-3 p-5">
@@ -59,14 +58,12 @@ const ListenersList = () => {
           )}
         </ListenersTable>
       </Card>
-      {showPagination && (
-        <Pagination
-          itemsPerPage={pageSize}
-          offset={offset}
-          setOffset={(value) => setOffset(value)}
-          totalItems={numberOfResults}
-        />
-      )}
+      <Pagination
+        itemsPerPage={pageSize}
+        offset={offset}
+        setOffset={(value) => setOffset(value)}
+        totalItems={numberOfResults}
+      />
     </div>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Settings/Variables/index.tsx
@@ -191,29 +191,30 @@ const VariablesList = ({ path }: { path: string }) => {
                 </NoResult>
               )}
             </Card>
-            {totalPages > 1 && (
-              <Pagination>
+            <Pagination>
+              <PaginationLink
+                disabled={totalPages === 1}
+                data-testid="pagination-btn-left"
+                icon="left"
+                onClick={() => goToPreviousPage()}
+              />
+              {pagesList.map((page) => (
                 <PaginationLink
-                  data-testid="pagination-btn-left"
-                  icon="left"
-                  onClick={() => goToPreviousPage()}
-                />
-                {pagesList.map((page) => (
-                  <PaginationLink
-                    active={currentPage === page}
-                    key={`${page}`}
-                    onClick={() => goToPage(page)}
-                  >
-                    {page}
-                  </PaginationLink>
-                ))}
-                <PaginationLink
-                  data-testid="pagination-btn-right"
-                  icon="right"
-                  onClick={() => goToNextPage()}
-                />
-              </Pagination>
-            )}
+                  disabled={totalPages === 1}
+                  active={currentPage === page}
+                  key={`${page}`}
+                  onClick={() => goToPage(page)}
+                >
+                  {page}
+                </PaginationLink>
+              ))}
+              <PaginationLink
+                disabled={totalPages === 1}
+                data-testid="pagination-btn-right"
+                icon="right"
+                onClick={() => goToNextPage()}
+              />
+            </Pagination>
           </>
         )}
       </PaginationProvider>

--- a/ui/src/pages/namespace/Instances/List/index.tsx
+++ b/ui/src/pages/namespace/Instances/List/index.tsx
@@ -39,7 +39,6 @@ const InstancesListPage = () => {
   const instances = data?.data ?? [];
   const numberOfInstances = data?.meta?.total ?? 0;
   const noResults = isSuccess && instances.length === 0;
-  const showPagination = numberOfInstances > instancesPerPage;
   const hasFilters = !!Object.keys(filters).length;
 
   return (
@@ -108,14 +107,12 @@ const InstancesListPage = () => {
           </TableBody>
         </Table>
       </Card>
-      {showPagination && (
-        <Pagination
-          itemsPerPage={instancesPerPage}
-          offset={offset}
-          setOffset={setOffset}
-          totalItems={numberOfInstances}
-        />
-      )}
+      <Pagination
+        itemsPerPage={instancesPerPage}
+        offset={offset}
+        setOffset={setOffset}
+        totalItems={numberOfInstances}
+      />
     </div>
   );
 };

--- a/ui/src/pages/namespace/Mirror/Detail/index.tsx
+++ b/ui/src/pages/namespace/Mirror/Detail/index.tsx
@@ -115,24 +115,28 @@ const MirrorDetail = () => {
                 </TableBody>
               </Table>
             </Card>
-            {totalPages > 1 && (
-              <Pagination>
+            <Pagination>
+              <PaginationLink
+                disabled={totalPages === 1}
+                icon="left"
+                onClick={() => goToPreviousPage()}
+              />
+              {pagesList.map((page) => (
                 <PaginationLink
-                  icon="left"
-                  onClick={() => goToPreviousPage()}
-                />
-                {pagesList.map((page) => (
-                  <PaginationLink
-                    active={currentPage === page}
-                    key={`${page}`}
-                    onClick={() => goToPage(page)}
-                  >
-                    {page}
-                  </PaginationLink>
-                ))}
-                <PaginationLink icon="right" onClick={() => goToNextPage()} />
-              </Pagination>
-            )}
+                  disabled={totalPages === 1}
+                  active={currentPage === page}
+                  key={`${page}`}
+                  onClick={() => goToPage(page)}
+                >
+                  {page}
+                </PaginationLink>
+              ))}
+              <PaginationLink
+                disabled={totalPages === 1}
+                icon="right"
+                onClick={() => goToNextPage()}
+              />
+            </Pagination>
           </div>
         )}
       </PaginationProvider>

--- a/ui/src/pages/namespace/Settings/Registries/index.tsx
+++ b/ui/src/pages/namespace/Settings/Registries/index.tsx
@@ -132,24 +132,28 @@ const RegistriesList: FC = () => {
                 <NoPermissions>{noPermissionMessage}</NoPermissions>
               )}
             </Card>
-            {totalPages > 1 && (
-              <Pagination>
+            <Pagination>
+              <PaginationLink
+                disabled={totalPages === 1}
+                icon="left"
+                onClick={() => goToPreviousPage()}
+              />
+              {pagesList.map((page) => (
                 <PaginationLink
-                  icon="left"
-                  onClick={() => goToPreviousPage()}
-                />
-                {pagesList.map((page) => (
-                  <PaginationLink
-                    active={currentPage === page}
-                    key={`${page}`}
-                    onClick={() => goToPage(page)}
-                  >
-                    {page}
-                  </PaginationLink>
-                ))}
-                <PaginationLink icon="right" onClick={() => goToNextPage()} />
-              </Pagination>
-            )}
+                  disabled={totalPages === 1}
+                  active={currentPage === page}
+                  key={`${page}`}
+                  onClick={() => goToPage(page)}
+                >
+                  {page}
+                </PaginationLink>
+              ))}
+              <PaginationLink
+                disabled={totalPages === 1}
+                icon="right"
+                onClick={() => goToNextPage()}
+              />
+            </Pagination>
           </>
         )}
       </PaginationProvider>

--- a/ui/src/pages/namespace/Settings/Secrets/index.tsx
+++ b/ui/src/pages/namespace/Settings/Secrets/index.tsx
@@ -183,24 +183,28 @@ const SecretsList: FC = () => {
                 <NoPermissions>{noPermissionMessage}</NoPermissions>
               )}
             </Card>
-            {totalPages > 1 && (
-              <Pagination>
+            <Pagination>
+              <PaginationLink
+                disabled={totalPages === 1}
+                icon="left"
+                onClick={() => goToPreviousPage()}
+              />
+              {pagesList.map((page) => (
                 <PaginationLink
-                  icon="left"
-                  onClick={() => goToPreviousPage()}
-                />
-                {pagesList.map((page) => (
-                  <PaginationLink
-                    active={currentPage === page}
-                    key={`${page}`}
-                    onClick={() => goToPage(page)}
-                  >
-                    {page}
-                  </PaginationLink>
-                ))}
-                <PaginationLink icon="right" onClick={() => goToNextPage()} />
-              </Pagination>
-            )}
+                  disabled={totalPages === 1}
+                  active={currentPage === page}
+                  key={`${page}`}
+                  onClick={() => goToPage(page)}
+                >
+                  {page}
+                </PaginationLink>
+              ))}
+              <PaginationLink
+                disabled={totalPages === 1}
+                icon="right"
+                onClick={() => goToNextPage()}
+              />
+            </Pagination>
           </>
         )}
       </PaginationProvider>

--- a/ui/src/pages/namespace/Settings/Variables/index.tsx
+++ b/ui/src/pages/namespace/Settings/Variables/index.tsx
@@ -201,24 +201,28 @@ const VariablesList: FC = () => {
                 <NoPermissions>{noPermissionMessage}</NoPermissions>
               )}
             </Card>
-            {totalPages > 1 && (
-              <Pagination>
+            <Pagination>
+              <PaginationLink
+                disabled={totalPages === 1}
+                icon="left"
+                onClick={() => goToPreviousPage()}
+              />
+              {pagesList.map((page) => (
                 <PaginationLink
-                  icon="left"
-                  onClick={() => goToPreviousPage()}
-                />
-                {pagesList.map((page) => (
-                  <PaginationLink
-                    active={currentPage === page}
-                    key={`${page}`}
-                    onClick={() => goToPage(page)}
-                  >
-                    {page}
-                  </PaginationLink>
-                ))}
-                <PaginationLink icon="right" onClick={() => goToNextPage()} />
-              </Pagination>
-            )}
+                  disabled={totalPages === 1}
+                  active={currentPage === page}
+                  key={`${page}`}
+                  onClick={() => goToPage(page)}
+                >
+                  {page}
+                </PaginationLink>
+              ))}
+              <PaginationLink
+                disabled={totalPages === 1}
+                icon="right"
+                onClick={() => goToNextPage()}
+              />
+            </Pagination>
           </>
         )}
       </PaginationProvider>


### PR DESCRIPTION
## Description

This makes the pagination and pagesize (number of items in the list on one page) always visible, also if the list is empty.

![Bildschirmfoto 2025-01-08 um 15 09 25](https://github.com/user-attachments/assets/2aaca13c-3f92-4fbf-8a66-206a7b4ae164)


## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
