### PR TITLE
[DIR-2033] Add methods to update blocks and pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,8 +251,10 @@ jobs:
       - name: Setup k3s
         run: curl -sfL https://get.k3s.io | sh -s - --disable traefik --write-kubeconfig-mode=644
 
-      - name: Install Helm
-        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: Install Helm v3.17.3
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
 
       - name: Create namespace for the DB
         run: kubectl create ns postgres
@@ -323,6 +325,7 @@ jobs:
 
           echo "API failed to be healthy";
           kubectl get pods;
+          kubectl describe pod -l app=direktiv-flow;
           kubectl logs deployments/direktiv-flow;
           exit 1;
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "github.com/ChannelMeter/iso8601duration"
+	_ "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/direktiv/direktiv/cmd/cli"
 	_ "github.com/direktiv/direktiv/pkg/gateway/plugins/auth"
 	_ "github.com/direktiv/direktiv/pkg/gateway/plugins/inbound"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/bbuck/go-lexer v1.0.0
 	github.com/caarlos0/env/v10 v10.0.0
 	github.com/cloudevents/sdk-go/v2 v2.16.0
+	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c
 	github.com/gabriel-vasile/mimetype v1.4.9
@@ -89,6 +90,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
+github.com/coreos/go-oidc/v3 v3.14.1 h1:9ePWwfdwC4QKRlCXsJGou56adA/owXczOzwKdOumLqk=
+github.com/coreos/go-oidc/v3 v3.14.1/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -100,6 +102,8 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMj
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.16.0 h1:k3kuOEpkc0DeY7xlL6NaaNg39xdgQbtH5mwCafHO9AQ=
 github.com/go-git/go-git/v5 v5.16.0/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=

