### PR TITLE
[DIR-1948] Fix sync param for displaying sync logs

### DIFF
--- a/ui/e2e/mirror.spec.ts
+++ b/ui/e2e/mirror.spec.ts
@@ -16,7 +16,9 @@ test.afterAll(async () => {
   namespace = "";
 });
 
-test("it is possible to create and sync a mirror", async ({ page }) => {
+test("it is possible to create and sync a mirror, view logs", async ({
+  page,
+}) => {
   /* prepare test data */
   const mirrorName = createNamespaceName();
 
@@ -59,6 +61,11 @@ test("it is possible to create and sync a mirror", async ({ page }) => {
     page.getByTestId("sync-row").getByTestId("createdAt-relative"),
     "It renders the relative time"
   ).toContainText("seconds ago");
+
+  /* visit detail page and ensure logs are rendered */
+  await page.getByTestId("sync-row").click();
+  await expect(page.getByText("msg: File 'broken.yaml' loaded.")).toBeVisible();
+  await page.getByRole("main").getByRole("link", { name: "Mirror" }).click();
 
   /* update mirror to be invalid */
   await page.getByRole("button", { name: "Edit mirror" }).click();

--- a/ui/src/pages/namespace/Mirror/Detail/Sync/SyncDetail.tsx
+++ b/ui/src/pages/namespace/Mirror/Detail/Sync/SyncDetail.tsx
@@ -1,11 +1,18 @@
 import Header from "./Header";
 import Logs from "./Logs";
+import { useParams } from "@tanstack/react-router";
 
-const SyncDetail = ({ syncId }: { syncId: string }) => (
-  <div className="flex grow flex-col">
-    <Header syncId={syncId} />
-    <Logs syncId={syncId} />
-  </div>
-);
+const SyncDetail = () => {
+  const { sync: syncId } = useParams({
+    from: "/n/$namespace/mirror/logs/$sync",
+  });
+
+  return (
+    <div className="flex grow flex-col">
+      <Header syncId={syncId} />
+      <Logs syncId={syncId} />
+    </div>
+  );
+};
 
 export default SyncDetail;

--- a/ui/src/pages/namespace/Mirror/Detail/Sync/index.tsx
+++ b/ui/src/pages/namespace/Mirror/Detail/Sync/index.tsx
@@ -23,7 +23,7 @@ const Logs = () => {
   return (
     <>
       <LogStreamingSubscriber activity={sync} />
-      <SyncDetail syncId={sync} />
+      <SyncDetail />
     </>
   );
 };


### PR DESCRIPTION
## Description

This fixes passing the sync id parameter to the components that need it to show the logs, and adds a test to ensure the logs can be viewed.

This was an oversight in the migration to tanstack router.

Main is currently broken, so this does not pass all checks either but I think we should still go ahead and merge as this doesn't add new issues.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
