### PR TITLE
[DIR-1496] - UI support for system namespace

### DIFF
--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -1172,7 +1172,8 @@
     "namespaceSelector": {
       "placeholder": "Select Namespace",
       "loading": "loading...",
-      "optionDoesNotExist": "{{namespace}} (does not exist)"
+      "optionDoesNotExist": "{{namespace}} (does not exist)",
+      "systemNamespaceTooltip": "This scope is a utility to make miscellaneous information accessible to an instance."
     },
     "variableForm": {
       "title": {

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -1131,7 +1131,8 @@
         "passphrase": "Passphrase to decrypt keys (optional).",
         "privateKey": "Private SSH key used for authentication via git@ url.",
         "publicKey": "Public SSH key used for authenticating via git@ url.",
-        "insecure": "This will skip all checks for TLS certificate validity (only relevant for https and ssh, has no effect on http)"
+        "insecure": "This will skip all checks for TLS certificate validity (only relevant for https and ssh, has no effect on http)",
+        "systemNamespaceTooltip": "Using the name 'system' will create a privileged namespace with special system-wide impacts"
       }
     },
     "button": {
@@ -1173,7 +1174,7 @@
       "placeholder": "Select Namespace",
       "loading": "loading...",
       "optionDoesNotExist": "{{namespace}} (does not exist)",
-      "systemNamespaceTooltip": "This scope is a utility to make miscellaneous information accessible to an instance."
+      "systemNamespaceTooltip": "A privileged namespace with special system-wide impacts"
     },
     "variableForm": {
       "title": {

--- a/ui/src/components/NamespaceEdit/index.tsx
+++ b/ui/src/components/NamespaceEdit/index.tsx
@@ -274,19 +274,24 @@ const NamespaceEdit = ({
           className="flex flex-col gap-y-5"
         >
           {isNew && (
-            <fieldset className="flex items-center gap-5">
+            <fieldset className="flex gap-2 items-center">
               <label
                 className="w-[112px] overflow-hidden text-right text-[14px]"
                 htmlFor="name"
               >
                 {t("components.namespaceEdit.label.name")}
               </label>
-              <Input
-                id="name"
-                data-testid="new-namespace-name"
-                placeholder={t("components.namespaceEdit.placeholder.name")}
-                {...register("name")}
-              />
+              <InputWithButton>
+                <Input
+                  id="name"
+                  data-testid="new-namespace-name"
+                  placeholder={t("components.namespaceEdit.placeholder.name")}
+                  {...register("name")}
+                />
+                <InfoTooltip>
+                  {t("components.namespaceEdit.tooltip.systemNamespaceTooltip")}
+                </InfoTooltip>
+              </InputWithButton>
             </fieldset>
           )}
 

--- a/ui/src/components/NamespaceSelectorList/index.tsx
+++ b/ui/src/components/NamespaceSelectorList/index.tsx
@@ -1,4 +1,11 @@
-import { Check, Circle, Loader2, Square } from "lucide-react";
+import {
+  Check,
+  Circle,
+  CircleHelp,
+  Loader2,
+  Square,
+  Wrench,
+} from "lucide-react";
 import {
   CommandEmpty,
   CommandGroup,
@@ -7,6 +14,12 @@ import {
   CommandList,
   CommandStaticItem,
 } from "~/design/Command";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/design/Tooltip";
 
 import { twMergeClsx } from "~/util/helpers";
 import { useListNamespaces } from "~/api/namespaces/query/get";
@@ -68,7 +81,29 @@ export const NamespaceSelectorList = ({
                         namespace === ns.name ? "opacity-100" : "opacity-0"
                       )}
                     />
-                    <span>{ns.name}</span>
+                    <span className="flex items-center gap-1 w-full">
+                      {ns.name}
+                      {ns.isSystemNamespace ? (
+                        <>
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger className="underline font-normal text-gray-400">
+                                System
+                              </TooltipTrigger>
+                              <TooltipContent className="w-[300px]">
+                                <p>
+                                  {t(
+                                    "components.namespaceSelector.systemNamespaceTooltip"
+                                  )}
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </>
+                      ) : (
+                        ""
+                      )}
+                    </span>
                   </>
                 )}
               </CommandItem>

--- a/ui/src/components/NamespaceSelectorList/index.tsx
+++ b/ui/src/components/NamespaceSelectorList/index.tsx
@@ -1,11 +1,4 @@
-import {
-  Check,
-  Circle,
-  CircleHelp,
-  Loader2,
-  Square,
-  Wrench,
-} from "lucide-react";
+import { Check, Circle, Loader2, Square } from "lucide-react";
 import {
   CommandEmpty,
   CommandGroup,
@@ -14,13 +7,8 @@ import {
   CommandList,
   CommandStaticItem,
 } from "~/design/Command";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "~/design/Tooltip";
 
+import InfoTooltip from "../NamespaceEdit/InfoTooltip";
 import { twMergeClsx } from "~/util/helpers";
 import { useListNamespaces } from "~/api/namespaces/query/get";
 import { useNamespace } from "~/util/store/namespace";
@@ -85,20 +73,11 @@ export const NamespaceSelectorList = ({
                       {ns.name}
                       {ns.isSystemNamespace ? (
                         <>
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger className="underline font-normal text-gray-400">
-                                System
-                              </TooltipTrigger>
-                              <TooltipContent className="w-[300px]">
-                                <p>
-                                  {t(
-                                    "components.namespaceSelector.systemNamespaceTooltip"
-                                  )}
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
+                          <InfoTooltip>
+                            {t(
+                              "components.namespaceSelector.systemNamespaceTooltip"
+                            )}
+                          </InfoTooltip>
                         </>
                       ) : (
                         ""

--- a/ui/src/components/NamespaceSelectorList/index.tsx
+++ b/ui/src/components/NamespaceSelectorList/index.tsx
@@ -71,16 +71,12 @@ export const NamespaceSelectorList = ({
                     />
                     <span className="flex items-center gap-1 w-full">
                       {ns.name}
-                      {ns.isSystemNamespace ? (
-                        <>
-                          <InfoTooltip>
-                            {t(
-                              "components.namespaceSelector.systemNamespaceTooltip"
-                            )}
-                          </InfoTooltip>
-                        </>
-                      ) : (
-                        ""
+                      {ns.isSystemNamespace && (
+                        <InfoTooltip>
+                          {t(
+                            "components.namespaceSelector.systemNamespaceTooltip"
+                          )}
+                        </InfoTooltip>
                       )}
                     </span>
                   </>


### PR DESCRIPTION
## Description

- Added tooltip targeting namespace named 'system' to inform the user about the properties that this namespace contains. 
- Added tooltip to name field when creating a namespace, to inform the user about that they can use the name 'system' and what it means.


https://github.com/user-attachments/assets/9624a1d3-6060-44e5-9562-01a952bfb180

