### PR TITLE
[DIR-1507] only quit silently on 404 errors in e2e test

### DIFF
--- a/ui/e2e/gateway/routes/utils.ts
+++ b/ui/e2e/gateway/routes/utils.ts
@@ -67,7 +67,7 @@ type FindRouteWithApiRequestParams = {
   match: (route: RouteSchemaType) => boolean;
 };
 
-// type ErrorType = { response: { status?: number } };
+type ErrorType = { response: { status?: number } };
 
 export const findRouteWithApiRequest = async ({
   namespace,
@@ -83,17 +83,16 @@ export const findRouteWithApiRequest = async ({
     });
     return routes.find(match);
   } catch (error) {
-    // Temporary workaround: Until DIR-1503 is resolved, fail silently even on
-    // 500 errors. Ideally, we should only catch 404s and still throw unexpected errors
-    // (as implemented in the commented code).
-    return false;
-    // const typedError = error as ErrorType;
-    // if (typedError.response.status === 404) {
-    //   // fail silently to allow for using poll() in tests
-    //   return false;
-    // }
-    // throw new Error(
-    //   `Unexpected error ${typedError?.response?.status} during lookup of service ${match} in namespace ${namespace}`
-    // );
+    // In case tests act up due to unexpected errors, we can use the following
+    // line (and comment the below) to fail silently on all errors.
+    // return false;
+    const typedError = error as ErrorType;
+    if (typedError.response.status === 404) {
+      // fail silently to allow for using poll() in tests
+      return false;
+    }
+    throw new Error(
+      `Unexpected error ${typedError?.response?.status} during lookup of service ${match} in namespace ${namespace}`
+    );
   }
 };


### PR DESCRIPTION
## Description

This adds back more specific error handling to gateway e2e tests. Previously, tests were allowed to fail silently on a 500 server error because they sometimes occurred during tests when a resource didn't exist. Now, the backend has implemented 404 errors, and the tests have been updated to throw errors on a 500 error so we don't miss those unexpected ones.

Note: 

Locally, this test fails: "the logs panel can be resized, it displays a log message from the workflow yaml, one initial and one final log entry" -- but this is unrelated to my changes (also happens on main), and does not happen in the CI, so I'm ignoring it for now.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
