### PR TITLE
[DIR-1901] - Add info tab to gateview view

### DIFF
--- a/ui/e2e/gateway/info/index.spec.ts
+++ b/ui/e2e/gateway/info/index.spec.ts
@@ -25,36 +25,29 @@ test("Info page default view", async ({ page }) => {
   await expect(page.getByText("Gateway Info")).toBeVisible();
 
   await expect(
-    page.getByText(namespace).first(),
+    page.getByTestId("breadcrumb-namespace"),
     "it displays the current namespace in the breadcrumb"
-  ).toBeVisible();
+  ).toHaveText(namespace);
 
   await expect(
-    page.getByText(namespace).nth(1),
-    "it displays the current namespace in the title"
-  ).toBeVisible();
-
-  await expect(
-    page.getByText(namespace).nth(2),
+    page.getByRole("cell", { name: namespace }),
     "it displays the current namespace in the info section"
   ).toBeVisible();
 
   await expect(
-    page.getByText("Version").nth(0),
-    "it displays the gateway version in the title"
-  ).toBeVisible();
-  await expect(
-    page.getByText("Version").nth(1),
-    "it displays the gateway version in the title"
-  ).toBeVisible();
-
-  await expect(
-    page.getByText("1.0").nth(0),
+    page.getByRole("cell", { name: "1.0" }),
     "it displays the gateway version in the info section"
   ).toBeVisible();
 
+  const editor = page.locator(".lines-content");
+
   await expect(
-    page.getByText("1.0").nth(1),
-    "it displays the gateway version in the info section"
-  ).toBeVisible();
+    editor,
+    "it displays the namespace in the editor preview"
+  ).toContainText(`title: ${namespace}`, { useInnerText: true });
+
+  await expect(
+    editor,
+    "it displays the version in the editor preview"
+  ).toContainText(`version: "1.0"`, { useInnerText: true });
 });

--- a/ui/e2e/gateway/info/index.spec.ts
+++ b/ui/e2e/gateway/info/index.spec.ts
@@ -1,0 +1,60 @@
+import { createNamespace, deleteNamespace } from "e2e/utils/namespace";
+import { expect, test } from "@playwright/test";
+
+let namespace = "";
+
+test.beforeEach(async () => {
+  namespace = await createNamespace();
+});
+
+test.afterEach(async () => {
+  await deleteNamespace(namespace);
+  namespace = "";
+});
+
+test("Info page default view", async ({ page }) => {
+  await page.goto(`/n/${namespace}/gateway/info`, {
+    waitUntil: "networkidle",
+  });
+
+  await expect(
+    page.getByTestId("breadcrumb-info"),
+    "it renders the 'Info' breadcrumb"
+  ).toBeVisible();
+
+  await expect(page.getByText("Gateway Info")).toBeVisible();
+
+  await expect(
+    page.getByText(namespace).first(),
+    "it displays the current namespace in the breadcrumb"
+  ).toBeVisible();
+
+  await expect(
+    page.getByText(namespace).nth(1),
+    "it displays the current namespace in the title"
+  ).toBeVisible();
+
+  await expect(
+    page.getByText(namespace).nth(2),
+    "it displays the current namespace in the info section"
+  ).toBeVisible();
+
+  await expect(
+    page.getByText("Version").nth(0),
+    "it displays the gateway version in the title"
+  ).toBeVisible();
+  await expect(
+    page.getByText("Version").nth(1),
+    "it displays the gateway version in the title"
+  ).toBeVisible();
+
+  await expect(
+    page.getByText("1.0").nth(0),
+    "it displays the gateway version in the info section"
+  ).toBeVisible();
+
+  await expect(
+    page.getByText("1.0").nth(1),
+    "it displays the gateway version in the info section"
+  ).toBeVisible();
+});

--- a/ui/src/api/gateway/index.ts
+++ b/ui/src/api/gateway/index.ts
@@ -15,4 +15,12 @@ export const gatewayKeys = {
         namespace,
       },
     ] as const,
-};
+  info: (namespace: string, { apiKey }: { apiKey?: string }) =>
+    [
+      {
+        scope: "gateway-info",
+        apiKey,
+        namespace,
+      },
+    ] as const,
+} as const;

