### PR TITLE
Makes garbage collection configurable.

### DIFF
--- a/pkg/core/app.go
+++ b/pkg/core/app.go
@@ -61,8 +61,8 @@ type Config struct {
 	OidcClientID         string `env:"DIREKTIV_OIDC_CLIENT_ID"`
 	VictoriaLogsEndpoint string `env:"DIREKTIV_VICTORIA_LOGS"`
 
-	LogHistoryHours      int `env:"DIREKTIV_LOG_HISTORY_HOURS" envDefault:"48"`
-	MirrorHistoryHours   int `env:"DIREKTIV_MIRROR_HISTORY_HOURS" envDefault:"192"`
+	LogHistoryHours      int `env:"DIREKTIV_LOG_HISTORY_HOURS"      envDefault:"48"`
+	MirrorHistoryHours   int `env:"DIREKTIV_MIRROR_HISTORY_HOURS"   envDefault:"192"`
 	InstanceHistoryHours int `env:"DIREKTIV_INSTANCE_HISTORY_HOURS" envDefault:"24"`
 }
 

--- a/pkg/core/app.go
+++ b/pkg/core/app.go
@@ -60,6 +60,10 @@ type Config struct {
 	OidcIssuerUrl        string `env:"DIREKTIV_OIDC_ISSUER_URL"`
 	OidcClientID         string `env:"DIREKTIV_OIDC_CLIENT_ID"`
 	VictoriaLogsEndpoint string `env:"DIREKTIV_VICTORIA_LOGS"`
+
+	LogHistoryHours      int `env:"DIREKTIV_LOG_HISTORY_HOURS" envDefault:"48"`
+	MirrorHistoryHours   int `env:"DIREKTIV_MIRROR_HISTORY_HOURS" envDefault:"192"`
+	InstanceHistoryHours int `env:"DIREKTIV_INSTANCE_HISTORY_HOURS" envDefault:"24"`
 }
 
 func (conf *Config) GetFunctionsTimeout() time.Duration {

--- a/pkg/flow/grpc-flow.go
+++ b/pkg/flow/grpc-flow.go
@@ -28,7 +28,7 @@ func initFlowServer(ctx context.Context, srv *server) (*flow, error) {
 
 		for {
 			<-time.After(time.Hour)
-			t := time.Now().UTC().Add(time.Hour * -24)
+			t := time.Now().UTC().Add(time.Hour * -1 * time.Duration(srv.config.InstanceHistoryHours))
 
 			tx, err := srv.flow.beginSQLTx(ctx)
 			if err != nil {
@@ -60,7 +60,8 @@ func initFlowServer(ctx context.Context, srv *server) (*flow, error) {
 		<-time.After(3 * time.Minute)
 		for {
 			<-time.After(time.Hour)
-			t := time.Now().UTC().Add(time.Hour * -48) // TODO make this a config option.
+
+			t := time.Now().UTC().Add(time.Hour * -1 * time.Duration(srv.config.LogHistoryHours))
 			slog.Debug("deleting all logs since", "since", t)
 			err = srv.flow.runSQLTx(ctx, func(tx *database.DB) error {
 				return tx.DataStore().NewLogs().DeleteOldLogs(ctx, t)

--- a/pkg/flow/server.go
+++ b/pkg/flow/server.go
@@ -194,6 +194,7 @@ func InitLegacyServer(circuit *core.Circuit, config *core.Config, bus *pubsub2.B
 			wfconf:   cc,
 		},
 	)
+	srv.MirrorManager.SetMirrorHistoryHours(config.MirrorHistoryHours)
 
 	srv.registerFunctions()
 

--- a/pkg/instancestore/instancestoresql/sql.go
+++ b/pkg/instancestore/instancestoresql/sql.go
@@ -232,6 +232,18 @@ func (s *sqlInstanceStore) DeleteOldInstances(ctx context.Context, before time.T
 		return res.Error
 	}
 
+	// NOTE: we perform a second delete on anything that exceeds the 'before' time by at least 48 hours to cleanup bugged hanging instances
+
+	query = fmt.Sprintf(`DELETE FROM %s WHERE %s < ?`, table, fieldEndedAt)
+
+	res = s.db.WithContext(ctx).Exec(
+		query,
+		before.Add(time.Hour*-48).UTC(),
+	)
+	if res.Error != nil {
+		return res.Error
+	}
+
 	return nil
 }
 

--- a/pkg/mirror/manager.go
+++ b/pkg/mirror/manager.go
@@ -17,18 +17,24 @@ import (
 // TODO: validate credentials helper
 
 type Manager struct {
-	callbacks Callbacks
-	local     sync.Map
+	callbacks          Callbacks
+	local              sync.Map
+	mirrorHistoryHours int
 }
 
 func NewManager(callbacks Callbacks) *Manager {
 	mgr := &Manager{
-		callbacks: callbacks,
+		callbacks:          callbacks,
+		mirrorHistoryHours: 48,
 	}
 
 	go mgr.gc()
 
 	return mgr
+}
+
+func (d *Manager) SetMirrorHistoryHours(x int) {
+	d.mirrorHistoryHours = x
 }
 
 // Garbage collector.
@@ -38,7 +44,7 @@ func (d *Manager) gc() {
 	jitter := 1000
 	interval := time.Second * 10
 	maxRunTime := 5 * time.Minute
-	maxRecordTime := time.Hour * 48
+	maxRecordTime := time.Hour * time.Duration(d.mirrorHistoryHours)
 
 	// TODO: gracefully close the loop
 	for {


### PR DESCRIPTION
## Description

This PR addresses two things:

1. It lets the backend auto-cleanup bugged instances. I don't even know if we still create bugged instances, but I've had to support some old versions of Direktiv where we manually had to interact with the database to remove broken instances that were weeks old. 

2. It lets the user configure their garbage collection to be more aggressive. I have seen Direktiv used in environments where it ingests dozens of gigabytes of data into workflows every day. And they were trying to run the entire cluster on a 100GiB disk. With these changes, users can make tweak the garbage collector to be more aggressive if they want. They can purge their old instances after 3 hours if they want. It's up to them. 

This is tangentially related to DIR-1871.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
