### PR TITLE
[TDI-87] Limit enabled dropzones to dialog if dialog is open

### DIFF
--- a/ui/src/design/DragAndDrop/Dropzone.tsx
+++ b/ui/src/design/DragAndDrop/Dropzone.tsx
@@ -20,16 +20,21 @@ export const Dropzone: FC<DroppableProps> = ({
   isVisible = () => true,
   children,
 }) => {
+  const { active } = useDndContext();
+
+  const parsedPayload = DragPayloadSchema.safeParse(active?.data.current);
+
+  const isDisabled = !isVisible(
+    parsedPayload.success ? parsedPayload.data : null
+  );
+
   const { setNodeRef, isOver } = useDroppable({
+    disabled: isDisabled,
     id: payload.targetPath.join("-"),
     data: payload,
   });
 
-  const { active } = useDndContext();
-
   const canDrop = !!active;
-
-  const parsedPayload = DragPayloadSchema.safeParse(active?.data.current);
 
   return (
     <div
@@ -37,8 +42,7 @@ export const Dropzone: FC<DroppableProps> = ({
       className={twMergeClsx(
         "relative m-0 my-4 h-1 w-full justify-center rounded-lg p-0",
         isOver && "h-1 bg-gray-4 transition-all dark:bg-gray-dark-4",
-        !isVisible(parsedPayload.success ? parsedPayload.data : null) &&
-          "invisible"
+        isDisabled && "invisible"
       )}
     >
       {children}

--- a/ui/src/design/DragAndDrop/Dropzone.tsx
+++ b/ui/src/design/DragAndDrop/Dropzone.tsx
@@ -12,41 +12,39 @@ import { twMergeClsx } from "~/util/helpers";
 
 type DroppableProps = PropsWithChildren & {
   payload: DropPayloadSchemaType;
-  isVisible?: (payload: DragPayloadSchemaType | null) => boolean;
+  enable?: (payload: DragPayloadSchemaType | null) => boolean;
 };
 
 export const Dropzone: FC<DroppableProps> = ({
   payload,
-  isVisible = () => true,
+  enable = () => true,
   children,
 }) => {
   const { active } = useDndContext();
 
   const parsedPayload = DragPayloadSchema.safeParse(active?.data.current);
 
-  const isDisabled = !isVisible(
-    parsedPayload.success ? parsedPayload.data : null
-  );
+  const isEnabled = enable(parsedPayload.success ? parsedPayload.data : null);
 
   const { setNodeRef, isOver } = useDroppable({
-    disabled: isDisabled,
+    disabled: !isEnabled,
     id: payload.targetPath.join("-"),
     data: payload,
   });
 
-  const canDrop = !!active;
+  const isDragging = !!active;
+  const showDropIndicator = isDragging && isEnabled;
 
   return (
     <div
       ref={setNodeRef}
       className={twMergeClsx(
         "relative m-0 my-4 h-1 w-full justify-center rounded-lg p-0",
-        isOver && "h-1 bg-gray-4 transition-all dark:bg-gray-dark-4",
-        isDisabled && "invisible"
+        isOver && "h-1 bg-gray-4 transition-all dark:bg-gray-dark-4"
       )}
     >
       {children}
-      {canDrop && (
+      {showDropIndicator && (
         <div className="absolute inset-0 flex flex-col items-center justify-center">
           <div className="z-10 flex flex-col">
             <Badge

--- a/ui/src/design/DragAndDrop/Dropzone.tsx
+++ b/ui/src/design/DragAndDrop/Dropzone.tsx
@@ -20,9 +20,11 @@ export const Dropzone: FC<DroppableProps> = ({
   enable = () => true,
   children,
 }) => {
-  const { active } = useDndContext();
+  const { active: activeDraggable } = useDndContext();
 
-  const parsedPayload = DragPayloadSchema.safeParse(active?.data.current);
+  const parsedPayload = DragPayloadSchema.safeParse(
+    activeDraggable?.data.current
+  );
 
   const isEnabled = enable(parsedPayload.success ? parsedPayload.data : null);
 
@@ -32,7 +34,7 @@ export const Dropzone: FC<DroppableProps> = ({
     data: payload,
   });
 
-  const isDragging = !!active;
+  const isDragging = !!activeDraggable;
   const showDropIndicator = isDragging && isEnabled;
 
   return (

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
@@ -14,11 +14,18 @@ import { EditorPanel } from "./components/EditorPanel";
 import { LocalDialogContainer } from "~/design/LocalDialog/container";
 import { getBlockTemplate } from "../PageCompiler/context/utils";
 
-type EditorPanelState = null | {
-  action: "create" | "edit" | "delete";
-  block: AllBlocksType;
-  path: BlockPathType;
-};
+type EditorPanelState =
+  | null
+  | {
+      action: null;
+      dialog?: BlockPathType | null;
+    }
+  | {
+      action: "create" | "edit" | "delete";
+      block: AllBlocksType;
+      path: BlockPathType;
+      dialog?: BlockPathType | null;
+    };
 
 type EditorPanelContextType = {
   panel: EditorPanelState;
@@ -71,7 +78,7 @@ export const EditorPanelLayoutProvider = ({
           </div>
           <Dialog open={panel && panel.action === "delete" ? true : false}>
             <DialogContent>
-              {!!panel && (
+              {!!panel && panel.action === "delete" && (
                 <BlockDeleteForm
                   path={panel.path}
                   onSubmit={() => {

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
@@ -14,41 +14,41 @@ export const EditorPanel = () => {
   const rootLevel = [1];
   const allowedBlockTypes = useBlockTypes(rootLevel);
 
-  if (!panel) {
+  if (panel?.action) {
     return (
-      <div>
-        <Tabs defaultValue="addBlock">
-          <TabsList variant="boxed">
-            <TabsTrigger variant="boxed" value="addBlock">
-              <Blocks size={16} />
-              {t("direktivPage.blockEditor.generic.addBlockTab")}
-            </TabsTrigger>
-            <TabsTrigger variant="boxed" value="settings">
-              <Settings size={16} />
-              {t("direktivPage.blockEditor.generic.settingsTab")}
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="addBlock" asChild>
-            <div className="relative flex-col-reverse overflow-visible">
-              {allowedBlockTypes.map((type, index) => (
-                <DragablePaletteItem
-                  key={index}
-                  payload={{ type: "add", blockType: type.type }}
-                  icon={type.icon}
-                >
-                  {type.label}
-                </DragablePaletteItem>
-              ))}
-            </div>
-          </TabsContent>
-          <TabsContent value="settings" asChild></TabsContent>
-        </Tabs>
-      </div>
+      <BlockForm action={panel.action} path={panel.path} block={panel.block} />
     );
   }
 
   return (
-    <BlockForm action={panel.action} path={panel.path} block={panel.block} />
+    <div>
+      <Tabs defaultValue="addBlock">
+        <TabsList variant="boxed">
+          <TabsTrigger variant="boxed" value="addBlock">
+            <Blocks size={16} />
+            {t("direktivPage.blockEditor.generic.addBlockTab")}
+          </TabsTrigger>
+          <TabsTrigger variant="boxed" value="settings">
+            <Settings size={16} />
+            {t("direktivPage.blockEditor.generic.settingsTab")}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="addBlock" asChild>
+          <div className="relative flex-col-reverse overflow-visible">
+            {allowedBlockTypes.map((type, index) => (
+              <DragablePaletteItem
+                key={index}
+                payload={{ type: "add", blockType: type.type }}
+                icon={type.icon}
+              >
+                {type.label}
+              </DragablePaletteItem>
+            ))}
+          </div>
+        </TabsContent>
+        <TabsContent value="settings" asChild></TabsContent>
+      </Tabs>
+    </div>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
@@ -11,8 +11,7 @@ export const EditorPanel = () => {
   const { panel } = usePageEditorPanel();
   const { t } = useTranslation();
 
-  const rootLevel = [1];
-  const allowedBlockTypes = useBlockTypes(rootLevel);
+  const blockTypes = useBlockTypes([]);
 
   if (panel?.action) {
     return (
@@ -36,7 +35,7 @@ export const EditorPanel = () => {
 
         <TabsContent value="addBlock" asChild>
           <div className="relative flex-col-reverse overflow-visible">
-            {allowedBlockTypes.map((type, index) => (
+            {blockTypes.map((type, index) => (
               <DragablePaletteItem
                 key={index}
                 payload={{ type: "add", blockType: type.type }}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Dialog.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/Dialog.tsx
@@ -51,12 +51,15 @@ const EditModeDialog = (props: DialogProps) => {
   return (
     <DialogBaseComponent
       {...props}
-      onOpenChange={() =>
-        setPanel({
-          action: "edit",
-          path: props.blockPath,
-          block: props.blockProps,
-        })
+      onOpenChange={(open) =>
+        setPanel(
+          open
+            ? {
+                action: null,
+                dialog: props.blockPath,
+              }
+            : null
+        )
       }
     />
   );

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -63,14 +63,14 @@ const EditorBlockWrapper = ({
 
   const isFocused = panel?.action && pathsEqual(panel.path, blockPath);
 
-  const parentDialog = findAncestor({
-    page,
-    path: blockPath,
-    match: (block) => block.type === "dialog",
-  });
-
   const handleClickBlock = (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
+
+    const parentDialog = findAncestor({
+      page,
+      path: blockPath,
+      match: (block) => block.type === "dialog",
+    });
 
     // if block losing focus is in a Dialog, focus the Dialog.
     if (isFocused && parentDialog) {

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -8,7 +8,7 @@ import {
 import {
   decrementPath,
   findAncestor,
-  pathContains,
+  pathIsDescendant,
   pathsEqual,
 } from "../../context/utils";
 import {
@@ -95,7 +95,7 @@ const EditorBlockWrapper = ({
   };
 
   const enableDropZone = (payload: DragPayloadSchemaType | null) => {
-    if (panel?.dialog && !pathContains(blockPath, panel.dialog)) {
+    if (panel?.dialog && !pathIsDescendant(blockPath, panel.dialog)) {
       return false;
     }
     if (payload?.type === "move") {

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -61,8 +61,7 @@ const EditorBlockWrapper = ({
     return () => document.removeEventListener("mousemove", handleMouseMove);
   }, []);
 
-  const isFocused =
-    panel?.action && panel.path && pathsEqual(panel.path, blockPath);
+  const isFocused = panel?.action && pathsEqual(panel.path, blockPath);
 
   const parentDialog = findAncestor({
     page,

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/utils/BlockWrapper.tsx
@@ -94,7 +94,7 @@ const EditorBlockWrapper = ({
     });
   };
 
-  const isDropAllowed = (payload: DragPayloadSchemaType | null) => {
+  const enableDropZone = (payload: DragPayloadSchemaType | null) => {
     if (panel?.dialog && !pathContains(blockPath, panel.dialog)) {
       return false;
     }
@@ -113,7 +113,7 @@ const EditorBlockWrapper = ({
 
   return (
     <>
-      <Dropzone payload={{ targetPath: blockPath }} isVisible={isDropAllowed} />
+      <Dropzone payload={{ targetPath: blockPath }} enable={enableDropZone} />
       <SortableItem
         payload={{
           type: "move",

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
@@ -8,6 +8,7 @@ import {
   findBlock,
   isPage,
   isParentBlock,
+  pathContains,
   pathsEqual,
   updateBlockInPage,
 } from "../utils";
@@ -383,6 +384,33 @@ describe("decrementPath", () => {
     const input: number[] = [];
     const expected: number[] = [];
     expect(decrementPath(input)).toEqual(expected);
+  });
+});
+
+describe("pathContains", () => {
+  test("returns true when a starts with b", () => {
+    expect(pathContains([0, 4, 3, 1], [0, 4, 3])).toBe(true);
+    expect(pathContains([1, 2, 3], [1])).toBe(true);
+    expect(pathContains([5, 6, 7, 8], [5, 6])).toBe(true);
+  });
+
+  test("returns true when a and b are exactly equal", () => {
+    expect(pathContains([1, 2, 3], [1, 2, 3])).toBe(true);
+  });
+
+  test("returns false when b is longer than a", () => {
+    expect(pathContains([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  test("returns false when a does not start with b", () => {
+    expect(pathContains([0, 4, 3, 1], [4, 3])).toBe(false);
+    expect(pathContains([1, 2, 3], [2])).toBe(false);
+  });
+
+  test("returns true when b is empty (every array starts with [])", () => {
+    expect(() => pathContains([1, 2, 3], [])).toThrow(
+      "Invalid input: b must not be empty."
+    );
   });
 });
 

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/__tests__/utils.test.ts
@@ -8,7 +8,7 @@ import {
   findBlock,
   isPage,
   isParentBlock,
-  pathContains,
+  pathIsDescendant,
   pathsEqual,
   updateBlockInPage,
 } from "../utils";
@@ -387,30 +387,29 @@ describe("decrementPath", () => {
   });
 });
 
-describe("pathContains", () => {
-  test("returns true when a starts with b", () => {
-    expect(pathContains([0, 4, 3, 1], [0, 4, 3])).toBe(true);
-    expect(pathContains([1, 2, 3], [1])).toBe(true);
-    expect(pathContains([5, 6, 7, 8], [5, 6])).toBe(true);
+describe("pathIsDescendant", () => {
+  test("returns true when descendant starts with ancestor", () => {
+    expect(pathIsDescendant([0, 4, 3, 1], [0, 4, 3])).toBe(true);
+    expect(pathIsDescendant([1, 2, 3], [1])).toBe(true);
+    expect(pathIsDescendant([5, 6, 7, 8], [5, 6])).toBe(true);
   });
 
-  test("returns true when a and b are exactly equal", () => {
-    expect(pathContains([1, 2, 3], [1, 2, 3])).toBe(true);
+  test("returns true when ancestor is []", () => {
+    expect(pathIsDescendant([0], [])).toBe(true);
   });
 
-  test("returns false when b is longer than a", () => {
-    expect(pathContains([1, 2], [1, 2, 3])).toBe(false);
+  test("returns false when descendant and ancestor are exactly equal", () => {
+    expect(pathIsDescendant([1, 2, 3], [1, 2, 3])).toBe(false);
+    expect(pathIsDescendant([], [])).toBe(false);
   });
 
-  test("returns false when a does not start with b", () => {
-    expect(pathContains([0, 4, 3, 1], [4, 3])).toBe(false);
-    expect(pathContains([1, 2, 3], [2])).toBe(false);
+  test("returns false when ancestor is longer than descendant", () => {
+    expect(pathIsDescendant([1, 2], [1, 2, 3])).toBe(false);
   });
 
-  test("returns true when b is empty (every array starts with [])", () => {
-    expect(() => pathContains([1, 2, 3], [])).toThrow(
-      "Invalid input: b must not be empty."
-    );
+  test("returns false when descendant does not start with ancestor", () => {
+    expect(pathIsDescendant([0, 4, 3, 1], [4, 3])).toBe(false);
+    expect(pathIsDescendant([1, 2, 3], [2])).toBe(false);
   });
 });
 

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
@@ -175,6 +175,14 @@ export const decrementPath = (path: BlockPathType): BlockPathType => {
   return updatedPath;
 };
 
+export const pathContains = (a: BlockPathType, b: BlockPathType) => {
+  if (b.length === 0) {
+    throw new Error("Invalid input: b must not be empty.");
+  }
+  if (b.length > a.length) return false;
+  return b.every((value, index) => a[index] === value);
+};
+
 type PathOrNull = BlockPathType | null;
 
 export const pathsEqual = (a: PathOrNull, b: PathOrNull) => {

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/utils/index.ts
@@ -166,12 +166,12 @@ export const decrementPath = (path: BlockPathType): BlockPathType => {
   return updatedPath;
 };
 
-export const pathContains = (a: BlockPathType, b: BlockPathType) => {
-  if (b.length === 0) {
-    throw new Error("Invalid input: b must not be empty.");
-  }
-  if (b.length > a.length) return false;
-  return b.every((value, index) => a[index] === value);
+export const pathIsDescendant = (
+  descendant: BlockPathType,
+  ancestor: BlockPathType
+): boolean => {
+  if (descendant.length <= ancestor.length) return false;
+  return ancestor.every((value, index) => descendant[index] === value);
 };
 
 type PathOrNull = BlockPathType | null;


### PR DESCRIPTION
## Description

This tweaks how dropzones are disabled.
* Previously, they were only hidden by the isVisible prop, but you could still drop something and the action would be triggered.
* Now, the "enable" function prop will prevent them from rendering the drop zone hint as well as set them to "disabled" via the useDroppable() API.
* The editor panel context now has a "dialog" property. If a dialog is open, this is set to the path of the dialog block.
* With a dialog open, only drop zones inside the dialog block's scope are enabled.

Follow-up: TDI-92 "Dropzones should know what block types are allowed to be dropped". This will extend this logic further (but TDI-77 with the single config layer should be merged first).

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
