### PR TITLE
[TDI-108] Close side panel when dragging a block

### DIFF
--- a/ui/src/design/DragAndDrop/index.tsx
+++ b/ui/src/design/DragAndDrop/index.tsx
@@ -8,9 +8,14 @@ import { FC, PropsWithChildren } from "react";
 
 type DndContextProps = PropsWithChildren & {
   onDrop: (payload: DragAndDropPayloadSchemaType) => void;
+  onDrag?: () => void;
 };
 
-export const DndContext: FC<DndContextProps> = ({ children, onDrop }) => {
+export const DndContext: FC<DndContextProps> = ({
+  children,
+  onDrag,
+  onDrop,
+}) => {
   const onDragEnd = (e: DragEndEvent) => {
     const parsedDragPayload = DragPayloadSchema.safeParse(
       e.active.data.current
@@ -26,5 +31,9 @@ export const DndContext: FC<DndContextProps> = ({ children, onDrop }) => {
     });
   };
 
-  return <DndKitContext onDragEnd={onDragEnd}>{children}</DndKitContext>;
+  return (
+    <DndKitContext onDragEnd={onDragEnd} onDragStart={onDrag}>
+      {children}
+    </DndKitContext>
+  );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/EditorPanelProvider.tsx
@@ -79,12 +79,17 @@ export const EditorPanelLayoutProvider = ({
     }
     if (drag.type === "move") {
       moveBlock(drag.originPath, drop.targetPath, drag.block);
+      setPanel({
+        action: "edit",
+        path: drop.targetPath,
+        block: drag.block,
+      });
     }
   };
 
   if (mode === "edit") {
     return (
-      <DndContext onDrop={onDrop}>
+      <DndContext onDrop={onDrop} onDrag={() => setPanel(null)}>
         <EditorPanelContext.Provider
           value={{ panel, setPanel, dialog, setDialog }}
         >


### PR DESCRIPTION
## Description

Fixes bug where after moving a block by dragging, the block was still open in the side panel but referencing the old path.

Bug fixed by closing the side panel when dragging, and opening it again at the new path after moving completed.