--- a/ui/src/api/gateway/query/getInfo.ts
+++ b/ui/src/api/gateway/query/getInfo.ts
@@ -1,0 +1,39 @@
+import { GatewayInfoSchema } from "../schema";
+import { QueryFunctionContext } from "@tanstack/react-query";
+import { apiFactory } from "~/api/apiFactory";
+import { gatewayKeys } from "..";
+import { useApiKey } from "~/util/store/apiKey";
+import { useNamespace } from "~/util/store/namespace";
+import useQueryWithPermissions from "~/api/useQueryWithPermissions";
+
+export const getInfo = apiFactory({
+  url: ({ baseUrl, namespace }: { baseUrl?: string; namespace: string }) =>
+    `${baseUrl ?? ""}/api/v2/namespaces/${namespace}/gateway/info`,
+  method: "GET",
+  schema: GatewayInfoSchema,
+});
+
+const fetchInfo = async ({
+  queryKey: [{ apiKey, namespace }],
+}: QueryFunctionContext<ReturnType<(typeof gatewayKeys)["info"]>>) =>
+  getInfo({
+    apiKey,
+    urlParams: { namespace },
+  });
+
+export const useInfo = () => {
+  const apiKey = useApiKey();
+  const namespace = useNamespace();
+
+  if (!namespace) {
+    throw new Error("namespace is undefined");
+  }
+
+  return useQueryWithPermissions({
+    queryKey: gatewayKeys.info(namespace, {
+      apiKey: apiKey ?? undefined,
+    }),
+    queryFn: fetchInfo,
+    enabled: !!namespace,
+  });
+};

--- a/ui/src/api/gateway/schema.ts
+++ b/ui/src/api/gateway/schema.ts
@@ -149,25 +149,23 @@ export const ConsumersListSchema = z.object({
 }
  */
 export const GatewayInfoSchema = z.object({
-  data: z
-    .object({
-      spec: z
-        .object({
-          openapi: z.string(),
-          info: z
-            .object({
-              title: z.string(),
-              version: z.string(),
-              description: z.string().optional(),
-            })
-            .passthrough(),
-          paths: z.record(z.any()),
-        })
-        .passthrough(),
-      file_path: z.string(),
-      errors: z.array(z.unknown()),
-    })
-    .passthrough(),
+  data: z.object({
+    spec: z
+      .object({
+        openapi: z.string(),
+        info: z
+          .object({
+            title: z.string(),
+            version: z.string(),
+            description: z.string().optional(),
+          })
+          .passthrough(),
+        paths: z.record(z.any()),
+      })
+      .passthrough(),
+    file_path: z.string(),
+    errors: z.array(z.unknown()),
+  }),
 });
 
 export type GatewayInfoSchemaType = z.infer<typeof GatewayInfoSchema>;

--- a/ui/src/api/gateway/schema.ts
+++ b/ui/src/api/gateway/schema.ts
@@ -130,3 +130,44 @@ export type ConsumerSchemaType = z.infer<typeof ConsumerSchema>;
 export const ConsumersListSchema = z.object({
   data: z.array(ConsumerSchema),
 });
+
+/**
+ * example INFO
+{
+  "data": {
+    "spec": {
+      "openapi": "3.0.0",
+      "info": {
+        "title": "cg",
+        "version": "1.0"
+      },
+      "paths": {}
+    },
+    "file_path": "virtual",
+    "errors": []
+  }
+}
+ */
+export const GatewayInfoSchema = z.object({
+  data: z
+    .object({
+      spec: z
+        .object({
+          openapi: z.string(),
+          info: z
+            .object({
+              title: z.string(),
+              version: z.string(),
+              description: z.string().optional(),
+            })
+            .passthrough(),
+          paths: z.record(z.any()),
+        })
+        .passthrough(),
+      file_path: z.string(),
+      errors: z.array(z.unknown()),
+    })
+    .passthrough(),
+});
+
+export type GatewayInfoSchemaType = z.infer<typeof GatewayInfoSchema>;

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -955,7 +955,8 @@
     "gateway": {
       "tabs": {
         "routes": "Routes",
-        "consumers": "Consumers"
+        "consumers": "Consumers",
+        "info": "Info"
       },
       "routes": {
         "columns": {
@@ -1006,6 +1007,15 @@
           "groups": "groups"
         },
         "empty": "No consumers exist yet"
+      },
+      "info": {
+        "title": "Gateway Info",
+        "columns": {
+          "title": "Title",
+          "version": "Version",
+          "description": "Description",
+          "file": "File"
+        }
       }
     },
     "jqPlayground": {
@@ -1069,6 +1079,7 @@
       "gateway": "Gateway",
       "gatewayRoutes": "Routes",
       "gatewayConsumers": "Consumers",
+      "gatewayInfo": "Info",
       "jqPlayground": "jq Playground"
     },
     "contextMenu": {

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -1014,7 +1014,8 @@
           "title": "Title",
           "version": "Version",
           "description": "Description",
-          "file": "File"
+          "file": "File",
+          "errors": "Errors"
         }
       }
     },

