### PR TITLE
[DIR-1671] - update playwright

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -68,7 +68,6 @@
     "msw": "^2.6.6",
     "npm-run-all": "^4.1.5",
     "oidc-client-ts": "^2.4.0",
-    "playwright": "^1.51.1",
     "postcss": "^8.4.21",
     "postcss-loader": "^7.0.2",
     "postcss-nesting": "^13.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -68,6 +68,7 @@
     "msw": "^2.6.6",
     "npm-run-all": "^4.1.5",
     "oidc-client-ts": "^2.4.0",
+    "playwright": "^1.51.1",
     "postcss": "^8.4.21",
     "postcss-loader": "^7.0.2",
     "postcss-nesting": "^13.0.1",
@@ -135,7 +136,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.2",
     "@faker-js/faker": "^9.2.0",
-    "@playwright/test": "^1.36.2",
+    "@playwright/test": "^1.51.1",
     "@storybook/addon-actions": "^8.4.6",
     "@storybook/addon-essentials": "^8.4.6",
     "@storybook/addon-interactions": "^8.4.6",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -47,14 +47,6 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
 
     /* Test against mobile viewports. */
     // {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       oidc-client-ts:
         specifier: ^2.4.0
         version: 2.4.0
+      playwright:
+        specifier: ^1.51.1
+        version: 1.51.1
       postcss:
         specifier: ^8.4.21
         version: 8.4.21
@@ -281,8 +284,8 @@ importers:
         specifier: ^9.2.0
         version: 9.2.0
       '@playwright/test':
-        specifier: ^1.36.2
-        version: 1.36.2
+        specifier: ^1.51.1
+        version: 1.51.1
       '@storybook/addon-actions':
         specifier: ^8.4.6
         version: 8.4.6(storybook@8.4.6(prettier@3.4.1))
@@ -369,7 +372,7 @@ importers:
         version: 4.3.2(typescript@5.7.2)(vite@5.4.11(@types/node@18.7.18)(terser@5.37.0))
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6(jsdom@21.1.0)(terser@5.37.0)
+        version: 0.34.6(jsdom@21.1.0)(playwright@1.51.1)(terser@5.37.0)
 
 packages:
 
@@ -1417,10 +1420,9 @@ packages:
     resolution: {integrity: sha512-2OCURAmRtdlL8iUDTypMrrxfwe8frXTeXaxGsVOaYtc/wrUyk8Z/0OBetM7cdlsy7ZFWlMX72VogKeh+A4Xcjw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.36.2':
-    resolution: {integrity: sha512-2rVZeyPRjxfPH6J0oGJqE8YxiM1IBRyM8hyrXYK7eSiAqmbNhxwcLa7dZ7fy9Kj26V7FYia5fh9XJRq4Dqme+g==}
-    engines: {node: '>=16'}
-    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
+  '@playwright/test@1.51.1':
+    resolution: {integrity: sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==}
+    engines: {node: '>=18'}
     hasBin: true
 
   '@radix-ui/colors@0.1.8':
@@ -5300,9 +5302,14 @@ packages:
   pkg-types@1.2.1:
     resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
 
-  playwright-core@1.36.2:
-    resolution: {integrity: sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==}
-    engines: {node: '>=16'}
+  playwright-core@1.51.1:
+    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.51.1:
+    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pluralize@7.0.0:
@@ -7796,12 +7803,9 @@ snapshots:
       picocolors: 1.1.1
       tslib: 2.5.0
 
-  '@playwright/test@1.36.2':
+  '@playwright/test@1.51.1':
     dependencies:
-      '@types/node': 18.7.18
-      playwright-core: 1.36.2
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright: 1.51.1
 
   '@radix-ui/colors@0.1.8': {}
 
@@ -12005,7 +12009,7 @@ snapshots:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   jest-leak-detector@29.4.0:
     dependencies:
@@ -12903,7 +12907,13 @@ snapshots:
       mlly: 1.7.3
       pathe: 1.1.2
 
-  playwright-core@1.36.2: {}
+  playwright-core@1.51.1: {}
+
+  playwright@1.51.1:
+    dependencies:
+      playwright-core: 1.51.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@7.0.0: {}
 
@@ -14146,7 +14156,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.37.0
 
-  vitest@0.34.6(jsdom@21.1.0)(terser@5.37.0):
+  vitest@0.34.6(jsdom@21.1.0)(playwright@1.51.1)(terser@5.37.0):
     dependencies:
       '@types/chai': 4.3.20
       '@types/chai-subset': 1.3.3
@@ -14174,6 +14184,7 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       jsdom: 21.1.0
+      playwright: 1.51.1
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Description

Upgraded @playwright/test to v1.50.1 to meet the minimum requirement for the VSCode plugin.

Note: Deprecated methods like .type() were not replaced with .fill() in this PR. While not required for the upgrade, updating them will involve additional work as some tests currently fail with .fill().

## Checklist

- [ ] Documentation updated if required
- [ ] Test coverage is appropriate
      
## Checklist Internal

- [ ] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [ ] Has the PR been labeled
