### PR TITLE
[TDI-90] Show dropzone after every block instead of before

### DIFF
--- a/ui/src/design/DragAndDrop/Draggable.tsx
+++ b/ui/src/design/DragAndDrop/Draggable.tsx
@@ -18,7 +18,8 @@ const useSharedDraggable = (payload: DragPayloadSchemaType) => {
   const styles: CSSProperties = transform
     ? {
         transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(1.05)`,
-        zIndex: "51",
+        position: "relative",
+        zIndex: "50",
       }
     : {};
 
@@ -35,7 +36,7 @@ export const SortableItem: FC<DraggableProps> = ({ payload, children }) => {
         ref={setNodeRef}
         {...listeners}
         {...attributes}
-        className="absolute z-50 h-full text-gray-8 dark:text-gray-dark-8"
+        className="absolute z-40 h-full text-gray-8 dark:text-gray-dark-8"
       >
         <div className="flex h-full w-5 items-center justify-center rounded rounded-e-none border-2 border-r-0 border-gray-4 bg-white p-0 hover:cursor-move hover:border-solid hover:bg-gray-2 active:cursor-move active:border-solid active:bg-gray-2 dark:border-gray-dark-4 dark:bg-black dark:hover:bg-gray-dark-2">
           <GripVertical />

--- a/ui/src/design/DragAndDrop/Draggable.tsx
+++ b/ui/src/design/DragAndDrop/Draggable.tsx
@@ -9,7 +9,7 @@ type DraggableProps = PropsWithChildren & {
   payload: DragPayloadSchemaType;
 };
 
-const useSharedDragable = (payload: DragPayloadSchemaType) => {
+const useSharedDraggable = (payload: DragPayloadSchemaType) => {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({
     id: JSON.stringify(payload),
     data: payload,
@@ -27,7 +27,7 @@ const useSharedDragable = (payload: DragPayloadSchemaType) => {
 
 export const SortableItem: FC<DraggableProps> = ({ payload, children }) => {
   const { attributes, listeners, setNodeRef, styles } =
-    useSharedDragable(payload);
+    useSharedDraggable(payload);
 
   return (
     <div style={styles} className="relative m-1">
@@ -49,13 +49,11 @@ export const SortableItem: FC<DraggableProps> = ({ payload, children }) => {
   );
 };
 
-export const DragablePaletteItem: FC<DraggableProps & { icon: LucideIcon }> = ({
-  payload,
-  icon: Icon,
-  children,
-}) => {
+export const DraggablePaletteItem: FC<
+  DraggableProps & { icon: LucideIcon }
+> = ({ payload, icon: Icon, children }) => {
   const { attributes, listeners, setNodeRef, styles } =
-    useSharedDragable(payload);
+    useSharedDraggable(payload);
 
   return (
     <div ref={setNodeRef} {...listeners} {...attributes} style={styles}>

--- a/ui/src/design/DragAndDrop/index.stories.tsx
+++ b/ui/src/design/DragAndDrop/index.stories.tsx
@@ -52,10 +52,9 @@ export const Default = () => {
         </Card>
         <Card className="grow p-3">
           {blocks.map((block, index) => {
-            const blockPath = [index];
+            const blockPath = [index + 1];
             return (
               <div key={index} className="my-2 flex flex-col items-center">
-                <Dropzone payload={{ targetPath: [index] }} />
                 <SortableItem
                   payload={{ type: "move", block, originPath: blockPath }}
                 >
@@ -63,13 +62,14 @@ export const Default = () => {
                     <div className="border-2 p-2">{block.label}</div>
                   )}
                 </SortableItem>
+                <Dropzone payload={{ targetPath: [index + 1] }} />
               </div>
             );
           })}
         </Card>
       </div>
       <Card className="mt-3 h-[100px] overflow-y-scroll p-5">
-        {actions.reverse().map((action, index) => (
+        {actions.map((action, index) => (
           <div key={index}>{action}</div>
         ))}
       </Card>

--- a/ui/src/design/DragAndDrop/index.stories.tsx
+++ b/ui/src/design/DragAndDrop/index.stories.tsx
@@ -1,4 +1,4 @@
-import { DragablePaletteItem, SortableItem } from "./Draggable";
+import { DraggablePaletteItem, SortableItem } from "./Draggable";
 
 import { Card } from "../Card";
 import { DndContext } from ".";
@@ -40,7 +40,7 @@ export const Default = () => {
     >
       <div className="flex gap-5">
         <Card className="w-[200px] p-3">
-          <DragablePaletteItem
+          <DraggablePaletteItem
             payload={{
               type: "add",
               blockType: "headline",
@@ -48,7 +48,7 @@ export const Default = () => {
             icon={Heading1}
           >
             Headline
-          </DragablePaletteItem>
+          </DraggablePaletteItem>
         </Card>
         <Card className="grow p-3">
           {blocks.map((block, index) => {

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
@@ -2,7 +2,7 @@ import { Blocks, Settings } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/design/Tabs";
 
 import { BlockForm } from "..";
-import { DragablePaletteItem } from "~/design/DragAndDrop/Draggable";
+import { DraggablePaletteItem } from "~/design/DragAndDrop/Draggable";
 import { useBlockTypes } from "../../PageCompiler/context/utils/useBlockTypes";
 import { usePageEditorPanel } from "../EditorPanelProvider";
 import { useTranslation } from "react-i18next";
@@ -33,13 +33,13 @@ export const EditorPanel = () => {
           <TabsContent value="addBlock" asChild>
             <div className="relative flex-col-reverse overflow-visible">
               {allowedBlockTypes.map((type, index) => (
-                <DragablePaletteItem
+                <DraggablePaletteItem
                   key={index}
                   payload={{ type: "add", blockType: type.type }}
                   icon={type.icon}
                 >
                   {type.label}
-                </DragablePaletteItem>
+                </DraggablePaletteItem>
               ))}
             </div>
           </TabsContent>

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { decrementPath, findAncestor, pathsEqual } from "../../context/utils";
+import { findAncestor, incrementPath, pathsEqual } from "../../context/utils";
 import {
   usePage,
   usePageStateContext,
@@ -87,12 +87,14 @@ const EditorBlockWrapper = ({
     });
   };
 
+  const followingSilblingPath = incrementPath(blockPath);
+
   const isDropAllowed = (payload: DragPayloadSchemaType | null) => {
     if (payload?.type === "move") {
       // don't show a dropzone for neighboring blocks
-      const precedingSilblingPath = decrementPath(blockPath);
+
       if (
-        pathsEqual(payload.originPath, precedingSilblingPath) ||
+        pathsEqual(payload.originPath, followingSilblingPath) ||
         pathsEqual(payload.originPath, blockPath)
       ) {
         return false;
@@ -104,7 +106,6 @@ const EditorBlockWrapper = ({
 
   return (
     <>
-      <Dropzone payload={{ targetPath: blockPath }} isVisible={isDropAllowed} />
       <SortableItem
         payload={{
           type: "move",
@@ -143,6 +144,10 @@ const EditorBlockWrapper = ({
           </Suspense>
         </div>
       </SortableItem>
+      <Dropzone
+        payload={{ targetPath: followingSilblingPath }}
+        isVisible={isDropAllowed}
+      />
     </>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -87,14 +87,14 @@ const EditorBlockWrapper = ({
     });
   };
 
-  const followingSilblingPath = incrementPath(blockPath);
+  const nextSilblingPath = incrementPath(blockPath);
 
   const isDropAllowed = (payload: DragPayloadSchemaType | null) => {
     if (payload?.type === "move") {
       // don't show a dropzone for neighboring blocks
 
       if (
-        pathsEqual(payload.originPath, followingSilblingPath) ||
+        pathsEqual(payload.originPath, nextSilblingPath) ||
         pathsEqual(payload.originPath, blockPath)
       ) {
         return false;
@@ -145,7 +145,7 @@ const EditorBlockWrapper = ({
         </div>
       </SortableItem>
       <Dropzone
-        payload={{ targetPath: followingSilblingPath }}
+        payload={{ targetPath: nextSilblingPath }}
         isVisible={isDropAllowed}
       />
     </>

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
@@ -2,10 +2,10 @@ import { ColumnType, ColumnsType } from "../../../schema/blocks/columns";
 import { ParentBlockType, SimpleBlockType } from "../../../schema/blocks";
 import {
   addBlockToPage,
-  decrementPath,
   deleteBlockFromPage,
   findAncestor,
   findBlock,
+  incrementPath,
   isPage,
   isParentBlock,
   pathsEqual,
@@ -354,35 +354,29 @@ describe("addBlockToPage", () => {
   });
 });
 
-describe("decrementPath", () => {
-  test("should decrement the last index of a non-empty path", () => {
-    const input = [0, 2, 3];
-    const expected = [0, 2, 2];
-    expect(decrementPath(input)).toEqual(expected);
+describe("incrementPath", () => {
+  test("should increment the last index of a non-empty path", () => {
+    const input = [0, 2, 2];
+    const expected = [0, 2, 3];
+    expect(incrementPath(input)).toEqual(expected);
   });
 
   test("should handle a path with a single element", () => {
-    const input = [1];
-    const expected = [0];
-    expect(decrementPath(input)).toEqual(expected);
+    const input = [0];
+    const expected = [1];
+    expect(incrementPath(input)).toEqual(expected);
   });
 
-  test("should not handle a path with last index 0 (result will never be -1)", () => {
-    const input = [0, 0];
-    const expected = [0, 0];
-    expect(decrementPath(input)).toEqual(expected);
-  });
-
-  test("should return the same path if the last index is falsy (e.g. 0)", () => {
-    const input = [1, 0];
-    const expected = [1, 0];
-    expect(decrementPath(input)).toEqual(expected);
+  test("should handle a path with last index 0", () => {
+    const input = [2, 0];
+    const expected = [2, 1];
+    expect(incrementPath(input)).toEqual(expected);
   });
 
   test("should return an empty array unchanged", () => {
     const input: number[] = [];
     const expected: number[] = [];
-    expect(decrementPath(input)).toEqual(expected);
+    expect(incrementPath(input)).toEqual(expected);
   });
 });
 

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
@@ -155,13 +155,12 @@ export const moveBlockWithinPage = (
   return pageWithDeletedBlock;
 };
 
-export const decrementPath = (path: BlockPathType): BlockPathType => {
+export const incrementPath = (path: BlockPathType): BlockPathType => {
   const pathLength = path.length;
   let lastIndex = path[pathLength - 1];
 
-  const updatedPath = lastIndex
-    ? [...path.slice(0, -1), (lastIndex -= 1)]
-    : path;
+  const updatedPath =
+    lastIndex !== undefined ? [...path.slice(0, -1), (lastIndex += 1)] : path;
 
   return updatedPath;
 };


### PR DESCRIPTION
## Description

In this PR I changed the dropzone to be placed after every block instead of before, because with that the "editor" view is more aligned with the layout that is shown in the "live" view.

Additionally I renamed a variable, where the spelling was different than for the others.
I also fixed a visual issue with the z-index of the blocks.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
