### PR TITLE
[DIR-1941] Restore gateway tabs

### DIFF
--- a/ui/e2e/gateway/consumers/index.spec.ts
+++ b/ui/e2e/gateway/consumers/index.spec.ts
@@ -18,10 +18,22 @@ test.afterEach(async () => {
   namespace = "";
 });
 
-test("Consumer list is empty by default", async ({ page }) => {
-  await page.goto(`/n/${namespace}/gateway/consumers`, {
+test("The consumer list can be visited", async ({ page }) => {
+  await page.goto(`/n/${namespace}/gateway/routes`, {
     waitUntil: "networkidle",
   });
+
+  await page.getByRole("tab", { name: "Consumers" }).click();
+
+  await expect(
+    page,
+    "it is possible to navigate to Consumers by breadcrumb"
+  ).toHaveURL(`n/${namespace}/gateway/consumers`);
+
+  await expect(
+    page.getByTestId("breadcrumb-gateway"),
+    "it renders the 'Gateway' breadcrumb"
+  ).toBeVisible();
 
   await expect(
     page.getByTestId("breadcrumb-consumers"),
@@ -31,6 +43,23 @@ test("Consumer list is empty by default", async ({ page }) => {
   await expect(
     page.getByText("No consumers exist yet"),
     "it renders an empty list of consumers"
+  ).toBeVisible();
+
+  await page.getByRole("tab", { name: "Routes" }).click();
+
+  await expect(
+    page,
+    "it is possible to navigate to Routes by breadcrumb"
+  ).toHaveURL(`n/${namespace}/gateway/routes`);
+
+  await expect(
+    page.getByTestId("breadcrumb-gateway"),
+    "it renders the 'Gateway' breadcrumb"
+  ).toBeVisible();
+
+  await expect(
+    page.getByTestId("breadcrumb-routes"),
+    "it renders the 'Routes' breadcrumb"
   ).toBeVisible();
 });
 

--- a/ui/e2e/gateway/routes/details/index.spec.ts
+++ b/ui/e2e/gateway/routes/details/index.spec.ts
@@ -47,7 +47,18 @@ test("Route details page shows all important information about the route", async
     )
     .toBeTruthy();
 
-  await page.goto(`/n/${namespace}/gateway/routes/${fileName}`);
+  await page.goto(`/n/${namespace}/gateway/routes`);
+
+  page
+    .getByTestId("route-table")
+    .locator("div")
+    .filter({ hasText: `/my-route.yaml` })
+    .click();
+
+  await expect(
+    page,
+    "it is possible to navigate to the route detail page"
+  ).toHaveURL(`n/${namespace}/gateway/routes/my-route.yaml`);
 
   await expect(
     page

--- a/ui/e2e/gateway/routes/list/index.spec.ts
+++ b/ui/e2e/gateway/routes/list/index.spec.ts
@@ -20,10 +20,15 @@ test.afterEach(async () => {
   namespace = "";
 });
 
-test("Route list is empty by default", async ({ page }) => {
+test("The route list can be visited", async ({ page }) => {
   await page.goto(`/n/${namespace}/gateway/routes`, {
     waitUntil: "networkidle",
   });
+
+  await expect(
+    page.getByTestId("breadcrumb-gateway"),
+    "it renders the 'Gateway' breadcrumb"
+  ).toBeVisible();
 
   await expect(
     page.getByTestId("breadcrumb-routes"),

--- a/ui/src/components/Breadcrumb/Gateway/Routes.tsx
+++ b/ui/src/components/Breadcrumb/Gateway/Routes.tsx
@@ -5,14 +5,14 @@ import { Breadcrumb as BreadcrumbLink } from "~/design/Breadcrumbs";
 import { useTranslation } from "react-i18next";
 
 const RoutesBreadcrumb = () => {
-  const { filename } = useParams({ strict: false });
+  const { _splat } = useParams({ strict: false });
   const isGatewayRoutesPage = useMatch({
     from: "/n/$namespace/gateway/routes/",
     shouldThrow: false,
   });
 
   const isGatewayRoutesDetailPage = useMatch({
-    from: "/n/$namespace/gateway/routes/$filename",
+    from: "/n/$namespace/gateway/routes/$",
     shouldThrow: false,
   });
 
@@ -28,15 +28,15 @@ const RoutesBreadcrumb = () => {
           {t("components.breadcrumb.gatewayRoutes")}
         </Link>
       </BreadcrumbLink>
-      {filename && (
+      {isGatewayRoutesDetailPage && (
         <BreadcrumbLink data-testid="breadcrumb-routes">
           <Link
-            to="/n/$namespace/gateway/routes/$filename"
+            to="/n/$namespace/gateway/routes/$"
             from="/n/$namespace"
-            params={{ filename }}
+            params={{ _splat }}
           >
             <SquareGanttChartIcon aria-hidden="true" />
-            {filename}
+            {_splat}
           </Link>
         </BreadcrumbLink>
       )}

--- a/ui/src/components/Breadcrumb/Gateway/index.tsx
+++ b/ui/src/components/Breadcrumb/Gateway/index.tsx
@@ -20,7 +20,7 @@ const GatewayBreadcrumb = () => {
 
   return (
     <>
-      <BreadcrumbLink>
+      <BreadcrumbLink data-testid="breadcrumb-gateway">
         <Link to="/n/$namespace/gateway/routes" from="/n/$namespace">
           <Network aria-hidden="true" />
           {t("components.breadcrumb.gateway")}

--- a/ui/src/components/Breadcrumb/Gateway/index.tsx
+++ b/ui/src/components/Breadcrumb/Gateway/index.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "react-i18next";
 
 const GatewayBreadcrumb = () => {
   const matches = useMatches();
-  const routeId: keyof FileRoutesById = "/n/$namespace/gateway/";
+  const routeId: keyof FileRoutesById = "/n/$namespace/gateway";
   const isGatewayPage = matches.some((match) =>
     match.routeId.startsWith(routeId)
   );
@@ -21,7 +21,7 @@ const GatewayBreadcrumb = () => {
   return (
     <>
       <BreadcrumbLink>
-        <Link to="/n/$namespace/gateway" from="/n/$namespace">
+        <Link to="/n/$namespace/gateway/routes" from="/n/$namespace">
           <Network aria-hidden="true" />
           {t("components.breadcrumb.gateway")}
         </Link>

--- a/ui/src/components/Breadcrumb/index.tsx
+++ b/ui/src/components/Breadcrumb/index.tsx
@@ -41,7 +41,7 @@ const Breadcrumb = () => {
       {matchRouteStart("/n/$namespace/settings") && <SettingsBreadcrumb />}
       {matchRouteStart("/n/$namespace/jq") && <JqPlaygroundBreadcrumb />}
       {matchRouteStart("/n/$namespace/mirror/") && <MirrorBreadcrumb />}
-      {matchRouteStart("/n/$namespace/gateway/") && <GatewayBreadcrumb />}
+      {matchRouteStart("/n/$namespace/gateway") && <GatewayBreadcrumb />}
     </BreadcrumbRoot>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Endpoint/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/index.tsx
@@ -58,9 +58,9 @@ const EndpointPage: FC = () => {
           </div>
           <Button isAnchor asChild variant="primary">
             <Link
-              to="/n/$namespace/gateway/routes/$filename"
+              to="/n/$namespace/gateway/routes/$"
               from="/n/$namespace"
-              params={{ filename: path }}
+              params={{ _splat: path }}
             >
               <ScrollText />
               {t("pages.explorer.endpoint.openRouteLogs")}

--- a/ui/src/pages/namespace/Gateway/Routes/Detail/Header.tsx
+++ b/ui/src/pages/namespace/Gateway/Routes/Detail/Header.tsx
@@ -12,16 +12,15 @@ import { useRoute } from "~/api/gateway/query/getRoutes";
 import { useTranslation } from "react-i18next";
 
 const Header = () => {
-  const { filename } = useParams({ strict: false });
+  const { _splat } = useParams({ strict: false });
   const { data: route } = useRoute({
-    routePath: filename ?? "",
-    enabled: !!filename,
+    routePath: _splat ?? "",
+    enabled: !!_splat,
   });
 
   const { t } = useTranslation();
 
   if (!route) return null;
-  if (!filename) return null;
 
   return (
     <div
@@ -80,7 +79,7 @@ const Header = () => {
             <Link
               to="/n/$namespace/explorer/endpoint/$"
               from="/n/$namespace"
-              params={{ _splat: filename }}
+              params={{ _splat }}
             >
               <Pencil />
               {t("pages.gateway.routes.detail.editRoute")}

--- a/ui/src/pages/namespace/Gateway/Routes/Detail/index.tsx
+++ b/ui/src/pages/namespace/Gateway/Routes/Detail/index.tsx
@@ -8,10 +8,10 @@ import { useParams } from "@tanstack/react-router";
 import { useRoute } from "~/api/gateway/query/getRoutes";
 
 const RoutesDetailPage = () => {
-  const { filename } = useParams({ strict: false });
+  const { _splat } = useParams({ strict: false });
   const { data, isAllowed, isFetched, noPermissionMessage } = useRoute({
-    routePath: filename ?? "",
-    enabled: !!filename,
+    routePath: _splat ?? "",
+    enabled: !!_splat,
   });
 
   if (!isFetched) return null;

--- a/ui/src/pages/namespace/Gateway/Routes/Table/Row.tsx
+++ b/ui/src/pages/namespace/Gateway/Routes/Table/Row.tsx
@@ -23,9 +23,9 @@ export const Row: FC<RowProps> = ({ route }) => {
     <TableRow
       onClick={() => {
         navigate({
-          to: "/n/$namespace/gateway/routes/$filename",
+          to: "/n/$namespace/gateway/routes/$",
           from: "/n/$namespace",
-          params: { filename: route.file_path },
+          params: { _splat: route.file_path },
         });
       }}
       className="cursor-pointer"

--- a/ui/src/pages/namespace/Gateway/index.tsx
+++ b/ui/src/pages/namespace/Gateway/index.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 const GatewayPage = () => {
   const { t } = useTranslation();
   const isGatewayRoutesPage = useMatch({
-    from: "/n/$namespace/gateway/",
+    from: "/n/$namespace/gateway",
     shouldThrow: false,
   });
   const isGatewayConsumerPage = useMatch({
@@ -15,7 +15,7 @@ const GatewayPage = () => {
     shouldThrow: false,
   });
   const isGatewayRoutesDetailPage = useMatch({
-    from: "/n/$namespace/gateway/routes/$filename",
+    from: "/n/$namespace/gateway/routes/$",
     shouldThrow: false,
   });
 

--- a/ui/src/pages/namespace/Gateway/index.tsx
+++ b/ui/src/pages/namespace/Gateway/index.tsx
@@ -25,7 +25,7 @@ const GatewayPage = () => {
       active: isGatewayRoutesPage,
       icon: <Workflow aria-hidden="true" />,
       title: t("pages.gateway.tabs.routes"),
-      link: "/n/$namespace/gateway",
+      link: "/n/$namespace/gateway/routes",
     },
     {
       value: "consumers",

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -21,13 +21,13 @@ import { Route as NNamespaceMonitoringImport } from './routes/n/$namespace/monit
 import { Route as NNamespaceJqImport } from './routes/n/$namespace/jq'
 import { Route as NNamespacePermissionsRouteImport } from './routes/n/$namespace/permissions/route'
 import { Route as NNamespaceMirrorRouteImport } from './routes/n/$namespace/mirror/route'
+import { Route as NNamespaceGatewayRouteImport } from './routes/n/$namespace/gateway/route'
 import { Route as NNamespaceExplorerRouteImport } from './routes/n/$namespace/explorer/route'
 import { Route as NNamespaceEventsRouteImport } from './routes/n/$namespace/events/route'
 import { Route as NNamespaceServicesIndexImport } from './routes/n/$namespace/services/index'
 import { Route as NNamespacePermissionsIndexImport } from './routes/n/$namespace/permissions/index'
 import { Route as NNamespaceMirrorIndexImport } from './routes/n/$namespace/mirror/index'
 import { Route as NNamespaceInstancesIndexImport } from './routes/n/$namespace/instances/index'
-import { Route as NNamespaceGatewayIndexImport } from './routes/n/$namespace/gateway/index'
 import { Route as NNamespaceExplorerIndexImport } from './routes/n/$namespace/explorer/index'
 import { Route as NNamespaceServicesLayoutImport } from './routes/n/$namespace/services/_layout'
 import { Route as NNamespaceServicesServiceImport } from './routes/n/$namespace/services/$service'
@@ -120,6 +120,12 @@ const NNamespaceMirrorRouteRoute = NNamespaceMirrorRouteImport.update({
   getParentRoute: () => NNamespaceRouteRoute,
 } as any)
 
+const NNamespaceGatewayRouteRoute = NNamespaceGatewayRouteImport.update({
+  id: '/gateway',
+  path: '/gateway',
+  getParentRoute: () => NNamespaceRouteRoute,
+} as any)
+
 const NNamespaceExplorerRouteRoute = NNamespaceExplorerRouteImport.update({
   id: '/explorer',
   path: '/explorer',
@@ -156,12 +162,6 @@ const NNamespaceInstancesIndexRoute = NNamespaceInstancesIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => NNamespaceInstancesRoute,
-} as any)
-
-const NNamespaceGatewayIndexRoute = NNamespaceGatewayIndexImport.update({
-  id: '/gateway/',
-  path: '/gateway/',
-  getParentRoute: () => NNamespaceRouteRoute,
 } as any)
 
 const NNamespaceExplorerIndexRoute = NNamespaceExplorerIndexImport.update({
@@ -208,9 +208,9 @@ const NNamespaceInstancesIdRoute = NNamespaceInstancesIdImport.update({
 
 const NNamespaceGatewayConsumersRoute = NNamespaceGatewayConsumersImport.update(
   {
-    id: '/gateway/consumers',
-    path: '/gateway/consumers',
-    getParentRoute: () => NNamespaceRouteRoute,
+    id: '/consumers',
+    path: '/consumers',
+    getParentRoute: () => NNamespaceGatewayRouteRoute,
   } as any,
 )
 
@@ -235,9 +235,9 @@ const NNamespaceExplorerWorkflowRouteRoute =
 
 const NNamespaceGatewayRoutesIndexRoute =
   NNamespaceGatewayRoutesIndexImport.update({
-    id: '/gateway/routes/',
-    path: '/gateway/routes/',
-    getParentRoute: () => NNamespaceRouteRoute,
+    id: '/routes/',
+    path: '/routes/',
+    getParentRoute: () => NNamespaceGatewayRouteRoute,
   } as any)
 
 const NNamespaceMirrorLogsSyncRoute = NNamespaceMirrorLogsSyncImport.update({
@@ -248,9 +248,9 @@ const NNamespaceMirrorLogsSyncRoute = NNamespaceMirrorLogsSyncImport.update({
 
 const NNamespaceGatewayRoutesFilenameRoute =
   NNamespaceGatewayRoutesFilenameImport.update({
-    id: '/gateway/routes/$filename',
-    path: '/gateway/routes/$filename',
-    getParentRoute: () => NNamespaceRouteRoute,
+    id: '/routes/$filename',
+    path: '/routes/$filename',
+    getParentRoute: () => NNamespaceGatewayRouteRoute,
   } as any)
 
 const NNamespaceExplorerTreeSplatRoute =
@@ -348,6 +348,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NNamespaceExplorerRouteImport
       parentRoute: typeof NNamespaceRouteImport
     }
+    '/n/$namespace/gateway': {
+      id: '/n/$namespace/gateway'
+      path: '/gateway'
+      fullPath: '/n/$namespace/gateway'
+      preLoaderRoute: typeof NNamespaceGatewayRouteImport
+      parentRoute: typeof NNamespaceRouteImport
+    }
     '/n/$namespace/mirror': {
       id: '/n/$namespace/mirror'
       path: '/mirror'
@@ -406,10 +413,10 @@ declare module '@tanstack/react-router' {
     }
     '/n/$namespace/gateway/consumers': {
       id: '/n/$namespace/gateway/consumers'
-      path: '/gateway/consumers'
+      path: '/consumers'
       fullPath: '/n/$namespace/gateway/consumers'
       preLoaderRoute: typeof NNamespaceGatewayConsumersImport
-      parentRoute: typeof NNamespaceRouteImport
+      parentRoute: typeof NNamespaceGatewayRouteImport
     }
     '/n/$namespace/instances/$id': {
       id: '/n/$namespace/instances/$id'
@@ -474,13 +481,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NNamespaceExplorerIndexImport
       parentRoute: typeof NNamespaceExplorerRouteImport
     }
-    '/n/$namespace/gateway/': {
-      id: '/n/$namespace/gateway/'
-      path: '/gateway'
-      fullPath: '/n/$namespace/gateway'
-      preLoaderRoute: typeof NNamespaceGatewayIndexImport
-      parentRoute: typeof NNamespaceRouteImport
-    }
     '/n/$namespace/instances/': {
       id: '/n/$namespace/instances/'
       path: '/'
@@ -539,10 +539,10 @@ declare module '@tanstack/react-router' {
     }
     '/n/$namespace/gateway/routes/$filename': {
       id: '/n/$namespace/gateway/routes/$filename'
-      path: '/gateway/routes/$filename'
+      path: '/routes/$filename'
       fullPath: '/n/$namespace/gateway/routes/$filename'
       preLoaderRoute: typeof NNamespaceGatewayRoutesFilenameImport
-      parentRoute: typeof NNamespaceRouteImport
+      parentRoute: typeof NNamespaceGatewayRouteImport
     }
     '/n/$namespace/mirror/logs/$sync': {
       id: '/n/$namespace/mirror/logs/$sync'
@@ -553,10 +553,10 @@ declare module '@tanstack/react-router' {
     }
     '/n/$namespace/gateway/routes/': {
       id: '/n/$namespace/gateway/routes/'
-      path: '/gateway/routes'
+      path: '/routes'
       fullPath: '/n/$namespace/gateway/routes'
       preLoaderRoute: typeof NNamespaceGatewayRoutesIndexImport
-      parentRoute: typeof NNamespaceRouteImport
+      parentRoute: typeof NNamespaceGatewayRouteImport
     }
     '/n/$namespace/explorer/workflow/edit/$': {
       id: '/n/$namespace/explorer/workflow/edit/$'
@@ -655,6 +655,24 @@ const NNamespaceExplorerRouteRouteWithChildren =
     NNamespaceExplorerRouteRouteChildren,
   )
 
+interface NNamespaceGatewayRouteRouteChildren {
+  NNamespaceGatewayConsumersRoute: typeof NNamespaceGatewayConsumersRoute
+  NNamespaceGatewayRoutesFilenameRoute: typeof NNamespaceGatewayRoutesFilenameRoute
+  NNamespaceGatewayRoutesIndexRoute: typeof NNamespaceGatewayRoutesIndexRoute
+}
+
+const NNamespaceGatewayRouteRouteChildren: NNamespaceGatewayRouteRouteChildren =
+  {
+    NNamespaceGatewayConsumersRoute: NNamespaceGatewayConsumersRoute,
+    NNamespaceGatewayRoutesFilenameRoute: NNamespaceGatewayRoutesFilenameRoute,
+    NNamespaceGatewayRoutesIndexRoute: NNamespaceGatewayRoutesIndexRoute,
+  }
+
+const NNamespaceGatewayRouteRouteWithChildren =
+  NNamespaceGatewayRouteRoute._addFileChildren(
+    NNamespaceGatewayRouteRouteChildren,
+  )
+
 interface NNamespaceMirrorRouteRouteChildren {
   NNamespaceMirrorIndexRoute: typeof NNamespaceMirrorIndexRoute
   NNamespaceMirrorLogsSyncRoute: typeof NNamespaceMirrorLogsSyncRoute
@@ -717,37 +735,31 @@ const NNamespaceServicesRouteWithChildren =
 interface NNamespaceRouteRouteChildren {
   NNamespaceEventsRouteRoute: typeof NNamespaceEventsRouteRouteWithChildren
   NNamespaceExplorerRouteRoute: typeof NNamespaceExplorerRouteRouteWithChildren
+  NNamespaceGatewayRouteRoute: typeof NNamespaceGatewayRouteRouteWithChildren
   NNamespaceMirrorRouteRoute: typeof NNamespaceMirrorRouteRouteWithChildren
   NNamespacePermissionsRouteRoute: typeof NNamespacePermissionsRouteRouteWithChildren
   NNamespaceJqRoute: typeof NNamespaceJqRoute
   NNamespaceMonitoringRoute: typeof NNamespaceMonitoringRoute
   NNamespaceSettingsRoute: typeof NNamespaceSettingsRoute
-  NNamespaceGatewayConsumersRoute: typeof NNamespaceGatewayConsumersRoute
   NNamespaceInstancesIdRoute: typeof NNamespaceInstancesIdRoute
   NNamespaceInstancesRoute: typeof NNamespaceInstancesRouteWithChildren
   NNamespaceServicesServiceRoute: typeof NNamespaceServicesServiceRoute
   NNamespaceServicesRoute: typeof NNamespaceServicesRouteWithChildren
-  NNamespaceGatewayIndexRoute: typeof NNamespaceGatewayIndexRoute
-  NNamespaceGatewayRoutesFilenameRoute: typeof NNamespaceGatewayRoutesFilenameRoute
-  NNamespaceGatewayRoutesIndexRoute: typeof NNamespaceGatewayRoutesIndexRoute
 }
 
 const NNamespaceRouteRouteChildren: NNamespaceRouteRouteChildren = {
   NNamespaceEventsRouteRoute: NNamespaceEventsRouteRouteWithChildren,
   NNamespaceExplorerRouteRoute: NNamespaceExplorerRouteRouteWithChildren,
+  NNamespaceGatewayRouteRoute: NNamespaceGatewayRouteRouteWithChildren,
   NNamespaceMirrorRouteRoute: NNamespaceMirrorRouteRouteWithChildren,
   NNamespacePermissionsRouteRoute: NNamespacePermissionsRouteRouteWithChildren,
   NNamespaceJqRoute: NNamespaceJqRoute,
   NNamespaceMonitoringRoute: NNamespaceMonitoringRoute,
   NNamespaceSettingsRoute: NNamespaceSettingsRoute,
-  NNamespaceGatewayConsumersRoute: NNamespaceGatewayConsumersRoute,
   NNamespaceInstancesIdRoute: NNamespaceInstancesIdRoute,
   NNamespaceInstancesRoute: NNamespaceInstancesRouteWithChildren,
   NNamespaceServicesServiceRoute: NNamespaceServicesServiceRoute,
   NNamespaceServicesRoute: NNamespaceServicesRouteWithChildren,
-  NNamespaceGatewayIndexRoute: NNamespaceGatewayIndexRoute,
-  NNamespaceGatewayRoutesFilenameRoute: NNamespaceGatewayRoutesFilenameRoute,
-  NNamespaceGatewayRoutesIndexRoute: NNamespaceGatewayRoutesIndexRoute,
 }
 
 const NNamespaceRouteRouteWithChildren = NNamespaceRouteRoute._addFileChildren(
@@ -760,6 +772,7 @@ export interface FileRoutesByFullPath {
   '/n/$namespace': typeof NNamespaceRouteRouteWithChildren
   '/n/$namespace/events': typeof NNamespaceEventsRouteRouteWithChildren
   '/n/$namespace/explorer': typeof NNamespaceExplorerRouteRouteWithChildren
+  '/n/$namespace/gateway': typeof NNamespaceGatewayRouteRouteWithChildren
   '/n/$namespace/mirror': typeof NNamespaceMirrorRouteRouteWithChildren
   '/n/$namespace/permissions': typeof NNamespacePermissionsRouteRouteWithChildren
   '/n/$namespace/jq': typeof NNamespaceJqRoute
@@ -776,7 +789,6 @@ export interface FileRoutesByFullPath {
   '/n/$namespace/services/$service': typeof NNamespaceServicesServiceRoute
   '/n/$namespace/services': typeof NNamespaceServicesLayoutRoute
   '/n/$namespace/explorer/': typeof NNamespaceExplorerIndexRoute
-  '/n/$namespace/gateway': typeof NNamespaceGatewayIndexRoute
   '/n/$namespace/instances/': typeof NNamespaceInstancesIndexRoute
   '/n/$namespace/mirror/': typeof NNamespaceMirrorIndexRoute
   '/n/$namespace/permissions/': typeof NNamespacePermissionsIndexRoute
@@ -799,6 +811,7 @@ export interface FileRoutesByTo {
   '/*': typeof Route
   '/n/$namespace': typeof NNamespaceRouteRouteWithChildren
   '/n/$namespace/events': typeof NNamespaceEventsRouteRouteWithChildren
+  '/n/$namespace/gateway': typeof NNamespaceGatewayRouteRouteWithChildren
   '/n/$namespace/jq': typeof NNamespaceJqRoute
   '/n/$namespace/monitoring': typeof NNamespaceMonitoringRoute
   '/n/$namespace/settings': typeof NNamespaceSettingsRoute
@@ -813,7 +826,6 @@ export interface FileRoutesByTo {
   '/n/$namespace/services/$service': typeof NNamespaceServicesServiceRoute
   '/n/$namespace/services': typeof NNamespaceServicesIndexRoute
   '/n/$namespace/explorer': typeof NNamespaceExplorerIndexRoute
-  '/n/$namespace/gateway': typeof NNamespaceGatewayIndexRoute
   '/n/$namespace/mirror': typeof NNamespaceMirrorIndexRoute
   '/n/$namespace/permissions': typeof NNamespacePermissionsIndexRoute
   '/n/$namespace/explorer/consumer/$': typeof NNamespaceExplorerConsumerSplatRoute
@@ -836,6 +848,7 @@ export interface FileRoutesById {
   '/n/$namespace': typeof NNamespaceRouteRouteWithChildren
   '/n/$namespace/events': typeof NNamespaceEventsRouteRouteWithChildren
   '/n/$namespace/explorer': typeof NNamespaceExplorerRouteRouteWithChildren
+  '/n/$namespace/gateway': typeof NNamespaceGatewayRouteRouteWithChildren
   '/n/$namespace/mirror': typeof NNamespaceMirrorRouteRouteWithChildren
   '/n/$namespace/permissions': typeof NNamespacePermissionsRouteRouteWithChildren
   '/n/$namespace/jq': typeof NNamespaceJqRoute
@@ -854,7 +867,6 @@ export interface FileRoutesById {
   '/n/$namespace/services': typeof NNamespaceServicesRouteWithChildren
   '/n/$namespace/services/_layout': typeof NNamespaceServicesLayoutRoute
   '/n/$namespace/explorer/': typeof NNamespaceExplorerIndexRoute
-  '/n/$namespace/gateway/': typeof NNamespaceGatewayIndexRoute
   '/n/$namespace/instances/': typeof NNamespaceInstancesIndexRoute
   '/n/$namespace/mirror/': typeof NNamespaceMirrorIndexRoute
   '/n/$namespace/permissions/': typeof NNamespacePermissionsIndexRoute
@@ -880,6 +892,7 @@ export interface FileRouteTypes {
     | '/n/$namespace'
     | '/n/$namespace/events'
     | '/n/$namespace/explorer'
+    | '/n/$namespace/gateway'
     | '/n/$namespace/mirror'
     | '/n/$namespace/permissions'
     | '/n/$namespace/jq'
@@ -896,7 +909,6 @@ export interface FileRouteTypes {
     | '/n/$namespace/services/$service'
     | '/n/$namespace/services'
     | '/n/$namespace/explorer/'
-    | '/n/$namespace/gateway'
     | '/n/$namespace/instances/'
     | '/n/$namespace/mirror/'
     | '/n/$namespace/permissions/'
@@ -918,6 +930,7 @@ export interface FileRouteTypes {
     | '/*'
     | '/n/$namespace'
     | '/n/$namespace/events'
+    | '/n/$namespace/gateway'
     | '/n/$namespace/jq'
     | '/n/$namespace/monitoring'
     | '/n/$namespace/settings'
@@ -932,7 +945,6 @@ export interface FileRouteTypes {
     | '/n/$namespace/services/$service'
     | '/n/$namespace/services'
     | '/n/$namespace/explorer'
-    | '/n/$namespace/gateway'
     | '/n/$namespace/mirror'
     | '/n/$namespace/permissions'
     | '/n/$namespace/explorer/consumer/$'
@@ -953,6 +965,7 @@ export interface FileRouteTypes {
     | '/n/$namespace'
     | '/n/$namespace/events'
     | '/n/$namespace/explorer'
+    | '/n/$namespace/gateway'
     | '/n/$namespace/mirror'
     | '/n/$namespace/permissions'
     | '/n/$namespace/jq'
@@ -971,7 +984,6 @@ export interface FileRouteTypes {
     | '/n/$namespace/services'
     | '/n/$namespace/services/_layout'
     | '/n/$namespace/explorer/'
-    | '/n/$namespace/gateway/'
     | '/n/$namespace/instances/'
     | '/n/$namespace/mirror/'
     | '/n/$namespace/permissions/'
@@ -1028,19 +1040,16 @@ export const routeTree = rootRoute
       "children": [
         "/n/$namespace/events",
         "/n/$namespace/explorer",
+        "/n/$namespace/gateway",
         "/n/$namespace/mirror",
         "/n/$namespace/permissions",
         "/n/$namespace/jq",
         "/n/$namespace/monitoring",
         "/n/$namespace/settings",
-        "/n/$namespace/gateway/consumers",
         "/n/$namespace/instances/$id",
         "/n/$namespace/instances",
         "/n/$namespace/services/$service",
-        "/n/$namespace/services",
-        "/n/$namespace/gateway/",
-        "/n/$namespace/gateway/routes/$filename",
-        "/n/$namespace/gateway/routes/"
+        "/n/$namespace/services"
       ]
     },
     "/n/$namespace/events": {
@@ -1061,6 +1070,15 @@ export const routeTree = rootRoute
         "/n/$namespace/explorer/endpoint/$",
         "/n/$namespace/explorer/service/$",
         "/n/$namespace/explorer/tree/$"
+      ]
+    },
+    "/n/$namespace/gateway": {
+      "filePath": "n/$namespace/gateway/route.tsx",
+      "parent": "/n/$namespace",
+      "children": [
+        "/n/$namespace/gateway/consumers",
+        "/n/$namespace/gateway/routes/$filename",
+        "/n/$namespace/gateway/routes/"
       ]
     },
     "/n/$namespace/mirror": {
@@ -1112,7 +1130,7 @@ export const routeTree = rootRoute
     },
     "/n/$namespace/gateway/consumers": {
       "filePath": "n/$namespace/gateway/consumers.tsx",
-      "parent": "/n/$namespace"
+      "parent": "/n/$namespace/gateway"
     },
     "/n/$namespace/instances/$id": {
       "filePath": "n/$namespace/instances/$id.tsx",
@@ -1158,10 +1176,6 @@ export const routeTree = rootRoute
       "filePath": "n/$namespace/explorer/index.tsx",
       "parent": "/n/$namespace/explorer"
     },
-    "/n/$namespace/gateway/": {
-      "filePath": "n/$namespace/gateway/index.tsx",
-      "parent": "/n/$namespace"
-    },
     "/n/$namespace/instances/": {
       "filePath": "n/$namespace/instances/index.tsx",
       "parent": "/n/$namespace/instances"
@@ -1196,7 +1210,7 @@ export const routeTree = rootRoute
     },
     "/n/$namespace/gateway/routes/$filename": {
       "filePath": "n/$namespace/gateway/routes/$filename.tsx",
-      "parent": "/n/$namespace"
+      "parent": "/n/$namespace/gateway"
     },
     "/n/$namespace/mirror/logs/$sync": {
       "filePath": "n/$namespace/mirror/logs.$sync.tsx",
@@ -1204,7 +1218,7 @@ export const routeTree = rootRoute
     },
     "/n/$namespace/gateway/routes/": {
       "filePath": "n/$namespace/gateway/routes/index.tsx",
-      "parent": "/n/$namespace"
+      "parent": "/n/$namespace/gateway"
     },
     "/n/$namespace/explorer/workflow/edit/$": {
       "filePath": "n/$namespace/explorer/workflow/edit.$.tsx",

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -41,7 +41,7 @@ import { Route as NNamespaceEventsHistoryImport } from './routes/n/$namespace/ev
 import { Route as NNamespaceExplorerWorkflowRouteImport } from './routes/n/$namespace/explorer/workflow/route'
 import { Route as NNamespaceGatewayRoutesIndexImport } from './routes/n/$namespace/gateway/routes/index'
 import { Route as NNamespaceMirrorLogsSyncImport } from './routes/n/$namespace/mirror/logs.$sync'
-import { Route as NNamespaceGatewayRoutesFilenameImport } from './routes/n/$namespace/gateway/routes/$filename'
+import { Route as NNamespaceGatewayRoutesSplatImport } from './routes/n/$namespace/gateway/routes/$'
 import { Route as NNamespaceExplorerTreeSplatImport } from './routes/n/$namespace/explorer/tree.$'
 import { Route as NNamespaceExplorerServiceSplatImport } from './routes/n/$namespace/explorer/service.$'
 import { Route as NNamespaceExplorerEndpointSplatImport } from './routes/n/$namespace/explorer/endpoint.$'
@@ -246,10 +246,10 @@ const NNamespaceMirrorLogsSyncRoute = NNamespaceMirrorLogsSyncImport.update({
   getParentRoute: () => NNamespaceMirrorRouteRoute,
 } as any)
 
-const NNamespaceGatewayRoutesFilenameRoute =
-  NNamespaceGatewayRoutesFilenameImport.update({
-    id: '/routes/$filename',
-    path: '/routes/$filename',
+const NNamespaceGatewayRoutesSplatRoute =
+  NNamespaceGatewayRoutesSplatImport.update({
+    id: '/routes/$',
+    path: '/routes/$',
     getParentRoute: () => NNamespaceGatewayRouteRoute,
   } as any)
 
@@ -537,11 +537,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NNamespaceExplorerTreeSplatImport
       parentRoute: typeof NNamespaceExplorerRouteImport
     }
-    '/n/$namespace/gateway/routes/$filename': {
-      id: '/n/$namespace/gateway/routes/$filename'
-      path: '/routes/$filename'
-      fullPath: '/n/$namespace/gateway/routes/$filename'
-      preLoaderRoute: typeof NNamespaceGatewayRoutesFilenameImport
+    '/n/$namespace/gateway/routes/$': {
+      id: '/n/$namespace/gateway/routes/$'
+      path: '/routes/$'
+      fullPath: '/n/$namespace/gateway/routes/$'
+      preLoaderRoute: typeof NNamespaceGatewayRoutesSplatImport
       parentRoute: typeof NNamespaceGatewayRouteImport
     }
     '/n/$namespace/mirror/logs/$sync': {
@@ -657,14 +657,14 @@ const NNamespaceExplorerRouteRouteWithChildren =
 
 interface NNamespaceGatewayRouteRouteChildren {
   NNamespaceGatewayConsumersRoute: typeof NNamespaceGatewayConsumersRoute
-  NNamespaceGatewayRoutesFilenameRoute: typeof NNamespaceGatewayRoutesFilenameRoute
+  NNamespaceGatewayRoutesSplatRoute: typeof NNamespaceGatewayRoutesSplatRoute
   NNamespaceGatewayRoutesIndexRoute: typeof NNamespaceGatewayRoutesIndexRoute
 }
 
 const NNamespaceGatewayRouteRouteChildren: NNamespaceGatewayRouteRouteChildren =
   {
     NNamespaceGatewayConsumersRoute: NNamespaceGatewayConsumersRoute,
-    NNamespaceGatewayRoutesFilenameRoute: NNamespaceGatewayRoutesFilenameRoute,
+    NNamespaceGatewayRoutesSplatRoute: NNamespaceGatewayRoutesSplatRoute,
     NNamespaceGatewayRoutesIndexRoute: NNamespaceGatewayRoutesIndexRoute,
   }
 
@@ -797,7 +797,7 @@ export interface FileRoutesByFullPath {
   '/n/$namespace/explorer/endpoint/$': typeof NNamespaceExplorerEndpointSplatRoute
   '/n/$namespace/explorer/service/$': typeof NNamespaceExplorerServiceSplatRoute
   '/n/$namespace/explorer/tree/$': typeof NNamespaceExplorerTreeSplatRoute
-  '/n/$namespace/gateway/routes/$filename': typeof NNamespaceGatewayRoutesFilenameRoute
+  '/n/$namespace/gateway/routes/$': typeof NNamespaceGatewayRoutesSplatRoute
   '/n/$namespace/mirror/logs/$sync': typeof NNamespaceMirrorLogsSyncRoute
   '/n/$namespace/gateway/routes': typeof NNamespaceGatewayRoutesIndexRoute
   '/n/$namespace/explorer/workflow/edit/$': typeof NNamespaceExplorerWorkflowEditSplatRoute
@@ -832,7 +832,7 @@ export interface FileRoutesByTo {
   '/n/$namespace/explorer/endpoint/$': typeof NNamespaceExplorerEndpointSplatRoute
   '/n/$namespace/explorer/service/$': typeof NNamespaceExplorerServiceSplatRoute
   '/n/$namespace/explorer/tree/$': typeof NNamespaceExplorerTreeSplatRoute
-  '/n/$namespace/gateway/routes/$filename': typeof NNamespaceGatewayRoutesFilenameRoute
+  '/n/$namespace/gateway/routes/$': typeof NNamespaceGatewayRoutesSplatRoute
   '/n/$namespace/mirror/logs/$sync': typeof NNamespaceMirrorLogsSyncRoute
   '/n/$namespace/gateway/routes': typeof NNamespaceGatewayRoutesIndexRoute
   '/n/$namespace/explorer/workflow/edit/$': typeof NNamespaceExplorerWorkflowEditSplatRoute
@@ -875,7 +875,7 @@ export interface FileRoutesById {
   '/n/$namespace/explorer/endpoint/$': typeof NNamespaceExplorerEndpointSplatRoute
   '/n/$namespace/explorer/service/$': typeof NNamespaceExplorerServiceSplatRoute
   '/n/$namespace/explorer/tree/$': typeof NNamespaceExplorerTreeSplatRoute
-  '/n/$namespace/gateway/routes/$filename': typeof NNamespaceGatewayRoutesFilenameRoute
+  '/n/$namespace/gateway/routes/$': typeof NNamespaceGatewayRoutesSplatRoute
   '/n/$namespace/mirror/logs/$sync': typeof NNamespaceMirrorLogsSyncRoute
   '/n/$namespace/gateway/routes/': typeof NNamespaceGatewayRoutesIndexRoute
   '/n/$namespace/explorer/workflow/edit/$': typeof NNamespaceExplorerWorkflowEditSplatRoute
@@ -917,7 +917,7 @@ export interface FileRouteTypes {
     | '/n/$namespace/explorer/endpoint/$'
     | '/n/$namespace/explorer/service/$'
     | '/n/$namespace/explorer/tree/$'
-    | '/n/$namespace/gateway/routes/$filename'
+    | '/n/$namespace/gateway/routes/$'
     | '/n/$namespace/mirror/logs/$sync'
     | '/n/$namespace/gateway/routes'
     | '/n/$namespace/explorer/workflow/edit/$'
@@ -951,7 +951,7 @@ export interface FileRouteTypes {
     | '/n/$namespace/explorer/endpoint/$'
     | '/n/$namespace/explorer/service/$'
     | '/n/$namespace/explorer/tree/$'
-    | '/n/$namespace/gateway/routes/$filename'
+    | '/n/$namespace/gateway/routes/$'
     | '/n/$namespace/mirror/logs/$sync'
     | '/n/$namespace/gateway/routes'
     | '/n/$namespace/explorer/workflow/edit/$'
@@ -992,7 +992,7 @@ export interface FileRouteTypes {
     | '/n/$namespace/explorer/endpoint/$'
     | '/n/$namespace/explorer/service/$'
     | '/n/$namespace/explorer/tree/$'
-    | '/n/$namespace/gateway/routes/$filename'
+    | '/n/$namespace/gateway/routes/$'
     | '/n/$namespace/mirror/logs/$sync'
     | '/n/$namespace/gateway/routes/'
     | '/n/$namespace/explorer/workflow/edit/$'
@@ -1077,7 +1077,7 @@ export const routeTree = rootRoute
       "parent": "/n/$namespace",
       "children": [
         "/n/$namespace/gateway/consumers",
-        "/n/$namespace/gateway/routes/$filename",
+        "/n/$namespace/gateway/routes/$",
         "/n/$namespace/gateway/routes/"
       ]
     },
@@ -1208,8 +1208,8 @@ export const routeTree = rootRoute
       "filePath": "n/$namespace/explorer/tree.$.tsx",
       "parent": "/n/$namespace/explorer"
     },
-    "/n/$namespace/gateway/routes/$filename": {
-      "filePath": "n/$namespace/gateway/routes/$filename.tsx",
+    "/n/$namespace/gateway/routes/$": {
+      "filePath": "n/$namespace/gateway/routes/$.tsx",
       "parent": "/n/$namespace/gateway"
     },
     "/n/$namespace/mirror/logs/$sync": {

--- a/ui/src/routes/n/$namespace/gateway/index.tsx
+++ b/ui/src/routes/n/$namespace/gateway/index.tsx
@@ -1,7 +1,0 @@
-import { Outlet, createFileRoute } from "@tanstack/react-router";
-
-const Routes = () => <Outlet />;
-
-export const Route = createFileRoute("/n/$namespace/gateway/")({
-  component: Routes,
-});

--- a/ui/src/routes/n/$namespace/gateway/route.tsx
+++ b/ui/src/routes/n/$namespace/gateway/route.tsx
@@ -1,0 +1,6 @@
+import GatewayPage from "~/pages/namespace/Gateway";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/n/$namespace/gateway")({
+  component: GatewayPage,
+});

--- a/ui/src/routes/n/$namespace/gateway/routes/$.tsx
+++ b/ui/src/routes/n/$namespace/gateway/routes/$.tsx
@@ -1,6 +1,6 @@
 import RoutesDetailPage from "~/pages/namespace/Gateway/Routes/Detail";
 import { createFileRoute } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/n/$namespace/gateway/routes/$filename")({
+export const Route = createFileRoute("/n/$namespace/gateway/routes/$")({
   component: RoutesDetailPage,
 });


### PR DESCRIPTION
## Description

In the tanstack router migration, I missed the tabs that allow navigating between consumers and routes under the gateway route. This fixes that and also adds e2e tests for navigating to the consumers page and back.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
