### PR TITLE
[TDI-80] overhaul page editor bottom toolbar

### DIFF
--- a/ui/src/assets/locales/en/translation.json
+++ b/ui/src/assets/locales/en/translation.json
@@ -1674,6 +1674,12 @@
         "cancelButton": "Cancel",
         "confirmButton": "Confirm"
       },
+
+      "toolbar": {
+        "code": "Code View",
+        "edit": "Edit",
+        "live": "Live View"
+      },
       "blockName": {
         "headline": "Headline",
         "text": "Text",

--- a/ui/src/design/DragAndDrop/Draggable.tsx
+++ b/ui/src/design/DragAndDrop/Draggable.tsx
@@ -58,7 +58,7 @@ export const DraggablePaletteItem: FC<
 
   return (
     <div ref={setNodeRef} {...listeners} {...attributes} style={styles}>
-      <Card className="z-50 flex items-center justify-center bg-gray-2 p-3 text-sm text-black hover:cursor-move active:cursor-move dark:bg-gray-dark-2">
+      <Card className="z-50 flex items-center justify-center bg-gray-2 p-2 text-sm text-black hover:cursor-move active:cursor-move dark:bg-gray-dark-2">
         <Icon size={16} className="mr-2" /> {children}
       </Card>
     </div>

--- a/ui/src/design/DragAndDrop/Draggable.tsx
+++ b/ui/src/design/DragAndDrop/Draggable.tsx
@@ -59,7 +59,7 @@ export const DragablePaletteItem: FC<DraggableProps & { icon: LucideIcon }> = ({
 
   return (
     <div ref={setNodeRef} {...listeners} {...attributes} style={styles}>
-      <Card className="z-50 flex items-center justify-center bg-gray-2 p-4 text-sm text-black hover:cursor-move active:cursor-move dark:bg-gray-dark-2">
+      <Card className="z-50 flex items-center justify-center bg-gray-2 p-3 text-sm text-black hover:cursor-move active:cursor-move dark:bg-gray-dark-2">
         <Icon size={16} className="mr-2" /> {children}
       </Card>
     </div>

--- a/ui/src/design/DragAndDrop/Draggable.tsx
+++ b/ui/src/design/DragAndDrop/Draggable.tsx
@@ -59,8 +59,8 @@ export const DragablePaletteItem: FC<DraggableProps & { icon: LucideIcon }> = ({
 
   return (
     <div ref={setNodeRef} {...listeners} {...attributes} style={styles}>
-      <Card className="z-50 m-4 flex items-center justify-center bg-gray-2 p-4 text-sm text-black hover:cursor-move active:cursor-move dark:bg-gray-dark-2">
-        <Icon size={16} className="mr-4" /> {children}
+      <Card className="z-50 flex items-center justify-center bg-gray-2 p-4 text-sm text-black hover:cursor-move active:cursor-move dark:bg-gray-dark-2">
+        <Icon size={16} className="mr-2" /> {children}
       </Card>
     </div>
   );

--- a/ui/src/design/LocalDialog/container.tsx
+++ b/ui/src/design/LocalDialog/container.tsx
@@ -32,7 +32,7 @@ export const LocalDialogContainer = ({
     <LocalDialogContainerContext.Provider value={{ container }}>
       <div
         ref={setContainer}
-        className={twMergeClsx("relative isolate z-0", className)}
+        className={twMergeClsx("relative isolate z-0 w-full", className)}
       >
         {children}
       </div>

--- a/ui/src/design/LocalDialog/index.tsx
+++ b/ui/src/design/LocalDialog/index.tsx
@@ -23,7 +23,7 @@ export const LocalDialogContent = ({ children }: PropsWithChildren) => {
         className="absolute inset-0 flex items-start justify-center px-5 pt-16"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="absolute inset-0 -m-6 bg-black/10 backdrop-blur-sm" />
+        <div className="absolute inset-0 -mx-4 -my-5 bg-black/10 backdrop-blur-sm" />
         <DialogPrimitive.Content
           className={twMergeClsx(
             "pointer-events-auto fixed z-50 grid w-full gap-4 rounded-b-lg bg-gray-1 p-6 animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:max-w-lg sm:rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",

--- a/ui/src/design/LocalDialog/index.tsx
+++ b/ui/src/design/LocalDialog/index.tsx
@@ -23,7 +23,7 @@ export const LocalDialogContent = ({ children }: PropsWithChildren) => {
         className="absolute inset-0 flex items-start justify-center px-5 pt-16"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="absolute inset-0 -m-2 bg-black/10 backdrop-blur-sm" />
+        <div className="absolute inset-0 -m-6 bg-black/10 backdrop-blur-sm" />
         <DialogPrimitive.Content
           className={twMergeClsx(
             "pointer-events-auto fixed z-50 grid w-full gap-4 rounded-b-lg bg-gray-1 p-6 animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:max-w-lg sm:rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
@@ -35,7 +35,7 @@ type EditorPanelContextType = {
 const EditorPanelContext = createContext<EditorPanelContextType | null>(null);
 
 const PagePreviewContainer = ({ children }: PropsWithChildren) => (
-  <div className="grow p-3 sm:h-[calc(100vh-230px)] sm:overflow-y-scroll">
+  <div className="grow px-3 py-5 sm:h-[calc(100vh-230px)] sm:overflow-y-scroll">
     {children}
   </div>
 );
@@ -80,7 +80,7 @@ export const EditorPanelLayoutProvider = ({
     return (
       <DndContext onDrop={onDrop}>
         <EditorPanelContext.Provider value={{ panel, setPanel }}>
-          <div className="grow gap-5 sm:flex">
+          <div className="grow sm:flex">
             <div className="h-[300px] overflow-y-visible border-b-2 border-gray-4 p-3 dark:border-gray-dark-4 sm:h-[calc(100vh-230px)] sm:w-1/3 sm:border-b-0 sm:border-r-2">
               <EditorPanel />
             </div>

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
@@ -28,7 +28,7 @@ type EditorPanelContextType = {
 const EditorPanelContext = createContext<EditorPanelContextType | null>(null);
 
 const PagePreviewContainer = ({ children }: PropsWithChildren) => (
-  <div className="grow p-3 lg:h-[calc(100vh-230px)] lg:overflow-y-scroll">
+  <div className="grow p-3 sm:h-[calc(100vh-230px)] sm:overflow-y-scroll">
     {children}
   </div>
 );
@@ -73,8 +73,8 @@ export const EditorPanelLayoutProvider = ({
     return (
       <DndContext onDrop={onDrop}>
         <EditorPanelContext.Provider value={{ panel, setPanel }}>
-          <div className="grow gap-5 lg:flex">
-            <div className="h-[300px] overflow-y-visible border-b-2 border-gray-4 p-3 dark:border-gray-dark-4 lg:h-[calc(100vh-230px)] lg:w-1/3 lg:border-b-0 lg:border-r-2">
+          <div className="grow gap-5 sm:flex">
+            <div className="h-[300px] overflow-y-visible border-b-2 border-gray-4 p-3 dark:border-gray-dark-4 sm:h-[calc(100vh-230px)] sm:w-1/3 sm:border-b-0 sm:border-r-2">
               <EditorPanel />
             </div>
             <PagePreviewContainer>

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
@@ -1,6 +1,6 @@
 import { AllBlocksType, inlineBlockTypes } from "../schema/blocks";
 import { Dialog, DialogContent } from "~/design/Dialog";
-import { createContext, useContext, useState } from "react";
+import { PropsWithChildren, createContext, useContext, useState } from "react";
 import {
   usePageEditor,
   usePageStateContext,
@@ -26,6 +26,12 @@ type EditorPanelContextType = {
 };
 
 const EditorPanelContext = createContext<EditorPanelContextType | null>(null);
+
+const PagePreviewContainer = ({ children }: PropsWithChildren) => (
+  <div className="grow p-3 lg:h-[calc(100vh-230px)] lg:overflow-y-scroll">
+    {children}
+  </div>
+);
 
 export const EditorPanelLayoutProvider = ({
   children,
@@ -61,13 +67,15 @@ export const EditorPanelLayoutProvider = ({
     return (
       <DndContext onDrop={onDrop}>
         <EditorPanelContext.Provider value={{ panel, setPanel }}>
-          <div className="flex gap-5">
-            <div className="w-1/3 max-w-md shrink-0 overflow-visible border-r-2 border-gray-4 pr-2 dark:border-gray-dark-4">
+          <div className="grow gap-5 lg:flex">
+            <div className="h-[300px] overflow-y-visible border-b-2 border-gray-4 p-3 dark:border-gray-dark-4 lg:h-[calc(100vh-230px)] lg:w-1/3 lg:border-b-0 lg:border-r-2">
               <EditorPanel />
             </div>
-            <LocalDialogContainer className="min-w-0 flex-1">
-              {children}
-            </LocalDialogContainer>
+            <PagePreviewContainer>
+              <LocalDialogContainer className="min-w-0 flex-1">
+                {children}
+              </LocalDialogContainer>
+            </PagePreviewContainer>
           </div>
           <Dialog open={panel && panel.action === "delete" ? true : false}>
             <DialogContent>
@@ -90,7 +98,11 @@ export const EditorPanelLayoutProvider = ({
     );
   }
 
-  return <LocalDialogContainer>{children}</LocalDialogContainer>;
+  return (
+    <LocalDialogContainer>
+      <PagePreviewContainer>{children}</PagePreviewContainer>
+    </LocalDialogContainer>
+  );
 };
 
 export const usePageEditorPanel = () => {

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/Delete.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/Delete.tsx
@@ -47,7 +47,7 @@ export const BlockDeleteForm = ({
           </Button>
         </DialogClose>
         <DialogClose asChild>
-          <Button variant="primary" onClick={() => onSubmit()}>
+          <Button variant="destructive" onClick={() => onSubmit()}>
             {t("direktivPage.blockEditor.generic.confirmButton")}
           </Button>
         </DialogClose>

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
@@ -16,35 +16,32 @@ export const EditorPanel = () => {
 
   if (!panel) {
     return (
-      <div>
-        <Tabs defaultValue="addBlock">
-          <TabsList variant="boxed">
-            <TabsTrigger variant="boxed" value="addBlock">
-              <Blocks size={16} />
-              {t("direktivPage.blockEditor.generic.addBlockTab")}
-            </TabsTrigger>
-            <TabsTrigger variant="boxed" value="settings">
-              <Settings size={16} />
-              {t("direktivPage.blockEditor.generic.settingsTab")}
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="addBlock" asChild>
-            <div className="relative flex-col-reverse overflow-visible">
-              {allowedBlockTypes.map((type, index) => (
-                <DragablePaletteItem
-                  key={index}
-                  payload={{ type: "add", blockType: type.type }}
-                  icon={type.icon}
-                >
-                  {type.label}
-                </DragablePaletteItem>
-              ))}
-            </div>
-          </TabsContent>
-          <TabsContent value="settings" asChild></TabsContent>
-        </Tabs>
-      </div>
+      <Tabs defaultValue="addBlock">
+        <TabsList variant="boxed">
+          <TabsTrigger variant="boxed" value="addBlock">
+            <Blocks size={16} />
+            {t("direktivPage.blockEditor.generic.addBlockTab")}
+          </TabsTrigger>
+          <TabsTrigger variant="boxed" value="settings">
+            <Settings size={16} />
+            {t("direktivPage.blockEditor.generic.settingsTab")}
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="addBlock" asChild>
+          <div className="grid grid-cols-3 gap-2 overflow-visible lg:grid-cols-1">
+            {allowedBlockTypes.map((type, index) => (
+              <DragablePaletteItem
+                key={index}
+                payload={{ type: "add", blockType: type.type }}
+                icon={type.icon}
+              >
+                {type.label}
+              </DragablePaletteItem>
+            ))}
+          </div>
+        </TabsContent>
+        <TabsContent value="settings" asChild></TabsContent>
+      </Tabs>
     );
   }
 

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/EditorPanel.tsx
@@ -29,7 +29,7 @@ export const EditorPanel = () => {
           </TabsTrigger>
         </TabsList>
         <TabsContent value="addBlock" asChild>
-          <div className="grid grid-cols-3 gap-2 overflow-visible lg:grid-cols-1">
+          <div className="grid grid-cols-3 gap-2 overflow-visible sm:grid-cols-1">
             {allowedBlockTypes.map((type, index) => (
               <DraggablePaletteItem
                 key={index}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/context/pageCompilerContext.tsx
@@ -11,7 +11,7 @@ import { AllBlocksType } from "../../schema/blocks";
 import { BlockPathType } from "../Block";
 import { DirektivPagesType } from "../../schema";
 
-type PageCompilerMode = "edit" | "live";
+export type PageCompilerMode = "edit" | "live";
 
 export type PageCompilerProps = {
   mode: PageCompilerMode;

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/ButtonBar.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/ButtonBar.tsx
@@ -37,14 +37,7 @@ type ButtonBarProps = {
   onChange: (value: PageEditorMode) => void;
 };
 
-/**
- *
- * TODO: rename comopnent and file
- * any better way to synch state
- *
- */
 const ButtonBar: FC<ButtonBarProps> = ({ value, onChange }) => {
-  const [activeButton, setActiveButton] = useState<PageEditorMode>(value);
   const { t } = useTranslation();
   return (
     <DesignButtonBar>
@@ -57,11 +50,10 @@ const ButtonBar: FC<ButtonBarProps> = ({ value, onChange }) => {
                 <div className="flex grow">
                   <Toggle
                     onClick={() => {
-                      setActiveButton(button.id);
                       onChange(button.id);
                     }}
                     className="grow"
-                    pressed={button.id === activeButton}
+                    pressed={button.id === value}
                   >
                     <IconComponent />
                   </Toggle>

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/ButtonBar.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/ButtonBar.tsx
@@ -1,0 +1,69 @@
+import { Code, Eye, LucideIcon, Pencil } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/design/Tooltip";
+
+import { ButtonBar as DesignButtonBar } from "~/design/ButtonBar";
+import { PageCompilerMode } from "./poc/PageCompiler/context/pageCompilerContext";
+import { Toggle } from "~/design/Toggle";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+type ButtonState = PageCompilerMode | "code";
+
+type Button = {
+  id: ButtonState;
+  icon: LucideIcon;
+};
+
+const buttons: Button[] = [
+  {
+    id: "code",
+    icon: Code,
+  },
+  {
+    id: "edit",
+    icon: Pencil,
+  },
+  {
+    id: "live",
+    icon: Eye,
+  },
+];
+
+const ButtonBar = () => {
+  const [activeButton, setActiveButton] = useState<ButtonState>("edit");
+  const { t } = useTranslation();
+  return (
+    <DesignButtonBar>
+      <TooltipProvider>
+        {buttons.map((button) => {
+          const IconComponent = button.icon;
+          return (
+            <Tooltip key={button.id}>
+              <TooltipTrigger asChild>
+                <div className="flex grow">
+                  <Toggle
+                    onClick={() => setActiveButton(button.id)}
+                    className="grow"
+                    pressed={button.id === activeButton}
+                  >
+                    <IconComponent />
+                  </Toggle>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                {t(`direktivPage.blockEditor.toolbar.${button.id}`)}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </TooltipProvider>
+    </DesignButtonBar>
+  );
+};
+
+export default ButtonBar;

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/ButtonBar.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/ButtonBar.tsx
@@ -1,4 +1,5 @@
 import { Code, Eye, LucideIcon, Pencil } from "lucide-react";
+import { FC, useState } from "react";
 import {
   Tooltip,
   TooltipContent,
@@ -7,15 +8,12 @@ import {
 } from "~/design/Tooltip";
 
 import { ButtonBar as DesignButtonBar } from "~/design/ButtonBar";
-import { PageCompilerMode } from "./poc/PageCompiler/context/pageCompilerContext";
+import { PageEditorMode } from ".";
 import { Toggle } from "~/design/Toggle";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-type ButtonState = PageCompilerMode | "code";
-
 type Button = {
-  id: ButtonState;
+  id: PageEditorMode;
   icon: LucideIcon;
 };
 
@@ -34,8 +32,19 @@ const buttons: Button[] = [
   },
 ];
 
-const ButtonBar = () => {
-  const [activeButton, setActiveButton] = useState<ButtonState>("edit");
+type ButtonBarProps = {
+  value: PageEditorMode;
+  onChange: (value: PageEditorMode) => void;
+};
+
+/**
+ *
+ * TODO: rename comopnent and file
+ * any better way to synch state
+ *
+ */
+const ButtonBar: FC<ButtonBarProps> = ({ value, onChange }) => {
+  const [activeButton, setActiveButton] = useState<PageEditorMode>(value);
   const { t } = useTranslation();
   return (
     <DesignButtonBar>
@@ -47,7 +56,10 @@ const ButtonBar = () => {
               <TooltipTrigger asChild>
                 <div className="flex grow">
                   <Toggle
-                    onClick={() => setActiveButton(button.id)}
+                    onClick={() => {
+                      setActiveButton(button.id);
+                      onChange(button.id);
+                    }}
                     className="grow"
                     pressed={button.id === activeButton}
                   >

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/EditorModeSwitcher.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/EditorModeSwitcher.tsx
@@ -1,5 +1,4 @@
 import { Code, Eye, LucideIcon, Pencil } from "lucide-react";
-import { FC, useState } from "react";
 import {
   Tooltip,
   TooltipContent,
@@ -7,7 +6,8 @@ import {
   TooltipTrigger,
 } from "~/design/Tooltip";
 
-import { ButtonBar as DesignButtonBar } from "~/design/ButtonBar";
+import { ButtonBar } from "~/design/ButtonBar";
+import { FC } from "react";
 import { PageEditorMode } from ".";
 import { Toggle } from "~/design/Toggle";
 import { useTranslation } from "react-i18next";
@@ -32,15 +32,18 @@ const buttons: Button[] = [
   },
 ];
 
-type ButtonBarProps = {
+type EditorModeSwitcherProps = {
   value: PageEditorMode;
   onChange: (value: PageEditorMode) => void;
 };
 
-const ButtonBar: FC<ButtonBarProps> = ({ value, onChange }) => {
+const EditorModeSwitcher: FC<EditorModeSwitcherProps> = ({
+  value,
+  onChange,
+}) => {
   const { t } = useTranslation();
   return (
-    <DesignButtonBar>
+    <ButtonBar>
       <TooltipProvider>
         {buttons.map((button) => {
           const IconComponent = button.icon;
@@ -66,8 +69,8 @@ const ButtonBar: FC<ButtonBarProps> = ({ value, onChange }) => {
           );
         })}
       </TooltipProvider>
-    </DesignButtonBar>
+    </ButtonBar>
   );
 };
 
-export default ButtonBar;
+export default EditorModeSwitcher;

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/index.tsx
@@ -3,6 +3,7 @@ import { DirektivPagesSchema, DirektivPagesType } from "../schema";
 import { jsonToYaml, yamlToJsonOrNull } from "../../../utils";
 
 import Button from "~/design/Button";
+import ButtonBar from "./ButtonBar";
 import { Card } from "~/design/Card";
 import Editor from "~/design/Editor";
 import { PageCompiler } from "../PageCompiler";
@@ -30,81 +31,39 @@ const PageEditor = ({ isPending, page: pageProp, onSave }: PageEditorProps) => {
 
   return (
     <div className="relative flex grow flex-col space-y-4 p-5">
-      <div
-        className={twMergeClsx(
-          "relative grid grow gap-5",
-          showCode && "grid-cols-2"
-        )}
-      >
-        {showCode && (
-          <Card className="p-4">
-            <Editor
-              value={jsonToYaml(page)}
-              theme={theme ?? undefined}
-              onChange={(newValue) => {
-                if (newValue) {
-                  const newValueJson = yamlToJsonOrNull(newValue);
-                  if (
-                    validate &&
-                    !DirektivPagesSchema.safeParse(newValueJson).success
-                  ) {
-                    return;
-                  }
-                  setPage(newValueJson);
-                }
-              }}
-            />
-          </Card>
-        )}
-        <PageCompiler
+      <Card className="grow p-5">
+        <Editor
+          value={jsonToYaml(page)}
+          theme={theme ?? undefined}
+          onChange={(newValue) => {
+            if (newValue) {
+              const newValueJson = yamlToJsonOrNull(newValue);
+              if (
+                validate &&
+                !DirektivPagesSchema.safeParse(newValueJson).success
+              ) {
+                return;
+              }
+              setPage(newValueJson);
+            }
+          }}
+        />
+        {/* <PageCompiler
           mode={mode}
           page={page}
           setPage={(page) => setPage(page)}
-        />
-      </div>
-      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-        <div className="flex gap-5 text-sm">
-          <div className="flex items-center gap-2">
-            <Switch
-              id="mode"
-              checked={mode === "edit"}
-              onCheckedChange={(value) => {
-                setMode(value ? "edit" : "live");
-              }}
-            />
-            <label htmlFor="mode">Editor</label>
-          </div>
-          <div className="flex items-center gap-2">
-            <Switch
-              id="show-code"
-              checked={showCode}
-              onCheckedChange={(value) => {
-                setShowCode(value);
-              }}
-            />
-            <label htmlFor="show-code">Show Code</label>
-          </div>
-          <div className="flex items-center gap-2">
-            <Switch
-              disabled={!showCode}
-              id="validate"
-              checked={validate}
-              onCheckedChange={(value) => {
-                setValidate(value);
-              }}
-            />
-            <label htmlFor="validate">Validate</label>
-          </div>
-        </div>
+        /> */}
+      </Card>
+      <div className="flex flex-col justify-end gap-4 sm:flex-row sm:items-center">
+        <ButtonBar />
         <Button
           variant="outline"
           type="button"
           disabled={isPending}
           onClick={() => onSave(page)}
-          data-testid="page-editor-btn-save"
         >
           <Save />
-          {t("pages.explorer.workflow.editor.saveBtn")}
+          {t("direktivPage.blockEditor.generic.saveButton")}
         </Button>
       </div>
     </div>

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/index.tsx
@@ -49,7 +49,9 @@ const PageEditor = ({ isPending, page: pageProp, onSave }: PageEditorProps) => {
           variant="outline"
           type="button"
           disabled={isPending}
-          onClick={() => onSave(pageProp)}
+          onClick={() => {
+            onSave(page);
+          }}
         >
           <Save />
           {t("direktivPage.blockEditor.generic.saveButton")}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/index.tsx
@@ -28,12 +28,13 @@ const PageEditor = ({ isPending, page: pageProp, onSave }: PageEditorProps) => {
 
   return (
     <div className="relative flex grow flex-col space-y-4 p-5">
-      <Card className="grow p-5">
+      <Card className="flex grow">
         {mode === "code" ? (
           <Editor
             value={jsonToYaml(page)}
             options={{ readOnly: true }}
             theme={theme ?? undefined}
+            className="p-5"
           />
         ) : (
           <PageCompiler

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageEditor/index.tsx
@@ -1,8 +1,8 @@
 import Button from "~/design/Button";
-import ButtonBar from "./ButtonBar";
 import { Card } from "~/design/Card";
 import { DirektivPagesType } from "../schema";
 import Editor from "~/design/Editor";
+import EditorModeSwitcher from "./EditorModeSwitcher";
 import { PageCompiler } from "../PageCompiler";
 import { PageCompilerMode } from "../PageCompiler/context/pageCompilerContext";
 import { Save } from "lucide-react";
@@ -44,7 +44,7 @@ const PageEditor = ({ isPending, page: pageProp, onSave }: PageEditorProps) => {
         )}
       </Card>
       <div className="flex flex-col justify-end gap-4 sm:flex-row sm:items-center">
-        <ButtonBar value={mode} onChange={setMode} />
+        <EditorModeSwitcher value={mode} onChange={setMode} />
         <Button
           variant="outline"
           type="button"


### PR DESCRIPTION
## Description

This PR overhauls the bottom toolbar. I went with a very simple approach and decided to do a button bar with three buttons to view code, edit and preview the page similar to the workflow editor.

I decided not to store the selected button state in localstorage as we normally do for these kinds of view settings. I am happy to change that if anyone has a strong opinion on that.

- There is not an explicit "copy code button" but I think this does not need an extra button when you see the code. 
- I changed the editor to be read-only
- the height of the main Card will adjust to the window height, and the right panel will overflow with a scrollbar if needed.
- the left panel currently does not overflow if the content is too big to fit in. This must be improved in a future version (as a form could potentially be too big to fit in), however I had to keep `overflow-y-visible` so that the draggable elements can leave the container while being dragged. We could change that by toggling `overflow-y-visible` and `overflow-y-scroll` depending on wheater something on the left panel is being dragged but I wanted to keep this a siple PR for now
- I slightly updated the left panel to reduce the amount of occupied vertical space (for the reasons mentioned above)
- small change I did on the side: changed the delete modal button to be variant `destructive`


| Before | After |
|--------|--------|
| <img width="3232" height="2956" alt="CleanShot 2025-07-24 at 09 57 46@2x" src="https://github.com/user-attachments/assets/11f8e7d1-2a77-4284-bbe9-eebab77e7044" /> | <img width="3232" height="2030" alt="CleanShot 2025-07-24 at 09 57 16@2x" src="https://github.com/user-attachments/assets/03c3f7ce-9299-43da-a908-75c8c94bd055" /> |


Very small screen


<img width="1364" height="2550" alt="CleanShot 2025-07-24 at 10 06 46@2x" src="https://github.com/user-attachments/assets/4e79cc3e-67ce-45ae-a28d-481f8a49a8dd" />


## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
