### PR TITLE
[TDI-57] Allow cards below other cards

### DIFF
--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockList.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockList.tsx
@@ -50,7 +50,7 @@ const EditorBlockList = ({
           >
             <SelectBlockType
               big
-              path={path}
+              path={[...path, 0]}
               onSelect={(type) => createBlock(type, [...path, 0])}
             />
           </div>

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
@@ -3,8 +3,8 @@ import { ParentBlocksType, SimpleBlocksType } from "../../../schema/blocks";
 import {
   addBlockToPage,
   deleteBlockFromPage,
+  findAncestor,
   findBlock,
-  findInBranch,
   isPage,
   isParentBlock,
   pathsEqual,
@@ -218,18 +218,18 @@ describe("deleteBlockFromPage", () => {
   });
 });
 
-describe("findInBranch", () => {
-  test("it returns true if the element identified by the path matches fn", () => {
-    const result = findInBranch({
+describe("findAncestor", () => {
+  test("it does not consider the last index in the path", () => {
+    const result = findAncestor({
       page: complex,
       path: [2, 0, 0],
       match: (block) => block.type && block.type === "text",
     });
-    expect(result).toEqual(true);
+    expect(result).toEqual(false);
   });
 
   test("it returns true if an ancester matches fn", () => {
-    const result = findInBranch({
+    const result = findAncestor({
       page: complex,
       path: [2, 0, 0],
       match: (block) => block.type && block.type === "columns",
@@ -238,7 +238,7 @@ describe("findInBranch", () => {
   });
 
   test("it returns false if no element in the branch upwards matches the fn", () => {
-    const result = findInBranch({
+    const result = findAncestor({
       page: complex,
       path: [2, 0],
       match: (block) => block.type && block.type === "text",
@@ -246,8 +246,8 @@ describe("findInBranch", () => {
     expect(result).toEqual(false);
   });
 
-  test("it returns true if ancestors within depth 1 evaluate as true", () => {
-    const result = findInBranch({
+  test("it returns true if depth is 1 and the first ancestor matches fn", () => {
+    const result = findAncestor({
       page: complex,
       path: [2, 0, 0],
       match: (block) => block.type && block.type === "column",
@@ -256,48 +256,18 @@ describe("findInBranch", () => {
     expect(result).toEqual(true);
   });
 
-  test("it returns false if elements within depth 1 evaluate as false", () => {
-    const result = findInBranch({
-      page: complex,
-      path: [2, 0, 0],
-      match: (block) => block.type && block.type === "columns",
-      depth: 1,
-    });
-    expect(result).toEqual(false);
-  });
-
-  test("it returns true if ancestors within depth 1 evaluate as true", () => {
-    const result = findInBranch({
-      page: complex,
-      path: [2, 0, 0],
-      match: (block) => block.type && block.type === "column",
-      depth: 1,
-    });
-    expect(result).toEqual(true);
-  });
-
-  test("it returns true if depth is 0 and the last element in path matches fn", () => {
-    const result = findInBranch({
+  test("it returns false if depth is 1 and the first ancestor does not match fn", () => {
+    const result = findAncestor({
       page: complex,
       path: [2, 0, 0],
       match: (block) => block.type && block.type === "text",
-      depth: 0,
-    });
-    expect(result).toEqual(true);
-  });
-
-  test("it returns false if depth is 0 and the last element in path does not match fn", () => {
-    const result = findInBranch({
-      page: complex,
-      path: [2, 0, 0],
-      match: (block) => block.type && block.type === "column",
-      depth: 0,
+      depth: 1,
     });
     expect(result).toEqual(false);
   });
 
   test("it returns true if elements within depth 2 evaluate as true", () => {
-    const result = findInBranch({
+    const result = findAncestor({
       page: complex,
       path: [3, 0, 0],
       match: (block) => block.type && block.type === "dialog",
@@ -307,7 +277,7 @@ describe("findInBranch", () => {
   });
 
   test("it returns true if elements within depth 3 evaluate as true", () => {
-    const result = findInBranch({
+    const result = findAncestor({
       page: complex,
       path: [3, 0, 0],
       match: (block) => block.type && block.type === "query-provider",
@@ -317,7 +287,7 @@ describe("findInBranch", () => {
   });
 
   test("it returns false if elements within depth 3 evaluate as false", () => {
-    const result = findInBranch({
+    const result = findAncestor({
       page: complex,
       path: [3, 0, 0],
       match: (block) => block.type && block.type === "columns",
@@ -337,53 +307,15 @@ describe("findInBranch", () => {
         },
       ],
     } satisfies DirektivPagesType;
-    const result = findInBranch({
+    const result = findAncestor({
       page,
       path: [0],
-      match: (block) => block.type && block.type === "card",
-    });
-    expect(result).toEqual(true);
-  });
-
-  test("it evaluates correctly (false) when path is [0]", () => {
-    const page = {
-      direktiv_api: "page/v1",
-      type: "page",
-      blocks: [
-        {
-          type: "card",
-          blocks: [],
-        },
-      ],
-    } satisfies DirektivPagesType;
-    const result = findInBranch({
-      page,
-      path: [0],
-      match: (block) => block.type && block.type === "text",
-    });
-    expect(result).toEqual(false);
-  });
-
-  test("it evaluates correctly (true) when path is []", () => {
-    const page = {
-      direktiv_api: "page/v1",
-      type: "page",
-      blocks: [
-        {
-          type: "card",
-          blocks: [],
-        },
-      ],
-    } satisfies DirektivPagesType;
-    const result = findInBranch({
-      page,
-      path: [],
       match: (block) => block.type && block.type === "page",
     });
     expect(result).toEqual(true);
   });
 
-  test("it evaluates correctly (false) when path is []", () => {
+  test("it evaluates correctly (false) if path is [0]", () => {
     const page = {
       direktiv_api: "page/v1",
       type: "page",
@@ -394,7 +326,26 @@ describe("findInBranch", () => {
         },
       ],
     } satisfies DirektivPagesType;
-    const result = findInBranch({
+    const result = findAncestor({
+      page,
+      path: [0],
+      match: (block) => block.type && block.type === "card",
+    });
+    expect(result).toEqual(false);
+  });
+
+  test("it evaluates as false when path is [], as there are no parents", () => {
+    const page = {
+      direktiv_api: "page/v1",
+      type: "page",
+      blocks: [
+        {
+          type: "card",
+          blocks: [],
+        },
+      ],
+    } satisfies DirektivPagesType;
+    const result = findAncestor({
       page,
       path: [],
       match: (block) => block.type && block.type === "card",

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
@@ -370,7 +370,7 @@ describe("findAncestor", () => {
     const result = findAncestor({
       page,
       path: [],
-      match: (block) => block.type && block.type === "card",
+      match: (block) => block.type && block.type === "page",
     });
     expect(result).toEqual(false);
   });

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
@@ -334,6 +334,28 @@ describe("findAncestor", () => {
     expect(result).toEqual(false);
   });
 
+  test("it throws an error if depth is 0", () => {
+    expect(() =>
+      findAncestor({
+        page: complex,
+        path: [2, 0, 0],
+        match: (block) => block.type && block.type === "column",
+        depth: 0,
+      })
+    ).toThrow("depth must be undefined or >= 1");
+  });
+
+  test("it throws an error if depth is negative", () => {
+    expect(() =>
+      findAncestor({
+        page: complex,
+        path: [2, 0, 0],
+        match: (block) => block.type && block.type === "column",
+        depth: -1,
+      })
+    ).toThrow("depth must be undefined or >= 1");
+  });
+
   test("it evaluates as false when path is [], as there are no parents", () => {
     const page = {
       direktiv_api: "page/v1",

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
@@ -142,6 +142,9 @@ export const findAncestor = ({
   match,
   depth,
 }: FindInBranchConfig) => {
+  if (depth !== undefined && !(depth >= 1)) {
+    throw new Error("depth must be undefined or >= 1");
+  }
   const limit = depth !== undefined ? path.length - depth : 0;
   for (let i = path.length - 1; i >= limit; i--) {
     const target = findBlock(page, path.slice(0, i));

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
@@ -136,14 +136,14 @@ type FindInBranchConfig = {
   depth?: number;
 };
 
-export const findInBranch = ({
+export const findAncestor = ({
   page,
   path,
   match,
   depth,
 }: FindInBranchConfig) => {
   const limit = depth !== undefined ? path.length - depth : 0;
-  for (let i = path.length; i >= limit; i--) {
+  for (let i = path.length - 1; i >= limit; i--) {
     const target = findBlock(page, path.slice(0, i));
     if (match(target)) {
       return true;

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/useBlockTypes.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/useBlockTypes.tsx
@@ -78,7 +78,7 @@ export const useBlockTypes = (path: BlockPathType): BlockTypeConfigReturn[] => {
       type: "dialog",
       label: t("direktivPage.blockEditor.blockName.dialog"),
       icon: RectangleHorizontal,
-      allow: !findInBranch({
+      allow: !findAncestor({
         page,
         path,
         match: (block) => block.type === "dialog",

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/useBlockTypes.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/useBlockTypes.tsx
@@ -9,7 +9,7 @@ import {
 
 import { AllBlocksType } from "../../../schema/blocks";
 import { BlockPathType } from "../../Block";
-import { findInBranch } from ".";
+import { findAncestor } from ".";
 import { usePage } from "../pageCompilerContext";
 import { useTranslation } from "react-i18next";
 
@@ -49,7 +49,7 @@ export const useBlockTypes = (path: BlockPathType): BlockTypeConfigReturn[] => {
       type: "columns",
       label: t("direktivPage.blockEditor.blockName.columns"),
       icon: Columns2,
-      allow: !findInBranch({
+      allow: !findAncestor({
         page,
         path,
         match: (block) => block.type === "columns",
@@ -59,7 +59,7 @@ export const useBlockTypes = (path: BlockPathType): BlockTypeConfigReturn[] => {
       type: "card",
       label: t("direktivPage.blockEditor.blockName.card"),
       icon: Captions,
-      allow: !findInBranch({
+      allow: !findAncestor({
         page,
         path,
         match: (block) => block.type === "card",


### PR DESCRIPTION
## Description

This fixes an error in detecting block types in the ancestors of a block when rendering the type selector menu for adding a new block. There are two sides to this:
* First, when adding a block in an empty list, we previously didn't begin parsing ancestors at the path of the new block, but at the parent.
* Second, I have changed findInPath to findAncestor. It makes more sense to always start at the parent path because the block at the current path should already be known. I have updated the tests accordingly.

The depth param also makes more sense now: depth 0 does not run any iterations. That's why I added a guard that throws an Error when depth is smaller than 1.

When path is [], no parents exist, but it fails silently, as this can happen naturally at the root of the path.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
