### PR TITLE
Add moveBlock method to usePageEditor

### DIFF
--- a/ui/src/pages/namespace/Explorer/Page/poc/DndContextProvider/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/DndContextProvider/index.tsx
@@ -1,35 +1,26 @@
-import {
-  addBlockToPage,
-  moveBlockWithinPage,
-} from "../PageCompiler/context/utils";
-
 import { AllBlocksType } from "../schema/blocks";
 import { BlockPathType } from "../PageCompiler/Block";
 import { DirektivPagesType } from "../schema";
 import { DndContext } from "~/design/DragAndDropEditor/Context.tsx";
 import { PropsWithChildren } from "react";
+import { usePageEditor } from "../PageCompiler/context/pageCompilerContext";
 
 type DndContextProviderProps = PropsWithChildren & {
   page: DirektivPagesType;
   setPage: (page: DirektivPagesType) => void;
 };
 
-export const DndContextProvider = ({
-  page,
-  setPage,
-  children,
-}: DndContextProviderProps) => {
+export const DndContextProvider = ({ children }: DndContextProviderProps) => {
+  const { addBlock, moveBlock } = usePageEditor();
+
   const onMove = (
     origin: BlockPathType | null,
     target: BlockPathType,
     block: AllBlocksType
   ) => {
-    const updatedPage =
-      origin === null
-        ? addBlockToPage(page, target, block)
-        : moveBlockWithinPage(page, origin, target, block);
-
-    setPage(updatedPage);
+    origin === null
+      ? addBlock(target, block)
+      : moveBlock(origin, target, block);
   };
 
   return <DndContext onMove={onMove}>{children} </DndContext>;

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
@@ -3,6 +3,7 @@ import {
   addBlockToPage,
   deleteBlockFromPage,
   findBlock,
+  moveBlockWithinPage,
   updateBlockInPage,
 } from "./utils";
 
@@ -77,10 +78,20 @@ export const usePageEditor = () => {
     setPage(newPage);
   };
 
+  const moveBlock = (
+    origin: BlockPathType,
+    target: BlockPathType,
+    block: AllBlocksType
+  ) => {
+    const newPage = moveBlockWithinPage(page, origin, target, block);
+    setPage(newPage);
+  };
+
   return {
     mode,
     addBlock,
     deleteBlock,
+    moveBlock,
     updateBlock,
     setPage,
   };


### PR DESCRIPTION
## Description

This wraps the moveBlockWithinPage function in a method inside the usePageEditor hook.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