--- a/ui/src/components/Breadcrumb/Gateway/GatewayInfo.tsx
+++ b/ui/src/components/Breadcrumb/Gateway/GatewayInfo.tsx
@@ -1,0 +1,30 @@
+import { BookOpen } from "lucide-react";
+import { Breadcrumb as BreadcrumbLink } from "~/design/Breadcrumbs";
+import { Link } from "react-router-dom";
+import { useNamespace } from "~/util/store/namespace";
+import { usePages } from "~/util/router/pages";
+import { useTranslation } from "react-i18next";
+
+const GatewayInfoBreadcrumb = () => {
+  const pages = usePages();
+  const namespace = useNamespace();
+  const { isGatewayInfoPage } = pages.gateway.useParams();
+
+  const { t } = useTranslation();
+
+  if (!namespace) return null;
+  if (!isGatewayInfoPage) return null;
+
+  return (
+    <>
+      <BreadcrumbLink data-testid="breadcrumb-info">
+        <Link to={pages.gateway.createHref({ namespace })}>
+          <BookOpen aria-hidden="true" />
+          {t("components.breadcrumb.gatewayInfo")}
+        </Link>
+      </BreadcrumbLink>
+    </>
+  );
+};
+
+export default GatewayInfoBreadcrumb;

--- a/ui/src/components/Breadcrumb/Gateway/Routes.tsx
+++ b/ui/src/components/Breadcrumb/Gateway/Routes.tsx
@@ -23,6 +23,7 @@ const RoutesBreadcrumb = () => {
         <Link
           to={pages.gateway.createHref({
             namespace,
+            subpage: "routes",
           })}
         >
           <Workflow aria-hidden="true" />

--- a/ui/src/components/Breadcrumb/Gateway/index.tsx
+++ b/ui/src/components/Breadcrumb/Gateway/index.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumb as BreadcrumbLink } from "~/design/Breadcrumbs";
 import ConsumerBreadcrumb from "./Consumer";
+import GatewayInfoBreadcrumb from "./GatewayInfo";
 import { Link } from "react-router-dom";
 import RoutesBreadcrumb from "./Routes";
 import { useNamespace } from "~/util/store/namespace";
@@ -30,6 +31,7 @@ const GatewayBreadcrumb = () => {
       </BreadcrumbLink>
       <RoutesBreadcrumb />
       <ConsumerBreadcrumb />
+      <GatewayInfoBreadcrumb />
     </>
   );
 };

--- a/ui/src/pages/namespace/Gateway/Info/index.tsx
+++ b/ui/src/pages/namespace/Gateway/Info/index.tsx
@@ -16,7 +16,7 @@ import { useInfo } from "~/api/gateway/query/getInfo";
 import { useTheme } from "~/util/store/theme";
 import { useTranslation } from "react-i18next";
 
