### PR TITLE
[TDI-129][TDI-130] Add variable picker to pointers, table, query-provider (url)

### DIFF
--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Form/Checkbox.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Form/Checkbox.tsx
@@ -18,7 +18,6 @@ import { BlockEditFormProps } from "..";
 import { Checkbox as CheckboxDesignComponent } from "~/design/Checkbox";
 import { Fieldset } from "~/components/Form/Fieldset";
 import { FormWrapper } from "../components/FormWrapper";
-import Input from "~/design/Input";
 import { VariableInput } from "../components/VariableInput";
 import { useTranslation } from "react-i18next";
 import z from "zod";

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Form/Checkbox.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Form/Checkbox.tsx
@@ -19,6 +19,7 @@ import { Checkbox as CheckboxDesignComponent } from "~/design/Checkbox";
 import { Fieldset } from "~/components/Form/Fieldset";
 import { FormWrapper } from "../components/FormWrapper";
 import Input from "~/design/Input";
+import { VariableInput } from "../components/VariableInput";
 import { useTranslation } from "react-i18next";
 import z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -134,9 +135,11 @@ export const Checkbox = ({
                   : "";
 
                 return (
-                  <Input
-                    {...field}
+                  <VariableInput
                     value={defaultValue}
+                    onUpdate={(value) =>
+                      form.setValue("defaultValue.value", value)
+                    }
                     placeholder={t(
                       "direktivPage.blockEditor.blockForms.formPrimitives.defaultValue.placeholderVariable"
                     )}

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Form/NumberInput.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Form/NumberInput.tsx
@@ -18,6 +18,7 @@ import { BlockEditFormProps } from "..";
 import { Fieldset } from "~/components/Form/Fieldset";
 import { FormWrapper } from "../components/FormWrapper";
 import Input from "~/design/Input";
+import { VariableInput } from "../components/VariableInput";
 import { useTranslation } from "react-i18next";
 import z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -133,9 +134,11 @@ export const NumberInput = ({
                   : "";
 
                 return (
-                  <Input
-                    {...field}
+                  <VariableInput
                     value={defaultValue}
+                    onUpdate={(value) =>
+                      form.setValue("defaultValue.value", value)
+                    }
                     placeholder={t(
                       "direktivPage.blockEditor.blockForms.formPrimitives.defaultValue.placeholderVariable"
                     )}

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Loop.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Loop.tsx
@@ -4,6 +4,7 @@ import { BlockEditFormProps } from ".";
 import { Fieldset } from "~/components/Form/Fieldset";
 import { FormWrapper } from "./components/FormWrapper";
 import Input from "~/design/Input";
+import { VariableInput } from "./components/VariableInput";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -49,9 +50,10 @@ export const Loop = ({
         label={t("direktivPage.blockEditor.blockForms.loop.dataLabel")}
         htmlFor="data"
       >
-        <Input
-          {...form.register("data")}
-          id="data"
+        <VariableInput
+          value={form.watch("data")}
+          onUpdate={(value) => form.setValue("data", value)}
+          id="data-data"
           placeholder={t(
             "direktivPage.blockEditor.blockForms.loop.dataPlaceholder"
           )}

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/QueryProvider/QueryForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/QueryProvider/QueryForm.tsx
@@ -5,6 +5,7 @@ import { Query, QueryType } from "../../schema/procedures/query";
 import { Fieldset } from "~/components/Form/Fieldset";
 import Input from "~/design/Input";
 import { KeyValueInput } from "../components/FormElements/KeyValueInput";
+import { SmartInput } from "../components/SmartInput";
 import { useTranslation } from "react-i18next";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -21,6 +22,8 @@ export const QueryForm = ({
 }: QueryFormProps) => {
   const { t } = useTranslation();
   const {
+    watch,
+    setValue,
     handleSubmit,
     register,
     control,
@@ -63,8 +66,9 @@ export const QueryForm = ({
         )}
         htmlFor="url"
       >
-        <Input
-          {...register("url")}
+        <SmartInput
+          value={watch("url")}
+          onUpdate={(value) => setValue("url", value)}
           id="url"
           placeholder={t(
             "direktivPage.blockEditor.blockForms.queryProvider.query.urlPlaceholder"

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Table/ColumnForm.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Table/ColumnForm.tsx
@@ -6,6 +6,7 @@ import {
 
 import { Fieldset } from "~/components/Form/Fieldset";
 import Input from "~/design/Input";
+import { SmartInput } from "../components/SmartInput";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -23,9 +24,11 @@ export const ColumnForm = ({
 }: ColumnFormProps) => {
   const { t } = useTranslation();
   const {
+    formState: { errors },
     handleSubmit,
     register,
-    formState: { errors },
+    setValue,
+    watch,
   } = useForm<TableColumnType>({
     resolver: zodResolver(TableColumn),
     defaultValues: {
@@ -62,8 +65,9 @@ export const ColumnForm = ({
         )}
         htmlFor="content"
       >
-        <Input
-          {...register("content")}
+        <SmartInput
+          value={watch("content")}
+          onUpdate={(value) => setValue("content", value)}
           id="content"
           placeholder={t(
             "direktivPage.blockEditor.blockForms.table.column.contentPlaceholder"

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Table/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Table/index.tsx
@@ -7,7 +7,7 @@ import { Fieldset } from "~/components/Form/Fieldset";
 import { FormWrapper } from "../components/FormWrapper";
 import Input from "~/design/Input";
 import { Table as TableForm } from "../components/FormElements/Table";
-import { VariablePicker } from "../components/VariablePicker";
+import { VariableInput } from "../components/VariableInput";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -53,7 +53,7 @@ export const Table = ({
         label={t("direktivPage.blockEditor.blockForms.table.data.dataLabel")}
         htmlFor="data-data"
       >
-        <VariablePicker
+        <VariableInput
           value={form.watch("data.data")}
           onUpdate={(value) => form.setValue("data.data", value)}
           id="data-data"

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Table/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/Table/index.tsx
@@ -7,6 +7,7 @@ import { Fieldset } from "~/components/Form/Fieldset";
 import { FormWrapper } from "../components/FormWrapper";
 import Input from "~/design/Input";
 import { Table as TableForm } from "../components/FormElements/Table";
+import { VariablePicker } from "../components/VariablePicker";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -52,8 +53,9 @@ export const Table = ({
         label={t("direktivPage.blockEditor.blockForms.table.data.dataLabel")}
         htmlFor="data-data"
       >
-        <Input
-          {...form.register("data.data")}
+        <VariablePicker
+          value={form.watch("data.data")}
+          onUpdate={(value) => form.setValue("data.data", value)}
           id="data-data"
           placeholder={t(
             "direktivPage.blockEditor.blockForms.table.data.dataPlaceholder"

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/FormElements/ExtendedKeyValueInput/VariableValueInput.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/FormElements/ExtendedKeyValueInput/VariableValueInput.tsx
@@ -1,4 +1,4 @@
-import Input from "~/design/Input";
+import { VariableInput } from "../../VariableInput";
 import { useTranslation } from "react-i18next";
 
 type VariableValueInputProps = {
@@ -12,10 +12,10 @@ export const VariableValueInput = ({
 }: VariableValueInputProps) => {
   const { t } = useTranslation();
   return (
-    <Input
+    <VariableInput
       placeholder={t("direktivPage.blockEditor.blockForms.keyValue.variable")}
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onUpdate={(value) => onChange(value)}
     />
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/SmartInput/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/SmartInput/index.tsx
@@ -105,7 +105,7 @@ export const SmartInput = ({
                       textarea &&
                       addSnippetToInputValue({
                         element: textarea,
-                        snippet,
+                        snippet: `{{${snippet}}}`,
                         value,
                         callback: onUpdate,
                       })

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/SmartInput/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/SmartInput/index.tsx
@@ -98,7 +98,6 @@ export const SmartInput = ({
               <div className="rounded-t-md border border-b-0 border-gray-4 p-2 dark:border-gray-dark-7">
                 <ButtonBar>
                   <TreePicker
-                    label={t("direktivPage.blockEditor.smartInput.variableBtn")}
                     container={dialogContainer ?? undefined}
                     tree={variables}
                     onSubmit={(snippet) =>
@@ -112,7 +111,15 @@ export const SmartInput = ({
                     }
                     preview={(path) => <Preview path={path} />}
                     preventSubmit={preventSubmit}
-                  />
+                  >
+                    <Button
+                      variant="outline"
+                      type="button"
+                      className="dark:border-gray-dark-7"
+                    >
+                      {t("direktivPage.blockEditor.smartInput.variableBtn")}
+                    </Button>
+                  </TreePicker>
                   <Popover>
                     <PopoverTrigger asChild>
                       <Button

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/TreePicker/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/TreePicker/index.tsx
@@ -1,4 +1,4 @@
-import { Check, Plus, X } from "lucide-react";
+import { Check, Locate, Plus, X } from "lucide-react";
 import {
   Command,
   CommandEmpty,
@@ -21,7 +21,7 @@ import { FakeInput } from "~/design/FakeInput";
 import { useTranslation } from "react-i18next";
 
 type TreePickerProps = {
-  label: string;
+  label?: string;
   tree: Tree;
   onSubmit: (value: string) => void;
   preventSubmit: (path: string[]) => boolean;
@@ -55,13 +55,24 @@ export const TreePicker: FC<TreePickerProps> = ({
     <Popover>
       <div className="flex">
         <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            type="button"
-            className="dark:border-gray-dark-7"
-          >
-            {label}
-          </Button>
+          {label ? (
+            <Button
+              variant="outline"
+              type="button"
+              className="dark:border-gray-dark-7"
+            >
+              {label}
+            </Button>
+          ) : (
+            <Button
+              icon
+              variant="ghost"
+              type="button"
+              className="dark:border-gray-dark-7"
+            >
+              <Locate />
+            </Button>
+          )}
         </PopoverTrigger>
       </div>
       <PopoverContent className="w-96" align="start" container={container}>

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/TreePicker/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/TreePicker/index.tsx
@@ -44,7 +44,7 @@ export const TreePicker: FC<TreePickerProps> = ({
   const disabled = useMemo(() => preventSubmit(path), [preventSubmit, path]);
 
   const allowCustomSegment = search.length > 0;
-  const formattedPath = `{{${path.join(".")}}}`;
+  const formattedPath = path.join(".");
 
   const addCustomSegment = () => {
     setPath([...path, search]);

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/TreePicker/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/TreePicker/index.tsx
@@ -1,4 +1,4 @@
-import { Check, Locate, Plus, X } from "lucide-react";
+import { Check, Plus, X } from "lucide-react";
 import {
   Command,
   CommandEmpty,
@@ -7,7 +7,7 @@ import {
   CommandItem,
   CommandList,
 } from "~/design/Command";
-import { FC, ReactNode, useMemo, useState } from "react";
+import { FC, ReactElement, ReactNode, useMemo, useState } from "react";
 import {
   Popover,
   PopoverClose,
@@ -21,17 +21,17 @@ import { FakeInput } from "~/design/FakeInput";
 import { useTranslation } from "react-i18next";
 
 type TreePickerProps = {
-  label?: string;
   tree: Tree;
   onSubmit: (value: string) => void;
   preventSubmit: (path: string[]) => boolean;
   container?: HTMLDivElement;
   preview: (path: string[]) => ReactNode;
+  children: ReactElement<HTMLButtonElement>;
 };
 
 export const TreePicker: FC<TreePickerProps> = ({
-  label,
   tree,
+  children,
   container,
   preventSubmit = () => false,
   onSubmit,
@@ -54,26 +54,7 @@ export const TreePicker: FC<TreePickerProps> = ({
   return (
     <Popover>
       <div className="flex">
-        <PopoverTrigger asChild>
-          {label ? (
-            <Button
-              variant="outline"
-              type="button"
-              className="dark:border-gray-dark-7"
-            >
-              {label}
-            </Button>
-          ) : (
-            <Button
-              icon
-              variant="ghost"
-              type="button"
-              className="dark:border-gray-dark-7"
-            >
-              <Locate />
-            </Button>
-          )}
-        </PopoverTrigger>
+        <PopoverTrigger asChild>{children}</PopoverTrigger>
       </div>
       <PopoverContent className="w-96" align="start" container={container}>
         <Command>

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/VariableInput/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/VariableInput/index.tsx
@@ -2,14 +2,16 @@ import {
   VariableNamespace,
   localVariableNamespace,
 } from "../../../schema/primitives/variable";
-import { useCallback, useState } from "react";
 
+import Input from "~/design/Input";
+import { InputWithButton } from "~/design/InputWithButton";
 import { Preview } from "../SmartInput/Preview";
 import { TreePicker } from "../TreePicker";
+import { useCallback } from "react";
 import { usePageEditorPanel } from "../../EditorPanelProvider";
-import { useTranslation } from "react-i18next";
 
-export const VariablePicker = ({
+export const VariableInput = ({
+  value,
   onUpdate,
   blacklist,
   id,
@@ -21,7 +23,6 @@ export const VariablePicker = ({
   placeholder: string;
   blacklist?: VariableNamespace[];
 }) => {
-  const { t } = useTranslation();
   const { panel } = usePageEditorPanel();
 
   const preventSubmit = useCallback((path: string[]) => {
@@ -41,12 +42,14 @@ export const VariablePicker = ({
   );
 
   return (
-    <TreePicker
-      label={t("direktivPage.blockEditor.smartInput.variableBtn")}
-      tree={variables}
-      onSubmit={(variable) => onUpdate(variable)}
-      preview={(path) => <Preview path={path} />}
-      preventSubmit={preventSubmit}
-    />
+    <InputWithButton>
+      <Input id={id} value={value} placeholder={placeholder} />
+      <TreePicker
+        tree={variables}
+        onSubmit={(variable) => onUpdate(variable)}
+        preview={(path) => <Preview path={path} />}
+        preventSubmit={preventSubmit}
+      />
+    </InputWithButton>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/VariableInput/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/VariableInput/index.tsx
@@ -3,8 +3,10 @@ import {
   localVariableNamespace,
 } from "../../../schema/primitives/variable";
 
+import Button from "~/design/Button";
 import Input from "~/design/Input";
 import { InputWithButton } from "~/design/InputWithButton";
+import { Locate } from "lucide-react";
 import { Preview } from "../SmartInput/Preview";
 import { TreePicker } from "../TreePicker";
 import { useCallback } from "react";
@@ -54,7 +56,16 @@ export const VariableInput = ({
         onSubmit={(variable) => onUpdate(variable)}
         preview={(path) => <Preview path={path} />}
         preventSubmit={preventSubmit}
-      />
+      >
+        <Button
+          icon
+          variant="ghost"
+          type="button"
+          className="dark:border-gray-dark-7"
+        >
+          <Locate />
+        </Button>
+      </TreePicker>
     </InputWithButton>
   );
 };

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/VariableInput/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/VariableInput/index.tsx
@@ -43,7 +43,12 @@ export const VariableInput = ({
 
   return (
     <InputWithButton>
-      <Input id={id} value={value} placeholder={placeholder} />
+      <Input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onUpdate(event.target.value)}
+      />
       <TreePicker
         tree={variables}
         onSubmit={(variable) => onUpdate(variable)}

--- a/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/VariablePicker/index.tsx
+++ b/ui/src/pages/namespace/Explorer/Page/poc/BlockEditor/components/VariablePicker/index.tsx
@@ -1,0 +1,52 @@
+import {
+  VariableNamespace,
+  localVariableNamespace,
+} from "../../../schema/primitives/variable";
+import { useCallback, useState } from "react";
+
+import { Preview } from "../SmartInput/Preview";
+import { TreePicker } from "../TreePicker";
+import { usePageEditorPanel } from "../../EditorPanelProvider";
+import { useTranslation } from "react-i18next";
+
+export const VariablePicker = ({
+  onUpdate,
+  blacklist,
+  id,
+  placeholder,
+}: {
+  onUpdate: (value: string) => void;
+  value: string;
+  id?: string;
+  placeholder: string;
+  blacklist?: VariableNamespace[];
+}) => {
+  const { t } = useTranslation();
+  const { panel } = usePageEditorPanel();
+
+  const preventSubmit = useCallback((path: string[]) => {
+    if (path[0] === localVariableNamespace && path.length > 1) return false;
+    if (path.length > 2) return false;
+    return true;
+  }, []);
+
+  if (!panel) return null;
+
+  const { variables: allVariables } = panel;
+
+  const variables = Object.fromEntries(
+    Object.entries(allVariables).filter(
+      ([key]) => !(blacklist as string[])?.includes(key)
+    )
+  );
+
+  return (
+    <TreePicker
+      label={t("direktivPage.blockEditor.smartInput.variableBtn")}
+      tree={variables}
+      onSubmit={(variable) => onUpdate(variable)}
+      preview={(path) => <Preview path={path} />}
+      preventSubmit={preventSubmit}
+    />
+  );
+};


### PR DESCRIPTION
## Description

This adds variable pickers to individual fields where it was still missing (TDI-129), and also implements a `<VariableInput />` component for fields that contain only a variable (not a template string).

The VariableInput is a minimal "MVP" implementation that could be realized quite quickly with the existing TreePicker. There is room for a few possible improvements, including better UI or hints to help the user understand that they are replacing the input value when they pick a variable, or editing existing variable pointers. However, in terms of covering the basics, I am already quite happy with this.

@stefan-kracht I am marking this as "ready for review", but as discussed, you're welcome to improve it further while I am away.

<img width="698" height="360" alt="image" src="https://github.com/user-attachments/assets/ec741d52-ebed-41b2-8ad6-c12f7e235ef1" />

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
