### PR TITLE
[TDI-106] Fix form element side panel interactions

### DIFF
--- a/ui/src/components/StopPropagation/index.tsx
+++ b/ui/src/components/StopPropagation/index.tsx
@@ -1,0 +1,29 @@
+import { MouseEventHandler, ReactElement, cloneElement } from "react";
+
+type StopPropagationProps = {
+  children: ReactElement;
+  asChild?: boolean;
+  onClick?: React.MouseEventHandler;
+};
+
+export const StopPropagation = ({
+  children,
+  asChild,
+  onClick,
+}: StopPropagationProps) => {
+  const handleClick: MouseEventHandler = (event) => {
+    event.stopPropagation();
+    onClick?.(event);
+  };
+
+  if (asChild) {
+    return cloneElement(children, {
+      onClick: (e: React.MouseEvent) => {
+        handleClick(e);
+        children.props.onClick?.(e);
+      },
+    });
+  }
+
+  return <div onClick={handleClick}>{children}</div>;
+};

--- a/ui/src/components/StopPropagation/index.tsx
+++ b/ui/src/components/StopPropagation/index.tsx
@@ -2,13 +2,11 @@ import { MouseEventHandler, ReactElement, cloneElement } from "react";
 
 type StopPropagationProps = {
   children: ReactElement;
-  asChild?: boolean;
   onClick?: React.MouseEventHandler;
 };
 
 export const StopPropagation = ({
   children,
-  asChild,
   onClick,
 }: StopPropagationProps) => {
   const handleClick: MouseEventHandler = (event) => {
@@ -16,14 +14,10 @@ export const StopPropagation = ({
     onClick?.(event);
   };
 
-  if (asChild) {
-    return cloneElement(children, {
-      onClick: (e: React.MouseEvent) => {
-        handleClick(e);
-        children.props.onClick?.(e);
-      },
-    });
-  }
-
-  return <div onClick={handleClick}>{children}</div>;
+  return cloneElement(children, {
+    onClick: (e: React.MouseEvent) => {
+      handleClick(e);
+      children.props.onClick?.(e);
+    },
+  });
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormCheckbox.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormCheckbox.tsx
@@ -1,6 +1,8 @@
 import { Checkbox } from "~/design/Checkbox";
 import { Fieldset } from "./utils/FieldSet";
 import { FormCheckboxType } from "../../../schema/blocks/form/checkbox";
+import { StopPropagation } from "~/components/StopPropagation";
+import { usePageStateContext } from "../../context/pageCompilerContext";
 import { useTranslation } from "react-i18next";
 import { useVariableBooleanResolver } from "../../primitives/Variable/utils/useVariableBooleanResolver";
 
@@ -12,6 +14,7 @@ export const FormCheckbox = ({ blockProps }: FormCheckboxProps) => {
   const { t } = useTranslation();
   const resolveVariableBoolean = useVariableBooleanResolver();
   const { id, label, description, defaultValue, optional } = blockProps;
+  const { mode } = usePageStateContext();
 
   const htmlID = `form-checkbox-${id}`;
   let value: boolean;
@@ -35,13 +38,16 @@ export const FormCheckbox = ({ blockProps }: FormCheckboxProps) => {
       htmlFor={htmlID}
       horizontal
       optional={optional}
+      onClickLabel={(event) => mode === "edit" && event.preventDefault()}
     >
-      <Checkbox
-        defaultChecked={value}
-        id={htmlID}
-        // remount when defaultValue changes
-        key={String(value)}
-      />
+      <StopPropagation asChild>
+        <Checkbox
+          defaultChecked={value}
+          id={htmlID}
+          // remount when defaultValue changes
+          key={String(value)}
+        />
+      </StopPropagation>
     </Fieldset>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormCheckbox.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormCheckbox.tsx
@@ -40,7 +40,7 @@ export const FormCheckbox = ({ blockProps }: FormCheckboxProps) => {
       optional={optional}
       onClickLabel={(event) => mode === "edit" && event.preventDefault()}
     >
-      <StopPropagation asChild>
+      <StopPropagation>
         <Checkbox
           defaultChecked={value}
           id={htmlID}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormDateInput/DatePicker.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormDateInput/DatePicker.tsx
@@ -16,12 +16,13 @@ type DatePickerProps = {
 
 export const DatePicker = ({ defaultValue, id }: DatePickerProps) => {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
   const [date, setDate] = useState<Date | undefined>(
     parseStringToDate(defaultValue)
   );
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={(open) => setOpen(open)}>
       <StopPropagation asChild>
         <PopoverTrigger asChild>
           <Button variant="outline">
@@ -33,12 +34,17 @@ export const DatePicker = ({ defaultValue, id }: DatePickerProps) => {
         </PopoverTrigger>
       </StopPropagation>
       <PopoverContent className="w-auto">
-        <DatepickerDesignComponent
-          id={id}
-          mode="single"
-          selected={date}
-          onSelect={setDate}
-        />
+        <StopPropagation>
+          <DatepickerDesignComponent
+            id={id}
+            mode="single"
+            selected={date}
+            onSelect={(date) => {
+              setOpen(false);
+              setDate(date);
+            }}
+          />
+        </StopPropagation>
       </PopoverContent>
     </Popover>
   );

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormDateInput/DatePicker.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormDateInput/DatePicker.tsx
@@ -22,7 +22,7 @@ export const DatePicker = ({ defaultValue, id }: DatePickerProps) => {
   );
 
   return (
-    <Popover open={open} onOpenChange={(open) => setOpen(open)}>
+    <Popover open={open} onOpenChange={setOpen}>
       <StopPropagation asChild>
         <PopoverTrigger asChild>
           <Button variant="outline">

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormDateInput/DatePicker.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormDateInput/DatePicker.tsx
@@ -23,7 +23,7 @@ export const DatePicker = ({ defaultValue, id }: DatePickerProps) => {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <StopPropagation asChild>
+      <StopPropagation>
         <PopoverTrigger asChild>
           <Button variant="outline">
             <CalendarIcon />{" "}
@@ -33,8 +33,8 @@ export const DatePicker = ({ defaultValue, id }: DatePickerProps) => {
           </Button>
         </PopoverTrigger>
       </StopPropagation>
-      <PopoverContent className="w-auto">
-        <StopPropagation>
+      <StopPropagation>
+        <PopoverContent className="w-auto">
           <DatepickerDesignComponent
             id={id}
             mode="single"
@@ -44,8 +44,8 @@ export const DatePicker = ({ defaultValue, id }: DatePickerProps) => {
               setDate(date);
             }}
           />
-        </StopPropagation>
-      </PopoverContent>
+        </PopoverContent>
+      </StopPropagation>
     </Popover>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormDateInput/DatePicker.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormDateInput/DatePicker.tsx
@@ -3,6 +3,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "~/design/Popover";
 import Button from "~/design/Button";
 import { CalendarIcon } from "lucide-react";
 import { Datepicker as DatepickerDesignComponent } from "~/design/Datepicker";
+import { StopPropagation } from "~/components/StopPropagation";
 import moment from "moment";
 import { parseStringToDate } from "./utils";
 import { useState } from "react";
@@ -21,14 +22,16 @@ export const DatePicker = ({ defaultValue, id }: DatePickerProps) => {
 
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        <Button variant="outline">
-          <CalendarIcon />{" "}
-          {date
-            ? moment(date).format("LL")
-            : t("direktivPage.page.blocks.form.datePickerPlaceholder")}
-        </Button>
-      </PopoverTrigger>
+      <StopPropagation asChild>
+        <PopoverTrigger asChild>
+          <Button variant="outline">
+            <CalendarIcon />{" "}
+            {date
+              ? moment(date).format("LL")
+              : t("direktivPage.page.blocks.form.datePickerPlaceholder")}
+          </Button>
+        </PopoverTrigger>
+      </StopPropagation>
       <PopoverContent className="w-auto">
         <DatepickerDesignComponent
           id={id}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormNumberInput.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormNumberInput.tsx
@@ -36,7 +36,7 @@ export const FormNumberInput = ({ blockProps }: FormNumberInputProps) => {
       htmlFor={htmlID}
       optional={optional}
     >
-      <StopPropagation asChild>
+      <StopPropagation>
         <Input
           type="number"
           defaultValue={value}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormNumberInput.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormNumberInput.tsx
@@ -1,6 +1,7 @@
 import { Fieldset } from "./utils/FieldSet";
 import { FormNumberInputType } from "../../../schema/blocks/form/numberInput";
 import Input from "~/design/Input";
+import { StopPropagation } from "~/components/StopPropagation";
 import { useTranslation } from "react-i18next";
 import { useVariableNumberResolver } from "../../primitives/Variable/utils/useVariableNumberResolver";
 
@@ -35,13 +36,15 @@ export const FormNumberInput = ({ blockProps }: FormNumberInputProps) => {
       htmlFor={htmlID}
       optional={optional}
     >
-      <Input
-        type="number"
-        defaultValue={value}
-        id={htmlID}
-        // remount when defaultValue changes
-        key={value}
-      />
+      <StopPropagation asChild>
+        <Input
+          type="number"
+          defaultValue={value}
+          id={htmlID}
+          // remount when defaultValue changes
+          key={value}
+        />
+      </StopPropagation>
     </Fieldset>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormSelect.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormSelect.tsx
@@ -46,7 +46,6 @@ export const FormSelect = ({ blockProps }: FormSelectProps) => {
             />
           </SelectTrigger>
         </StopPropagation>
-
         <SelectContent>
           {values.map((value) => (
             <SelectItem key={value} value={value}>

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormSelect.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormSelect.tsx
@@ -39,7 +39,7 @@ export const FormSelect = ({ blockProps }: FormSelectProps) => {
         // remount when defaultValue changes
         key={value}
       >
-        <StopPropagation asChild>
+        <StopPropagation>
           <SelectTrigger variant="outline" id={htmlID} value={value}>
             <SelectValue
               placeholder={t("direktivPage.page.blocks.form.selectPlaceholder")}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormSelect.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormSelect.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Fieldset } from "./utils/FieldSet";
 import { FormSelectType } from "../../../schema/blocks/form/select";
+import { StopPropagation } from "~/components/StopPropagation";
 import { useTemplateStringResolver } from "../../primitives/Variable/utils/useTemplateStringResolver";
 import { useTranslation } from "react-i18next";
 
@@ -38,11 +39,14 @@ export const FormSelect = ({ blockProps }: FormSelectProps) => {
         // remount when defaultValue changes
         key={value}
       >
-        <SelectTrigger variant="outline" id={htmlID} value={value}>
-          <SelectValue
-            placeholder={t("direktivPage.page.blocks.form.selectPlaceholder")}
-          />
-        </SelectTrigger>
+        <StopPropagation asChild>
+          <SelectTrigger variant="outline" id={htmlID} value={value}>
+            <SelectValue
+              placeholder={t("direktivPage.page.blocks.form.selectPlaceholder")}
+            />
+          </SelectTrigger>
+        </StopPropagation>
+
         <SelectContent>
           {values.map((value) => (
             <SelectItem key={value} value={value}>

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormStringInput.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormStringInput.tsx
@@ -23,7 +23,7 @@ export const FormStringInput = ({ blockProps }: FormStringInputProps) => {
       htmlFor={htmlID}
       optional={optional}
     >
-      <StopPropagation asChild>
+      <StopPropagation>
         <Input
           id={htmlID}
           defaultValue={value}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormStringInput.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormStringInput.tsx
@@ -1,6 +1,7 @@
 import { Fieldset } from "./utils/FieldSet";
 import { FormStringInputType } from "../../../schema/blocks/form/stringInput";
 import Input from "~/design/Input";
+import { StopPropagation } from "~/components/StopPropagation";
 import { useTemplateStringResolver } from "../../primitives/Variable/utils/useTemplateStringResolver";
 
 type FormStringInputProps = {
@@ -22,13 +23,15 @@ export const FormStringInput = ({ blockProps }: FormStringInputProps) => {
       htmlFor={htmlID}
       optional={optional}
     >
-      <Input
-        id={htmlID}
-        defaultValue={value}
-        type={variant}
-        // remount when defaultValue changes
-        key={value}
-      />
+      <StopPropagation asChild>
+        <Input
+          id={htmlID}
+          defaultValue={value}
+          type={variant}
+          // remount when defaultValue changes
+          key={value}
+        />
+      </StopPropagation>
     </Fieldset>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormTextarea.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormTextarea.tsx
@@ -1,5 +1,6 @@
 import { Fieldset } from "./utils/FieldSet";
 import { FormTextareaType } from "../../../schema/blocks/form/textarea";
+import { StopPropagation } from "~/components/StopPropagation";
 import { Textarea } from "~/design/TextArea";
 import { useTemplateStringResolver } from "../../primitives/Variable/utils/useTemplateStringResolver";
 
@@ -21,12 +22,14 @@ export const FormTextarea = ({ blockProps }: FormTextareaProps) => {
       htmlFor={htmlID}
       optional={optional}
     >
-      <Textarea
-        defaultValue={value}
-        id={htmlID}
-        // remount when defaultValue changes
-        key={value}
-      />
+      <StopPropagation asChild>
+        <Textarea
+          defaultValue={value}
+          id={htmlID}
+          // remount when defaultValue changes
+          key={value}
+        />
+      </StopPropagation>
     </Fieldset>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormTextarea.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/FormTextarea.tsx
@@ -22,7 +22,7 @@ export const FormTextarea = ({ blockProps }: FormTextareaProps) => {
       htmlFor={htmlID}
       optional={optional}
     >
-      <StopPropagation asChild>
+      <StopPropagation>
         <Textarea
           defaultValue={value}
           id={htmlID}

--- a/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/utils/FieldSet.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/PageCompiler/Block/formPrimitives/utils/FieldSet.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from "react";
+import { FC, MouseEvent, PropsWithChildren } from "react";
 
 import { TemplateString } from "../../../primitives/TemplateString";
 import { twMergeClsx } from "~/util/helpers";
@@ -10,6 +10,7 @@ type FieldsetProps = PropsWithChildren & {
   htmlFor: string;
   optional: boolean;
   horizontal?: boolean;
+  onClickLabel?: (event: MouseEvent<HTMLElement>) => void;
 };
 
 export const Fieldset: FC<FieldsetProps> = ({
@@ -19,11 +20,16 @@ export const Fieldset: FC<FieldsetProps> = ({
   htmlFor,
   horizontal,
   optional,
+  onClickLabel,
 }) => {
   const { t } = useTranslation();
   return (
     <fieldset className="flex flex-col gap-1">
-      <label className="flex grow gap-1 text-sm font-bold" htmlFor={htmlFor}>
+      <label
+        className="flex grow gap-1 text-sm font-bold"
+        htmlFor={htmlFor}
+        onClick={onClickLabel}
+      >
         <span>
           <TemplateString value={label} />
         </span>


### PR DESCRIPTION
## Description

This fixes the onClick behavior of form elements in the page editor.

* I have created a <StopPropagation> helper component that will do just that, and wrapped form elements in it (easier than adding the onClick prop manually, and also easy to read).
* Clicking on the label should still always trigger the side panel (there is no other way to reliably focus/unfocus when no description exists for a form element). 
* For the checkbox, I have even added logic that overrides the label's default behavior (toggling the checkbox) when in edit mode.
* For the date picker, I also have added code that will close it when a date has been selected (previously it stayed open).

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
