### PR TITLE
[DIR-2039] reduce unnecessary cache hits for pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,13 @@ RUN corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /app
 
-COPY ui/ ./
 
+# install dependencies (only necessary files are copied to be able to cache this layer)
+COPY ui/package.json .
+COPY ui/pnpm-lock.yaml .
 RUN pnpm install --frozen-lockfile
+
+COPY ui/ ./
 
 RUN pnpm run build
 


### PR DESCRIPTION
## Description

When running `pnpm install` in the Docker container, we now only copy the minimum required files for the installation to achieve more efficient caching at that step.

This is the same behavior as before [this PR](https://github.com/direktiv/direktiv/pull/1823). I changed it to make it more explicit (technically, the copy command below could now overwrite files that the pnpm install created), but I was not aware of the caching implications that this change would have.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
