### PR TITLE
[DIR-1733] - Space before first line causes workflow execution error

### DIFF
--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -201,6 +201,7 @@
         "editor": {
           "unsavedNote": "unsaved changes",
           "theresOneIssue": "There is an issue",
+          "cannotStartWithSpace": "Workflows cannot start with a space",
           "runBtn": "Run",
           "saveBtn": "Save",
           "layout": {

--- a/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Workflow/Edit/WorkflowEditor.tsx
@@ -57,11 +57,15 @@ const WorkflowEditor: FC<{
 
   const onSave = (toSave: string | undefined) => {
     if (toSave) {
-      setError(undefined);
-      updateFile({
-        path: data.path,
-        payload: { data: encode(toSave) },
-      });
+      if (toSave.startsWith(" ")) {
+        setError(t("pages.explorer.workflow.editor.cannotStartWithSpace"));
+      } else {
+        setError(undefined);
+        updateFile({
+          path: data.path,
+          payload: { data: encode(toSave) },
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Description

When adding a leading space in the yaml editor, saving and then clicking 'Run' we got an 'oops..'-screen

I figured that catching any leading space upon save, and throwing an error would be the best way to go here.

## Checklist

- [x] Documentation updated if required
- [ ] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