-const GatewayInfoPage = () => {
+const InfoPage = () => {
   const { t } = useTranslation();
   const { data } = useInfo();
   const theme = useTheme();
@@ -65,7 +65,7 @@ const GatewayInfoPage = () => {
 
           {errors?.length ? (
             <Alert variant="error">
-              <h3>Errors</h3>
+              <h3>{t("pages.gateway.info.columns.errors")}</h3>
               <p>
                 <ul className="list-disc pl-4">
                   {errors.map((error, index) => (
@@ -95,4 +95,4 @@ const GatewayInfoPage = () => {
   );
 };
 
-export default GatewayInfoPage;
+export default InfoPage;

--- a/ui/src/pages/namespace/Gateway/Info/index.tsx
+++ b/ui/src/pages/namespace/Gateway/Info/index.tsx
@@ -1,0 +1,9 @@
+import { Card } from "~/design/Card";
+
+const GatewayInfoPage = () => (
+  <Card className="m-5">
+    <div>GatewayInfo</div>
+  </Card>
+);
+
+export default GatewayInfoPage;

--- a/ui/src/pages/namespace/Gateway/Info/index.tsx
+++ b/ui/src/pages/namespace/Gateway/Info/index.tsx
@@ -1,9 +1,98 @@
-import { Card } from "~/design/Card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+} from "~/design/Table";
 
-const GatewayInfoPage = () => (
-  <Card className="m-5">
-    <div>GatewayInfo</div>
-  </Card>
-);
+import Alert from "~/design/Alert";
+import { BookOpen } from "lucide-react";
+import { Card } from "~/design/Card";
+import Editor from "~/design/Editor";
+import { jsonToYaml } from "../../Explorer/utils";
+import { useInfo } from "~/api/gateway/query/getInfo";
+import { useTheme } from "~/util/store/theme";
+import { useTranslation } from "react-i18next";
+
+const GatewayInfoPage = () => {
+  const { t } = useTranslation();
+  const { data } = useInfo();
+  const theme = useTheme();
+  const info = data?.data;
+  const { spec, errors, file_path: filePath } = info || {};
+  const { title, version, description = "" } = spec?.info || {};
+
+  const specToYaml = spec ? jsonToYaml(spec) : "";
+
+  return (
+    <div className="flex grow flex-col gap-y-4 p-5">
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <h3 className="flex grow items-center gap-x-2 pb-1 font-bold">
+          <BookOpen className="h-5" />
+          {t("pages.gateway.info.title")}
+        </h3>
+      </div>
+      <div className="flex flex-col gap-4 sm:flex-row w-full">
+        <Card className=" lg:h-[calc(100vh-15.5rem)] lg:overflow-y-scroll w-1/2">
+          <Table className=" border-gray-5 dark:border-gray-dark-5">
+            <TableHead>
+              <TableRow className="hover:bg-inherit dark:hover:bg-inherit">
+                <TableHeaderCell>
+                  {t("pages.gateway.info.columns.title")}
+                </TableHeaderCell>
+                <TableHeaderCell>
+                  {t("pages.gateway.info.columns.version")}
+                </TableHeaderCell>
+                <TableHeaderCell>
+                  {t("pages.gateway.info.columns.description")}
+                </TableHeaderCell>
+                <TableHeaderCell>
+                  {t("pages.gateway.info.columns.file")}
+                </TableHeaderCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow className="hover:bg-inherit dark:hover:bg-inherit">
+                <TableCell>{title}</TableCell>
+                <TableCell>{version}</TableCell>
+                <TableCell>{description}</TableCell>
+                <TableCell>{filePath}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+
+          {errors?.length ? (
+            <Alert variant="error">
+              <h3>Errors</h3>
+              <p>
+                <ul className="list-disc pl-4">
+                  {errors.map((error, index) => (
+                    <li key={index}>
+                      {typeof error === "object"
+                        ? JSON.stringify(error)
+                        : String(error)}
+                    </li>
+                  ))}
+                </ul>
+              </p>
+            </Alert>
+          ) : null}
+        </Card>
+
+        <Card className="flex grow p-4 max-lg:h-[500px] w-1/2">
+          <Editor
+            value={specToYaml}
+            theme={theme ?? undefined}
+            options={{
+              readOnly: true,
+            }}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+};
 
 export default GatewayInfoPage;

--- a/ui/src/pages/namespace/Gateway/index.tsx
+++ b/ui/src/pages/namespace/Gateway/index.tsx
@@ -27,7 +27,6 @@ const GatewayPage = () => {
       title: t("pages.gateway.tabs.info"),
       link: pages.gateway.createHref({
         namespace,
-        subpage: "GatewayInfoPage",
       }),
     },
     {
@@ -37,6 +36,8 @@ const GatewayPage = () => {
       title: t("pages.gateway.tabs.routes"),
       link: pages.gateway.createHref({
         namespace,
+        subpage: "routeDetail",
+        routePath: "",
       }),
     },
     {

--- a/ui/src/pages/namespace/Gateway/index.tsx
+++ b/ui/src/pages/namespace/Gateway/index.tsx
@@ -36,8 +36,7 @@ const GatewayPage = () => {
       title: t("pages.gateway.tabs.routes"),
       link: pages.gateway.createHref({
         namespace,
-        subpage: "routeDetail",
-        routePath: "",
+        subpage: "routes",
       }),
     },
     {

--- a/ui/src/pages/namespace/Gateway/index.tsx
+++ b/ui/src/pages/namespace/Gateway/index.tsx
@@ -1,4 +1,4 @@
-import { Info, Users, Workflow } from "lucide-react";
+import { BookOpen, Users, Workflow } from "lucide-react";
 import { Link, Outlet } from "react-router-dom";
 import { Tabs, TabsList, TabsTrigger } from "~/design/Tabs";
 
@@ -23,8 +23,8 @@ const GatewayPage = () => {
     {
       value: "info",
       active: isGatewayInfoPage,
-      icon: <Info aria-hidden="true" />,
-      title: "Info",
+      icon: <BookOpen aria-hidden="true" />,
+      title: t("pages.gateway.tabs.info"),
       link: pages.gateway.createHref({
         namespace,
         subpage: "GatewayInfoPage",

--- a/ui/src/pages/namespace/Gateway/index.tsx
+++ b/ui/src/pages/namespace/Gateway/index.tsx
@@ -1,6 +1,6 @@
+import { Info, Users, Workflow } from "lucide-react";
 import { Link, Outlet } from "react-router-dom";
 import { Tabs, TabsList, TabsTrigger } from "~/design/Tabs";
-import { Users, Workflow } from "lucide-react";
 
 import { useNamespace } from "~/util/store/namespace";
 import { usePages } from "~/util/router/pages";
@@ -14,11 +14,22 @@ const GatewayPage = () => {
     isGatewayRoutesPage,
     isGatewayConsumerPage,
     isGatewayRoutesDetailPage,
+    isGatewayInfoPage,
   } = pages.gateway.useParams();
 
   if (!namespace) return null;
 
   const tabs = [
+    {
+      value: "info",
+      active: isGatewayInfoPage,
+      icon: <Info aria-hidden="true" />,
+      title: "Info",
+      link: pages.gateway.createHref({
+        namespace,
+        subpage: "GatewayInfoPage",
+      }),
+    },
     {
       value: "endpoints",
       active: isGatewayRoutesPage,

--- a/ui/src/util/router/pages.tsx
+++ b/ui/src/util/router/pages.tsx
@@ -19,6 +19,7 @@ import ErrorPage from "./ErrorPage";
 import EventsPage from "~/pages/namespace/Events";
 import ExplorerPage from "~/pages/namespace/Explorer";
 import GatewayConsumersPage from "~/pages/namespace/Gateway/Consumers";
+import GatewayInfoPage from "~/pages/namespace/Gateway/Info";
 import GatewayPage from "~/pages/namespace/Gateway";
 import GatewayRoutesPage from "~/pages/namespace/Gateway/Routes";
 import GroupsPage from "~/pages/namespace/Permissions/Groups";
@@ -202,6 +203,9 @@ type GatewayPageSetup = Record<
             subpage: "routeDetail";
             routePath: string;
           }
+        | {
+            subpage: "GatewayInfoPage";
+          }
       )
     ) => string;
     useParams: () => {
@@ -209,6 +213,7 @@ type GatewayPageSetup = Record<
       isGatewayRoutesPage: boolean;
       isGatewayRoutesDetailPage: boolean;
       isGatewayConsumerPage: boolean;
+      isGatewayInfoPage: boolean;
       routePath?: string;
     };
   }
@@ -568,12 +573,16 @@ export const usePages = (): PageType & EnterprisePageType => {
         if (params.subpage === "consumers") {
           subpage = "consumers";
         }
+        if (params.subpage === "GatewayInfoPage") {
+          subpage = "info";
+        }
         return `/n/${params.namespace}/gateway/${subpage}`;
       },
       useParams: () => {
         const { "*": path } = useParams();
         const [, secondLevel, thirdLevel] = useMatches(); // first level is namespace level
         const isGatewayPage = checkHandler(secondLevel, "isGatewayPage");
+        const isGatewayInfoPage = checkHandler(thirdLevel, "isGatewayInfoPage");
         const isGatewayRoutesPage = checkHandler(
           thirdLevel,
           "isGatewayRoutesPage"
@@ -588,6 +597,7 @@ export const usePages = (): PageType & EnterprisePageType => {
           "isGatewayRoutesDetailPage"
         );
         return {
+          isGatewayInfoPage,
           isGatewayPage,
           isGatewayRoutesPage,
           isGatewayConsumerPage,
@@ -600,6 +610,11 @@ export const usePages = (): PageType & EnterprisePageType => {
         element: <GatewayPage />,
         handle: { gateway: true, isGatewayPage: true },
         children: [
+          {
+            path: "info",
+            element: <GatewayInfoPage />,
+            handle: { isGatewayInfoPage: true },
+          },
           {
             path: "routes",
             element: <GatewayRoutesPage />,

--- a/ui/src/util/router/pages.tsx
+++ b/ui/src/util/router/pages.tsx
@@ -204,7 +204,7 @@ type GatewayPageSetup = Record<
             routePath: string;
           }
         | {
-            subpage: "GatewayInfoPage";
+            subpage: "info";
           }
       )
     ) => string;
@@ -566,14 +566,14 @@ export const usePages = (): PageType & EnterprisePageType => {
       name: "components.mainMenu.gateway",
       icon: Network,
       createHref: (params) => {
-        let subpage = "routes";
+        let subpage = "info";
         if (params.subpage === "routeDetail") {
           subpage = `routes/${removeLeadingSlash(params.routePath)}`;
         }
         if (params.subpage === "consumers") {
           subpage = "consumers";
         }
-        if (params.subpage === "GatewayInfoPage") {
+        if (params.subpage === "info") {
           subpage = "info";
         }
         return `/n/${params.namespace}/gateway/${subpage}`;

--- a/ui/src/util/router/pages.tsx
+++ b/ui/src/util/router/pages.tsx
@@ -199,12 +199,10 @@ type GatewayPageSetup = Record<
     createHref: (
       params: { namespace: string } & (
         | { subpage?: "consumers" }
+        | { subpage?: "routes" }
         | {
             subpage: "routeDetail";
             routePath: string;
-          }
-        | {
-            subpage: "info";
           }
       )
     ) => string;
@@ -573,8 +571,8 @@ export const usePages = (): PageType & EnterprisePageType => {
         if (params.subpage === "consumers") {
           subpage = "consumers";
         }
-        if (params.subpage === "info") {
-          subpage = "info";
+        if (params.subpage === "routes") {
+          subpage = "routes";
         }
         return `/n/${params.namespace}/gateway/${subpage}`;
       },


### PR DESCRIPTION
## Description

Added:
- Info tab to Gateway section
- with a table showing the basic info; Title, Version, Description, and also included File
- Breadcrumbs
- Yaml view

<img width="1718" alt="Screenshot 2025-01-22 at 10 10 41" src="https://github.com/user-attachments/assets/4934f898-6219-45f5-9caf-681738ee0bf9" />


## Checklist

- [ ] Documentation updated if required
- [ ] Test coverage is appropriate
      
## Checklist Internal

- [ ] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [ ] Has the PR been labeled
