### PR TITLE
[TDI-95] local dialog backdrop might not cover the entire page

### DIFF
--- a/ui/src/design/LocalDialog/index.tsx
+++ b/ui/src/design/LocalDialog/index.tsx
@@ -20,10 +20,10 @@ export const LocalDialogContent = ({ children }: PropsWithChildren) => {
   return (
     <DialogPrimitive.DialogPortal container={container}>
       <div
-        className="absolute inset-0 flex items-start justify-center px-5 pt-16"
+        className="absolute inset-0 flex items-start justify-center px-5 pt-20"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="absolute inset-0 -mx-4 -my-5 bg-black/10 backdrop-blur-sm" />
+        <div className="absolute inset-0 bg-black/10 backdrop-blur-sm" />
         <DialogPrimitive.Content
           className={twMergeClsx(
             "pointer-events-auto fixed z-50 grid w-full gap-4 rounded-b-lg bg-gray-1 p-6 animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:max-w-lg sm:rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
@@ -35,8 +35,10 @@ type EditorPanelContextType = {
 const EditorPanelContext = createContext<EditorPanelContextType | null>(null);
 
 const PagePreviewContainer = ({ children }: PropsWithChildren) => (
-  <div className="grow px-3 py-5 sm:h-[calc(100vh-230px)] sm:overflow-y-scroll">
-    {children}
+  <div className="grow sm:h-[calc(100vh-230px)] sm:overflow-y-scroll">
+    <LocalDialogContainer className="h-full min-w-0 flex-1 px-3 py-5">
+      {children}
+    </LocalDialogContainer>
   </div>
 );
 
@@ -84,11 +86,7 @@ export const EditorPanelLayoutProvider = ({
             <div className="h-[300px] overflow-y-visible border-b-2 border-gray-4 p-3 dark:border-gray-dark-4 sm:h-[calc(100vh-230px)] sm:w-1/3 sm:border-b-0 sm:border-r-2">
               <EditorPanel />
             </div>
-            <PagePreviewContainer>
-              <LocalDialogContainer className="min-w-0 flex-1">
-                {children}
-              </LocalDialogContainer>
-            </PagePreviewContainer>
+            <PagePreviewContainer>{children}</PagePreviewContainer>
           </div>
           <Dialog open={panel && panel.action === "delete" ? true : false}>
             <DialogContent>
@@ -111,11 +109,7 @@ export const EditorPanelLayoutProvider = ({
     );
   }
 
-  return (
-    <LocalDialogContainer>
-      <PagePreviewContainer>{children}</PagePreviewContainer>
-    </LocalDialogContainer>
-  );
+  return <PagePreviewContainer>{children}</PagePreviewContainer>;
 };
 
 export const usePageEditorPanel = () => {


### PR DESCRIPTION
## Description

local dialog backdrop might not cover the entire page height (see [screenshot in the ticket](https://archtis.atlassian.net/browse/TDI-95))

I also fixed a related issue where the backdrop is overflowing the container when in preview mode. The main issue here was that the local dialog had a negative margin in the design component itself. But since the component cannot know how it is embedded and how much negative margin is appropriate, I lifted that class up to the parent. 

| before | after |
|--------|--------|
| <img width="3248" height="2112" alt="after" src="https://github.com/user-attachments/assets/615e2582-590f-465b-866c-420f9fb3c752" /> |  <img width="3248" height="2112" alt="before" src="https://github.com/user-attachments/assets/bb883d2f-a40f-46a9-8bf2-98352d85afa9" /> |




## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