--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -1660,6 +1660,9 @@
       }
     },
     "blockEditor": {
+      "generic": {
+        "saveButton": "Save"
+      },
       "Text": {
         "modalTitle": "Edit Text Block @{{path}}"
       }

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Text.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Text.tsx
@@ -11,7 +11,11 @@ type TextBlockEditFormProps = Omit<BlockEditFormProps, "block"> & {
   block: TextType;
 };
 
-export const Text = ({ block: propBlock, path }: TextBlockEditFormProps) => {
+export const Text = ({
+  block: propBlock,
+  path,
+  onSave,
+}: TextBlockEditFormProps) => {
   const { t } = useTranslation();
 
   const [block, setBlock] = useState<TextType>(structuredClone(propBlock));
@@ -37,7 +41,7 @@ export const Text = ({ block: propBlock, path }: TextBlockEditFormProps) => {
       <div>Debug Info {JSON.stringify(block)}</div>
 
       <DialogFooter>
-        <Button variant="primary" onClick={() => "TBD"}>
+        <Button variant="primary" onClick={() => onSave(block)}>
           {t("direktivPage.blockEditor.generic.saveButton")}
         </Button>
       </DialogFooter>

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Text.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Text.tsx
@@ -1,21 +1,47 @@
-import { DialogHeader, DialogTitle } from "~/design/Dialog";
+import { DialogFooter, DialogHeader, DialogTitle } from "~/design/Dialog";
 
 import { BlockEditFormProps } from ".";
+import Button from "~/design/Button";
+import { TextType } from "../schema/blocks/text";
+import { Textarea } from "~/design/TextArea";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-export const Text = ({ block, path }: BlockEditFormProps) => {
+type TextBlockEditFormProps = Omit<BlockEditFormProps, "block"> & {
+  block: TextType;
+};
+
+export const Text = ({ block: propBlock, path }: TextBlockEditFormProps) => {
   const { t } = useTranslation();
+
+  const [block, setBlock] = useState<TextType>(structuredClone(propBlock));
 
   return (
     <>
       <DialogHeader>
         <DialogTitle>
+          {" "}
           {t("direktivPage.blockEditor.Text.modalTitle", {
             path: path.join("."),
           })}
         </DialogTitle>
       </DialogHeader>
-      <div>{JSON.stringify(block)}</div>
+      <Textarea
+        value={block.content}
+        onChange={(event) =>
+          setBlock({
+            ...block,
+            content: event.target.value,
+          })
+        }
+      />
+      <div>Debug Info {JSON.stringify(block)}</div>
+
+      <DialogFooter>
+        <Button variant="primary" onClick={() => "TBD"}>
+          {t("direktivPage.blockEditor.generic.saveButton")}
+        </Button>
+      </DialogFooter>
     </>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Text.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Text.tsx
@@ -20,7 +20,6 @@ export const Text = ({ block: propBlock, path }: TextBlockEditFormProps) => {
     <>
       <DialogHeader>
         <DialogTitle>
-          {" "}
           {t("direktivPage.blockEditor.Text.modalTitle", {
             path: path.join("."),
           })}

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/index.tsx
@@ -6,6 +6,7 @@ import {
 import { AllBlocksType } from "../schema/blocks";
 import { BlockPathType } from "../PageCompiler/Block";
 import { Text } from "../BlockEditor/Text";
+import { isPage } from "../PageCompiler/context/utils";
 
 export type BlockFormProps = { path: BlockPathType; close: () => void };
 
@@ -23,18 +24,18 @@ export const BlockForm = ({ path, close }: BlockFormProps) => {
     throw Error("Can not load list into block editor");
   }
 
+  if (isPage(block)) {
+    throw Error("Unexpected page object when parsing block");
+  }
+
+  const handleUpdate = (newBlock: AllBlocksType) => {
+    updateBlock(path, newBlock);
+    close();
+  };
+
   switch (block.type) {
     case "text": {
-      return (
-        <Text
-          block={block}
-          path={path}
-          onSave={(newBlock) => {
-            updateBlock(path, newBlock);
-            close();
-          }}
-        />
-      );
+      return <Text block={block} path={path} onSave={handleUpdate} />;
     }
   }
 

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/index.tsx
@@ -1,14 +1,23 @@
+import {
+  useBlock,
+  useUpdateBlock,
+} from "../PageCompiler/context/pageCompilerContext";
+
 import { AllBlocksType } from "../schema/blocks";
 import { BlockPathType } from "../PageCompiler/Block";
 import { Text } from "../BlockEditor/Text";
-import { useBlock } from "../PageCompiler/context/pageCompilerContext";
 
 export type BlockFormProps = { path: BlockPathType };
 
-export type BlockEditFormProps = { block: AllBlocksType; path: BlockPathType };
+export type BlockEditFormProps = {
+  block: AllBlocksType;
+  path: BlockPathType;
+  onSave: (newBlock: AllBlocksType) => void;
+};
 
 export const BlockForm = ({ path }: { path: BlockPathType }) => {
   const block = useBlock(path);
+  const { updateBlock } = useUpdateBlock();
 
   if (Array.isArray(block)) {
     throw Error("Can not load list into block editor");
@@ -16,7 +25,15 @@ export const BlockForm = ({ path }: { path: BlockPathType }) => {
 
   switch (block.type) {
     case "text": {
-      return <Text block={block} path={path} />;
+      return (
+        <Text
+          block={block}
+          path={path}
+          onSave={(newBlock) => {
+            updateBlock(path, newBlock);
+          }}
+        />
+      );
     }
   }
 

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/index.tsx
@@ -7,7 +7,7 @@ import { AllBlocksType } from "../schema/blocks";
 import { BlockPathType } from "../PageCompiler/Block";
 import { Text } from "../BlockEditor/Text";
 
-export type BlockFormProps = { path: BlockPathType };
+export type BlockFormProps = { path: BlockPathType; close: () => void };
 
 export type BlockEditFormProps = {
   block: AllBlocksType;
@@ -15,7 +15,7 @@ export type BlockEditFormProps = {
   onSave: (newBlock: AllBlocksType) => void;
 };
 
-export const BlockForm = ({ path }: { path: BlockPathType }) => {
+export const BlockForm = ({ path, close }: BlockFormProps) => {
   const block = useBlock(path);
   const { updateBlock } = useUpdateBlock();
 
@@ -31,6 +31,7 @@ export const BlockForm = ({ path }: { path: BlockPathType }) => {
           path={path}
           onSave={(newBlock) => {
             updateBlock(path, newBlock);
+            close();
           }}
         />
       );

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/index.tsx
@@ -1,13 +1,13 @@
 import { AllBlocksType } from "../schema/blocks";
-import { BlockPath } from "../PageCompiler/Block";
+import { BlockPathType } from "../PageCompiler/Block";
 import { Text } from "../BlockEditor/Text";
 import { useBlock } from "../PageCompiler/context/pageCompilerContext";
 
-export type BlockFormProps = { path: BlockPath };
+export type BlockFormProps = { path: BlockPathType };
 
-export type BlockEditFormProps = { block: AllBlocksType; path: BlockPath };
+export type BlockEditFormProps = { block: AllBlocksType; path: BlockPathType };
 
-export const BlockForm = ({ path }: { path: BlockPath }) => {
+export const BlockForm = ({ path }: { path: BlockPathType }) => {
   const block = useBlock(path);
 
   if (Array.isArray(block)) {

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/utils.ts
@@ -1,4 +1,8 @@
 import { AllBlocksType } from "../schema/blocks";
+import { DirektivPagesType } from "../schema";
 
 export const cloneBlocks = (blocks: AllBlocksType[]): AllBlocksType[] =>
   structuredClone(blocks);
+
+export const clonePage = (page: DirektivPagesType): DirektivPagesType =>
+  structuredClone(page);

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Card.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Card.tsx
@@ -1,4 +1,4 @@
-import { Block, BlockPath } from ".";
+import { Block, BlockPathType } from ".";
 
 import { BlockList } from "./utils/BlockList";
 import { Card as CardDesignComponent } from "~/design/Card";
@@ -6,7 +6,7 @@ import { CardType } from "../../schema/blocks/card";
 
 type CardProps = {
   blockProps: CardType;
-  blockPath: BlockPath;
+  blockPath: BlockPathType;
 };
 
 export const Card = ({ blockProps, blockPath }: CardProps) => (

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Columns.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Columns.tsx
@@ -12,7 +12,7 @@ export const Columns = ({ blockProps, blockPath }: ColumnsProps) => (
   <BlockList horizontal>
     {blockProps.blocks.map((column, columnIndex) => (
       <BlockList key={columnIndex}>
-        {column.map((block, blockIndex) => (
+        {column.blocks.map((block, blockIndex) => (
           <Block
             key={blockIndex}
             block={block}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Columns.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Columns.tsx
@@ -1,11 +1,11 @@
-import { Block, BlockPath } from ".";
+import { Block, BlockPathType } from ".";
 
 import { BlockList } from "./utils/BlockList";
 import { ColumnsType } from "../../schema/blocks/columns";
 
 type ColumnsProps = {
   blockProps: ColumnsType;
-  blockPath: BlockPath;
+  blockPath: BlockPathType;
 };
 
 export const Columns = ({ blockProps, blockPath }: ColumnsProps) => (

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Dialog.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Dialog.tsx
@@ -1,4 +1,4 @@
-import { Block, BlockPath } from ".";
+import { Block, BlockPathType } from ".";
 import {
   DialogClose,
   DialogContent,
@@ -14,7 +14,7 @@ import { DialogType } from "../../schema/blocks/dialog";
 
 type DialogProps = {
   blockProps: DialogType;
-  blockPath: BlockPath;
+  blockPath: BlockPathType;
 };
 export const Dialog = ({ blockProps, blockPath }: DialogProps) => {
   const { blocks, trigger } = blockProps;

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Loop.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Loop.tsx
@@ -1,4 +1,4 @@
-import { Block, BlockPath } from ".";
+import { Block, BlockPathType } from ".";
 import {
   VariableContextProvider,
   useVariables,
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 
 type LoopProps = {
   blockProps: LoopType;
-  blockPath: BlockPath;
+  blockPath: BlockPathType;
 };
 
 export const Loop = ({ blockProps, blockPath }: LoopProps) => {

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/QueryProvider.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/QueryProvider.tsx
@@ -1,4 +1,4 @@
-import { Block, BlockPath } from ".";
+import { Block, BlockPathType } from ".";
 import {
   State,
   VariableContextProvider,
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 
 type QueryProviderProps = {
   blockProps: QueryProviderType;
-  blockPath: BlockPath;
+  blockPath: BlockPathType;
 };
 
 export const QueryProvider = ({

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/index.tsx
@@ -13,10 +13,10 @@ import { useTranslation } from "react-i18next";
 
 type BlockProps = {
   block: AllBlocksType;
-  blockPath: BlockPath;
+  blockPath: BlockPathType;
 };
 
-export type BlockPath = number[];
+export type BlockPathType = number[];
 
 export const Block = ({ block, blockPath }: BlockProps) => {
   const { t } = useTranslation();

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -87,10 +87,10 @@ export const BlockWrapper = ({
         if (isPage(acc)) {
           return acc.blocks[index] as AllBlocksType;
         }
-        if (!isParentBlock(acc)) {
-          throw new Error("Unexpected non-parent block while parsing path");
+        if (isParentBlock(acc)) {
+          return acc.blocks[index] as AllBlocksType;
         }
-        return acc.blocks[index] as AllBlocksType;
+        throw new Error("Unexpected non-parent block while parsing path");
       }, block);
 
   const list = findParentBlock(page, [1, 0]);

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -7,11 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  useMode,
-  usePage,
-  useSetPage,
-} from "../../context/pageCompilerContext";
+import { useAddBlock, useMode } from "../../context/pageCompilerContext";
 
 import { AllBlocksType } from "../../../schema/blocks";
 import Badge from "~/design/Badge";
@@ -21,7 +17,6 @@ import Button from "~/design/Button";
 import { ErrorBoundary } from "react-error-boundary";
 import { Loading } from "./Loading";
 import { ParsingError } from "./ParsingError";
-import { addBlock } from "../../context/utils";
 import { twMergeClsx } from "~/util/helpers";
 import { useTranslation } from "react-i18next";
 
@@ -37,11 +32,10 @@ export const BlockWrapper = ({
 }: BlockWrapperProps) => {
   const { t } = useTranslation();
   const mode = useMode();
-  const page = usePage();
-  const setPage = useSetPage();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const { addBlock } = useAddBlock();
 
   useEffect(() => {
     if (mode !== "inspect") {
@@ -68,14 +62,12 @@ export const BlockWrapper = ({
       <Button
         variant="outline"
         className="w-fit"
-        onClick={() => {
-          const newPage = addBlock(
-            page,
-            { type: "text", content: "New block!" },
-            blockPath
-          );
-          setPage(newPage);
-        }}
+        onClick={() =>
+          addBlock(blockPath, {
+            type: "text",
+            content: "New block!",
+          })
+        }
       >
         <Plus className="size-4 mr-2" />
         Add Block

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -95,8 +95,27 @@ export const BlockWrapper = ({
     content: "This is the updated text",
   });
 
-  const addBlockToPage = (block: AllBlocksType, path: BlockPathType) => {
-    `TBD ${block} ${path}`;
+  const addBlock = (
+    page: DirektivPagesType,
+    block: AllBlocksType,
+    path: BlockPathType
+  ) => {
+    const newPage = clonePage(page);
+    const parent = findBlock(newPage, path.slice(0, -1));
+    const index = path[path.length] as number;
+
+    if (isPage(parent) || isParentBlock(parent)) {
+      const newList: AllBlocksType[] = [
+        ...parent.blocks.slice(0, index - 1),
+        block,
+        ...parent.blocks.slice(index),
+      ];
+
+      parent.blocks = newList;
+      return newPage;
+    }
+
+    throw new Error("Could not update block");
   };
 
   useEffect(() => {
@@ -124,13 +143,17 @@ export const BlockWrapper = ({
       <Button
         variant="outline"
         className="w-fit"
-        onClick={
-          () => setPage(updatedPage)
-          // addBlockToPage({ type: "text", content: "Added text" }, [0])
-        }
+        onClick={() => {
+          const newPage = addBlock(
+            page,
+            { type: "text", content: "New block!" },
+            blockPath
+          );
+          setPage(newPage);
+        }}
       >
         <Plus className="size-4 mr-2" />
-        Test
+        Add Block
       </Button>
       <div
         ref={containerRef}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -1,6 +1,4 @@
-import { AllBlocksType, ParentBlockUnion } from "../../../schema/blocks";
 import { Dialog, DialogContent, DialogTrigger } from "~/design/Dialog";
-import { DirektivPagesSchema, DirektivPagesType } from "../../../schema";
 import { Edit, Plus } from "lucide-react";
 import {
   PropsWithChildren,
@@ -15,6 +13,7 @@ import {
   useSetPage,
 } from "../../context/pageCompilerContext";
 
+import { AllBlocksType } from "../../../schema/blocks";
 import Badge from "~/design/Badge";
 import { BlockForm } from "../../../BlockEditor";
 import { BlockPathType } from "..";
@@ -22,10 +21,9 @@ import Button from "~/design/Button";
 import { ErrorBoundary } from "react-error-boundary";
 import { Loading } from "./Loading";
 import { ParsingError } from "./ParsingError";
-import { clonePage } from "../../../BlockEditor/utils";
+import { addBlock } from "../../context/utils";
 import { twMergeClsx } from "~/util/helpers";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 type BlockWrapperProps = PropsWithChildren<{
   blockPath: BlockPathType;
@@ -44,74 +42,6 @@ export const BlockWrapper = ({
 
   const [isHovered, setIsHovered] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  const isParentBlock = (
-    block: AllBlocksType
-  ): block is z.infer<typeof ParentBlockUnion> =>
-    ParentBlockUnion.safeParse(block).success;
-
-  const isPage = (
-    page: AllBlocksType | DirektivPagesType
-  ): page is z.infer<typeof DirektivPagesSchema> =>
-    DirektivPagesSchema.safeParse(page).success;
-
-  const findBlock = (
-    parent: AllBlocksType | DirektivPagesType,
-    path: BlockPathType
-  ) =>
-    path.reduce<AllBlocksType | DirektivPagesType>((acc, index) => {
-      let next;
-
-      if (isPage(acc) || isParentBlock(acc)) {
-        next = acc.blocks[index] as AllBlocksType;
-      }
-
-      if (next) {
-        return next;
-      }
-
-      throw new Error(`index ${index} not found in ${JSON.stringify(acc)}`);
-    }, parent);
-
-  const updateBlock = (
-    page: DirektivPagesType,
-    path: BlockPathType,
-    block: AllBlocksType
-  ): DirektivPagesType => {
-    const newPage = clonePage(page);
-    const parent = findBlock(newPage, path.slice(0, -1));
-    const targetIndex = path[path.length - 1] as number;
-
-    if (isPage(parent) || isParentBlock(parent)) {
-      parent.blocks[targetIndex] = block;
-      return newPage;
-    }
-
-    throw new Error("Could not update block");
-  };
-
-  const addBlock = (
-    page: DirektivPagesType,
-    block: AllBlocksType,
-    path: BlockPathType
-  ) => {
-    const newPage = clonePage(page);
-    const parent = findBlock(newPage, path.slice(0, -1));
-    const index = path[path.length] as number;
-
-    if (isPage(parent) || isParentBlock(parent)) {
-      const newList: AllBlocksType[] = [
-        ...parent.blocks.slice(0, index - 1),
-        block,
-        ...parent.blocks.slice(index),
-      ];
-
-      parent.blocks = newList;
-      return newPage;
-    }
-
-    throw new Error("Could not update block");
-  };
 
   useEffect(() => {
     if (mode !== "inspect") {

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -90,11 +90,6 @@ export const BlockWrapper = ({
     throw new Error("Could not update block");
   };
 
-  const updatedPage = updateBlock(page, [1, 0, 0], {
-    type: "text",
-    content: "This is the updated text",
-  });
-
   const addBlock = (
     page: DirektivPagesType,
     block: AllBlocksType,

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -39,7 +39,7 @@ export const BlockWrapper = ({
   const mode = useMode();
   const page = usePage();
   const setPage = useSetPage();
-
+  const [dialogOpen, setDialogOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -92,7 +92,7 @@ export const BlockWrapper = ({
         data-block-wrapper
       >
         {mode === "inspect" && (
-          <Dialog>
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
             <Badge
               className="-m-6 absolute z-50"
               variant="secondary"
@@ -111,7 +111,10 @@ export const BlockWrapper = ({
               </Button>
             </DialogTrigger>
             <DialogContent>
-              <BlockForm path={blockPath}></BlockForm>
+              <BlockForm
+                path={blockPath}
+                close={() => setDialogOpen(false)}
+              ></BlockForm>
             </DialogContent>
           </Dialog>
         )}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
@@ -1,5 +1,5 @@
 import { FC, PropsWithChildren, createContext, useContext } from "react";
-import { findBlock, updateBlockInPage } from "./utils";
+import { addBlockToPage, findBlock, updateBlockInPage } from "./utils";
 
 import { AllBlocksType } from "../../schema/blocks";
 import { BlockPathType } from "../Block";
@@ -64,6 +64,19 @@ export const useUpdateBlock = () => {
 
   return {
     updateBlock,
+  };
+};
+
+export const useAddBlock = () => {
+  const page = usePage();
+  const setPage = useSetPage();
+  const addBlock = (path: BlockPathType, block: AllBlocksType) => {
+    const newPage = addBlockToPage(page, path, block);
+    setPage(newPage);
+  };
+
+  return {
+    addBlock,
   };
 };
 

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
@@ -1,7 +1,7 @@
 import { AllBlocksType, ParentBlockUnion } from "../../schema/blocks";
 import { FC, PropsWithChildren, createContext, useContext } from "react";
 
-import { BlockPath } from "../Block";
+import { BlockPathType } from "../Block";
 import { DirektivPagesType } from "../../schema";
 import { z } from "zod";
 
@@ -53,7 +53,7 @@ const isParentBlock = (
 ): block is z.infer<typeof ParentBlockUnion> =>
   ParentBlockUnion.safeParse(block).success;
 
-const getBlock = (list: BlockOrList, path: BlockPath): BlockOrList => {
+const getBlock = (list: BlockOrList, path: BlockPathType): BlockOrList => {
   const result = path.reduce<BlockOrList>((acc, index) => {
     let next;
 
@@ -72,7 +72,7 @@ const getBlock = (list: BlockOrList, path: BlockPath): BlockOrList => {
   return result;
 };
 
-const useBlock = (path: BlockPath) => {
+const useBlock = (path: BlockPathType) => {
   const page = usePage();
   return getBlock(page.blocks, path);
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
@@ -1,8 +1,9 @@
 import { FC, PropsWithChildren, createContext, useContext } from "react";
+import { findBlock, updateBlockInPage } from "./utils";
 
+import { AllBlocksType } from "../../schema/blocks";
 import { BlockPathType } from "../Block";
 import { DirektivPagesType } from "../../schema";
-import { findBlock } from "./utils";
 
 export type State = {
   mode: "inspect" | "live";
@@ -51,6 +52,19 @@ const useBlock = (path: BlockPathType) => {
 const useSetPage = () => {
   const { setPage } = usePageStateContext();
   return setPage;
+};
+
+export const useUpdateBlock = () => {
+  const page = usePage();
+  const setPage = useSetPage();
+  const updateBlock = (path: BlockPathType, newBlock: AllBlocksType) => {
+    const newPage = updateBlockInPage(page, path, newBlock);
+    setPage(newPage);
+  };
+
+  return {
+    updateBlock,
+  };
 };
 
 export { PageCompilerContextProvider, useMode, usePage, useSetPage, useBlock };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
@@ -1,9 +1,8 @@
-import { AllBlocksType, ParentBlockUnion } from "../../schema/blocks";
 import { FC, PropsWithChildren, createContext, useContext } from "react";
 
 import { BlockPathType } from "../Block";
 import { DirektivPagesType } from "../../schema";
-import { z } from "zod";
+import { findBlock } from "./utils";
 
 export type State = {
   mode: "inspect" | "live";
@@ -44,37 +43,9 @@ const usePage = () => {
   return page;
 };
 
-type Block = AllBlocksType;
-type List = AllBlocksType[];
-type BlockOrList = Block | List;
-
-const isParentBlock = (
-  block: AllBlocksType
-): block is z.infer<typeof ParentBlockUnion> =>
-  ParentBlockUnion.safeParse(block).success;
-
-const getBlock = (list: BlockOrList, path: BlockPathType): BlockOrList => {
-  const result = path.reduce<BlockOrList>((acc, index) => {
-    let next;
-
-    if (Array.isArray(acc)) {
-      next = acc[index];
-    } else if (isParentBlock(acc)) {
-      next = acc.blocks[index];
-    }
-
-    if (next) {
-      return next;
-    }
-
-    throw Error(`index ${index} not found in ${JSON.stringify(acc)}`);
-  }, list);
-  return result;
-};
-
 const useBlock = (path: BlockPathType) => {
   const page = usePage();
-  return getBlock(page.blocks, path);
+  return findBlock(page, path);
 };
 
 const useSetPage = () => {

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils.ts
@@ -43,7 +43,7 @@ export const findBlock = (
   }, parent) as AllBlocksType;
 };
 
-export const updateBlock = (
+export const updateBlockInPage = (
   page: DirektivPagesType,
   path: BlockPathType,
   block: AllBlocksType

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils.ts
@@ -1,0 +1,84 @@
+import { AllBlocksType, ParentBlockUnion } from "../../schema/blocks";
+import { DirektivPagesSchema, DirektivPagesType } from "../../schema";
+
+import { BlockPathType } from "../Block";
+import { clonePage } from "../../BlockEditor/utils";
+import { z } from "zod";
+
+export const isParentBlock = (
+  block: AllBlocksType
+): block is z.infer<typeof ParentBlockUnion> =>
+  ParentBlockUnion.safeParse(block).success;
+
+export const isPage = (
+  page: AllBlocksType | DirektivPagesType
+): page is z.infer<typeof DirektivPagesSchema> =>
+  DirektivPagesSchema.safeParse(page).success;
+
+/**
+ * Note: This function cannot logically return a page, but TypeScript doesn't
+ * recognize that the type is narrowed down in the Array.prototype.reduce()
+ * function. Thus we need to explicitly typecast the return.
+ */
+export const findBlock = (
+  parent: AllBlocksType | DirektivPagesType,
+  path: BlockPathType
+): AllBlocksType => {
+  if (path.length === 0) {
+    throw new Error("Path must not be empty");
+  }
+
+  return path.reduce<AllBlocksType | DirektivPagesType>((acc, index) => {
+    let next;
+
+    if (isPage(acc) || isParentBlock(acc)) {
+      next = acc.blocks[index] as AllBlocksType;
+    }
+
+    if (!next) {
+      throw new Error(`index ${index} not found in ${JSON.stringify(acc)}`);
+    }
+
+    return next;
+  }, parent) as AllBlocksType;
+};
+
+export const updateBlock = (
+  page: DirektivPagesType,
+  path: BlockPathType,
+  block: AllBlocksType
+): DirektivPagesType => {
+  const newPage = clonePage(page);
+  const parent = findBlock(newPage, path.slice(0, -1));
+  const targetIndex = path[path.length - 1] as number;
+
+  if (isPage(parent) || isParentBlock(parent)) {
+    parent.blocks[targetIndex] = block;
+    return newPage;
+  }
+
+  throw new Error("Could not update block");
+};
+
+export const addBlock = (
+  page: DirektivPagesType,
+  block: AllBlocksType,
+  path: BlockPathType
+) => {
+  const newPage = clonePage(page);
+  const parent = findBlock(newPage, path.slice(0, -1));
+  const index = path[path.length] as number;
+
+  if (isPage(parent) || isParentBlock(parent)) {
+    const newList: AllBlocksType[] = [
+      ...parent.blocks.slice(0, index - 1),
+      block,
+      ...parent.blocks.slice(index),
+    ];
+
+    parent.blocks = newList;
+    return newPage;
+  }
+
+  throw new Error("Could not update block");
+};

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils.ts
@@ -15,11 +15,6 @@ export const isPage = (
 ): page is z.infer<typeof DirektivPagesSchema> =>
   DirektivPagesSchema.safeParse(page).success;
 
-/**
- * Note: This function cannot logically return a page, but TypeScript doesn't
- * recognize that the type is narrowed down in the Array.prototype.reduce()
- * function. Thus we need to explicitly typecast the return.
- */
 export const findBlock = (
   parent: AllBlocksType | DirektivPagesType,
   path: BlockPathType
@@ -75,5 +70,5 @@ export const addBlockToPage = (
     return newPage;
   }
 
-  throw new Error("Could not update block");
+  throw new Error("Could not add block");
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils.ts
@@ -23,12 +23,8 @@ export const isPage = (
 export const findBlock = (
   parent: AllBlocksType | DirektivPagesType,
   path: BlockPathType
-): AllBlocksType => {
-  if (path.length === 0) {
-    throw new Error("Path must not be empty");
-  }
-
-  return path.reduce<AllBlocksType | DirektivPagesType>((acc, index) => {
+) =>
+  path.reduce<AllBlocksType | DirektivPagesType>((acc, index) => {
     let next;
 
     if (isPage(acc) || isParentBlock(acc)) {
@@ -40,8 +36,7 @@ export const findBlock = (
     }
 
     return next;
-  }, parent) as AllBlocksType;
-};
+  }, parent);
 
 export const updateBlockInPage = (
   page: DirektivPagesType,
@@ -60,18 +55,18 @@ export const updateBlockInPage = (
   throw new Error("Could not update block");
 };
 
-export const addBlock = (
+export const addBlockToPage = (
   page: DirektivPagesType,
-  block: AllBlocksType,
-  path: BlockPathType
+  path: BlockPathType,
+  block: AllBlocksType
 ) => {
   const newPage = clonePage(page);
   const parent = findBlock(newPage, path.slice(0, -1));
-  const index = path[path.length] as number;
+  const index = path[path.length - 1] as number;
 
   if (isPage(parent) || isParentBlock(parent)) {
     const newList: AllBlocksType[] = [
-      ...parent.blocks.slice(0, index - 1),
+      ...parent.blocks.slice(0, index),
       block,
       ...parent.blocks.slice(index),
     ];

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor.tsx
@@ -14,7 +14,16 @@ const examplePage: DirektivPagesType = {
   blocks: [
     {
       type: "text",
-      content: "Lorem Ipsum",
+      content: "Text block 1",
+    },
+    {
+      type: "card",
+      blocks: [
+        {
+          type: "card",
+          blocks: [{ type: "text", content: "text block in 2 cards" }],
+        },
+      ],
     },
     {
       type: "query-provider",

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor.tsx
@@ -13,8 +13,17 @@ const examplePage: DirektivPagesType = {
   direktiv_api: "pages/v1",
   blocks: [
     {
-      type: "text",
-      content: "Text block 1",
+      type: "columns",
+      blocks: [
+        {
+          type: "column",
+          blocks: [{ type: "text", content: "column 1 text" }],
+        },
+        {
+          type: "column",
+          blocks: [{ type: "text", content: "column 2 text" }],
+        },
+      ],
     },
     {
       type: "card",

--- a/ui/src/pages/namespace/Explorer/Page/poc/schema/__tests__/examples/complex.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/schema/__tests__/examples/complex.ts
@@ -16,53 +16,59 @@ export default {
     {
       type: "columns",
       blocks: [
-        [
-          {
-            type: "text",
-            content: "Some text goes here",
-          },
-        ],
-        [
-          {
-            type: "query-provider",
-            queries: [
-              {
-                id: "fetching-resources",
-                endpoint: "/api/get/resources",
-                queryParams: [
-                  {
-                    key: "query",
-                    value: "my-search-query",
-                  },
-                ],
-              },
-            ],
-            blocks: [
-              {
-                type: "dialog",
-                trigger: {
-                  type: "button",
-                  label: "open dialog",
+        {
+          type: "column",
+          blocks: [
+            {
+              type: "text",
+              content: "Some text goes here",
+            },
+          ],
+        },
+        {
+          type: "column",
+          blocks: [
+            {
+              type: "query-provider",
+              queries: [
+                {
+                  id: "fetching-resources",
+                  endpoint: "/api/get/resources",
+                  queryParams: [
+                    {
+                      key: "query",
+                      value: "my-search-query",
+                    },
+                  ],
                 },
-                blocks: [
-                  {
-                    type: "form",
-                    trigger: {
-                      type: "button",
-                      label: "delete",
-                    },
-                    mutation: {
-                      id: "my-delete",
-                      endpoint: "/api/delete/",
-                      method: "DELETE",
-                    },
-                    blocks: [],
+              ],
+              blocks: [
+                {
+                  type: "dialog",
+                  trigger: {
+                    type: "button",
+                    label: "open dialog",
                   },
-                ],
-              },
-            ],
-          },
-        ],
+                  blocks: [
+                    {
+                      type: "form",
+                      trigger: {
+                        type: "button",
+                        label: "delete",
+                      },
+                      mutation: {
+                        id: "my-delete",
+                        endpoint: "/api/delete/",
+                        method: "DELETE",
+                      },
+                      blocks: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ],
     },
   ],

--- a/ui/src/pages/namespace/Explorer/Page/poc/schema/__tests__/examples/simple.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/schema/__tests__/examples/simple.ts
@@ -16,18 +16,14 @@ export default {
     {
       type: "columns",
       blocks: [
-        [
-          {
-            type: "text",
-            content: "Some text goes here",
-          },
-        ],
-        [
-          {
-            type: "text",
-            content: "Some text goes here",
-          },
-        ],
+        {
+          type: "column",
+          blocks: [{ type: "text", content: "some text goes here" }],
+        },
+        {
+          type: "column",
+          blocks: [{ type: "text", content: "some text goes here" }],
+        },
       ],
     },
   ],

--- a/ui/src/pages/namespace/Explorer/Page/poc/schema/blocks/columns.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/schema/blocks/columns.ts
@@ -7,12 +7,22 @@ import { z } from "zod";
  * It is currently possible to extend the schema without updating the type.
  * The schema needs to get the type input to avoid circular dependencies.
  */
+export type ColumnType = {
+  type: "column";
+  blocks: AllBlocksType[];
+};
+
+export const Column = z.object({
+  type: z.literal("column"),
+  blocks: z.array(z.lazy(() => AllBlocks)),
+}) satisfies z.ZodType<ColumnType>;
+
 export type ColumnsType = {
   type: "columns";
-  blocks: AllBlocksType[][];
+  blocks: ColumnType[];
 };
 
 export const Columns = z.object({
   type: z.literal("columns"),
-  blocks: z.array(z.array(z.lazy(() => AllBlocks))),
+  blocks: z.array(z.lazy(() => Column)),
 }) satisfies z.ZodType<ColumnsType>;

--- a/ui/src/pages/namespace/Explorer/Page/poc/schema/blocks/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/schema/blocks/index.ts
@@ -46,6 +46,10 @@ export const AllBlocks: z.ZodType<AllBlocksType> = z.lazy(() =>
   z.union([SimpleBlockUnion, ParentBlockUnion])
 );
 
+export const BlockList = z.array(AllBlocks);
+
+export type BlockListType = z.infer<typeof BlockList>;
+
 export const TriggerBlocks = z.discriminatedUnion("type", [Button]);
 
 export type TriggerBlocksType = z.infer<typeof TriggerBlocks>;

--- a/ui/src/pages/namespace/Explorer/Page/poc/schema/blocks/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/schema/blocks/index.ts
@@ -1,6 +1,6 @@
 import { Button, ButtonType } from "./button";
 import { Card, CardType } from "./card";
-import { Columns, ColumnsType } from "./columns";
+import { Column, ColumnType, Columns, ColumnsType } from "./columns";
 import { Dialog, DialogType } from "./dialog";
 import { Form, FormType } from "./form";
 import { Headline, HeadlineType } from "./headline";
@@ -28,6 +28,7 @@ export const ParentBlockUnion = z.discriminatedUnion("type", [
   Form,
   Loop,
   QueryProvider,
+  Column,
   Columns,
 ]);
 
@@ -38,6 +39,7 @@ export type ParentBlocksType =
   | FormType
   | LoopType
   | QueryProviderType
+  | ColumnType
   | ColumnsType;
 
 export type AllBlocksType = SimpleBlocksType | ParentBlocksType;


### PR DESCRIPTION
## Description

This adds the following hooks to update pages:
* useBlock() (was already there)
* useSetPage() (to update the page in the context)
* useUpdateBlock() (to update a block at a specified path)
* useAddBlock() (to insert a block at a specified path)

Furthermore, a demo editor block for text blocks was added, using these hooks to update the page.

The hooks targeting specific blocks should be used over useSetPage() whenever possible.

The hooks are defined in 
src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx

and relying on methods defined in a utils folder.

We should add unit tests for the hooks and/or utils, for which I have created DIR-2034.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
