### PR TITLE
[DIR-2016] Fix fetching logs for routes (enforce leading slash in route path)

### DIFF
--- a/ui/e2e/explorer/route/index.spec.ts
+++ b/ui/e2e/explorer/route/index.spec.ts
@@ -20,7 +20,7 @@ test("it is possible to create a basic route file", async ({ page }) => {
   const filename = "myroute.yaml";
 
   const expectedYaml = createRouteYaml({
-    path: "path",
+    path: "/path",
     timeout: 3000,
     methods: {
       get: {},

--- a/ui/e2e/instances/details/logs.spec.ts
+++ b/ui/e2e/instances/details/logs.spec.ts
@@ -83,7 +83,9 @@ test("It displays a log message from the workflow yaml, one initial and one fina
   page.reload();
 
   await expect(
-    scrollContainer.locator("pre").locator("span").nth(5),
+    scrollContainer
+      .locator("pre")
+      .locator("span", { hasText: "msg: hello-world" }),
     "It displays the log message from the log field in the workflow yaml"
   ).toContainText("msg: hello-world");
 

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/index.tsx
@@ -17,6 +17,7 @@ import { OpenAPIDocsForm } from "./openAPIDocs";
 import { OutboundPluginForm } from "./plugins/Outbound";
 import { Switch } from "~/design/Switch";
 import { TargetPluginForm } from "./plugins/Target";
+import { forceLeadingSlash } from "~/api/files/utils";
 import { routeMethods } from "~/api/gateway/schema";
 import { treatAsNumberOrUndefined } from "../../../utils";
 import { useTranslation } from "react-i18next";
@@ -57,7 +58,16 @@ export const Form: FC<FormProps> = ({ defaultConfig, children, onSave }) => {
             htmlFor="path"
             className="grow"
           >
-            <Input {...register("x-direktiv-config.path")} id="path" />
+            <Input
+              {...register("x-direktiv-config.path")}
+              id="path"
+              onChange={(event) =>
+                form.setValue(
+                  "x-direktiv-config.path",
+                  forceLeadingSlash(event.target.value)
+                )
+              }
+            />
           </Fieldset>
           <Fieldset
             label={t("pages.explorer.endpoint.editor.form.timeout")}

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/index.ts
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/index.ts
@@ -22,11 +22,6 @@ const processPath = (value: unknown) => {
       { message: "Path must be a string", path: ["path"], code: "custom" },
     ]);
   }
-  if (value.length === 0) {
-    throw new z.ZodError([
-      { message: "Path cannot be empty", path: ["path"], code: "custom" },
-    ]);
-  }
 
   return forceLeadingSlash(value);
 };

--- a/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/index.ts
+++ b/ui/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/index.ts
@@ -3,6 +3,7 @@ import { InboundPluginFormSchema } from "./plugins/inbound/schema";
 import { MethodsSchema } from "~/api/gateway/schema";
 import { OutboundPluginFormSchema } from "./plugins/outbound/schema";
 import { TargetPluginFormSchema } from "./plugins/target/schema";
+import { forceLeadingSlash } from "~/api/files/utils";
 import { z } from "zod";
 
 export const EndpointsPluginsSchema = z.object({
@@ -14,9 +15,25 @@ export const EndpointsPluginsSchema = z.object({
 
 export type EndpointsPluginsSchemaType = z.infer<typeof EndpointsPluginsSchema>;
 
+const processPath = (value: unknown) => {
+  // adds leading slash to path when loading file that doesn't have it yet
+  if (typeof value !== "string") {
+    throw new z.ZodError([
+      { message: "Path must be a string", path: ["path"], code: "custom" },
+    ]);
+  }
+  if (value.length === 0) {
+    throw new z.ZodError([
+      { message: "Path cannot be empty", path: ["path"], code: "custom" },
+    ]);
+  }
+
+  return forceLeadingSlash(value);
+};
+
 export const XDirektivConfigSchema = z.object({
   allow_anonymous: z.boolean().optional(),
-  path: z.string().nonempty().optional(),
+  path: z.preprocess((value) => processPath(value), z.string().optional()),
   timeout: z.number().int().positive().optional(),
   plugins: EndpointsPluginsSchema.optional(),
 });


### PR DESCRIPTION
## Description

Please describe the aim of the pull request and the changes made in the commits

Route logs did not work previously when the "path" in the route definition lacked a leading slash:
* `foo` or `foo/bar` -> no logs found
* `/foo` or `/foo/bar` -> logs found

The old API did not require a leading slash, the new API does.

To ensure our route definition files will always have paths with leading slashes, 2 changes have been implemented:
* a `z.preprocess()` that will update files loaded that do not yet have a leading slash for path,
* a setValue() in the Input component for the path that makes sure a `/` is always added when editing it (without this, it would get added through the schema before saving, but react would not be aware of the updated value and not update the DOM to reflect it).

These two steps have some overlap, but are probably needed to deal with all edge cases.

I have also created DIR-2017 to make sure this issue is caught in backend validation (for files added via mirrors).

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
