### PR TITLE
[TDI-149] remove base64 encoding for instance object fields

### DIFF
--- a/cmd/cli/filesystem_helper.go
+++ b/cmd/cli/filesystem_helper.go
@@ -150,7 +150,7 @@ func handleOutput(profile profile, uploader *uploader, id string) error {
 			continue
 		}
 
-		fmt.Printf("Output:\n%s\n", string(instance.Data.Output))
+		fmt.Printf("Output:\n%v\n", instance.Data.Output)
 
 		break
 	}

--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -36,12 +36,12 @@ type InstanceData struct {
 	Lineage      []*LineageData `json:"lineage"`
 	Namespace    string         `json:"namespace"`
 
-	InputLength    int    `json:"inputLength"`
-	Input          []byte `json:"input"`
-	OutputLength   int    `json:"outputLength"`
-	Output         []byte `json:"output"`
-	MetadataLength int    `json:"metadataLength"`
-	Metadata       []byte `json:"metadata"`
+	InputLength    int     `json:"inputLength"`
+	Input          []byte  `json:"input"`
+	OutputLength   int     `json:"outputLength"`
+	Output         *string `json:"output"`
+	MetadataLength int     `json:"metadataLength"`
+	Metadata       []byte  `json:"metadata"`
 }
 
 type instController struct {
@@ -70,10 +70,13 @@ func convertInstanceData(data *engine.InstanceStatus) *InstanceData {
 		OutputLength:   len(data.Output),
 		MetadataLength: len(data.Metadata),
 		Input:          data.Input,
-		Output:         data.Output,
 	}
 	if !data.EndedAt.IsZero() {
 		resp.EndedAt = &data.EndedAt
+	}
+	if data.Output != nil {
+		s := string(data.Output)
+		resp.Output = &s
 	}
 	if data.Error != "" {
 		resp.ErrorMessage = []byte(data.Error)

--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -37,7 +37,7 @@ type InstanceData struct {
 	Namespace    string         `json:"namespace"`
 
 	InputLength    int     `json:"inputLength"`
-	Input          []byte  `json:"input"`
+	Input          string  `json:"input"`
 	OutputLength   int     `json:"outputLength"`
 	Output         *string `json:"output"`
 	MetadataLength int     `json:"metadataLength"`
@@ -67,9 +67,9 @@ func convertInstanceData(data *engine.InstanceStatus) *InstanceData {
 		Lineage:        []*LineageData{},
 		Namespace:      data.Namespace,
 		InputLength:    len(data.Input),
+		Input:          string(data.Input),
 		OutputLength:   len(data.Output),
 		MetadataLength: len(data.Metadata),
-		Input:          data.Input,
 	}
 	if !data.EndedAt.IsZero() {
 		resp.EndedAt = &data.EndedAt

--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -31,7 +31,7 @@ type InstanceData struct {
 	ErrorCode    *string        `json:"errorCode"`
 	Invoker      string         `json:"invoker"`
 	Definition   []byte         `json:"definition,omitempty"`
-	ErrorMessage []byte         `json:"errorMessage"`
+	ErrorMessage *string        `json:"errorMessage"`
 	Flow         []string       `json:"flow"`
 	TraceID      string         `json:"traceId"`
 	Lineage      []*LineageData `json:"lineage"`
@@ -80,7 +80,7 @@ func convertInstanceData(data *engine.InstanceStatus) *InstanceData {
 		resp.Output = &s
 	}
 	if data.Error != "" {
-		resp.ErrorMessage = []byte(data.Error)
+		resp.ErrorMessage = &data.Error
 	}
 
 	return resp

--- a/tests/engine/create_run_workflow.test.js
+++ b/tests/engine/create_run_workflow.test.js
@@ -15,7 +15,7 @@ describe('Test js engine', () => {
 	const testCases = [
 		{ name: 'singleStep.wf.ts',
 			input: { foo: 'bar' },
-			wantOutput: btoa(JSON.stringify('done')),
+			wantOutput: JSON.stringify('done'),
 			wantErrorMessage: null,
 			wantStatus: 'complete',
 			file: `
@@ -24,7 +24,7 @@ function stateOne(payload) {
 }`		},
 		{ name: 'twoSteps.wf.ts',
 			input: JSON.stringify({ foo: 'bar' }),
-			wantOutput: btoa(JSON.stringify({ bar: 'foo', foo: 'bar' })),
+			wantOutput: JSON.stringify({ bar: 'foo', foo: 'bar' }),
 			wantErrorMessage: null,
 			wantStatus: 'complete',
 			file: `
@@ -39,7 +39,7 @@ function stateTwo(payload) {
 }`		},
 		{ name: 'stringInput.wf.ts',
 			input: JSON.stringify("hello"),
-			wantOutput: btoa(JSON.stringify('helloWorld')),
+			wantOutput: JSON.stringify('helloWorld'),
 			wantErrorMessage: null,
 			wantStatus: 'complete',
 			file: `
@@ -48,7 +48,7 @@ function stateOne(payload) {
 }`		},
 		{ name: 'numberInput.wf.ts',
 			input: JSON.stringify(146),
-			wantOutput: btoa(JSON.stringify(147)),
+			wantOutput: JSON.stringify(147),
 			wantErrorMessage: null,
 			wantStatus: 'complete',
 			file: `

--- a/tests/engine/create_run_workflow.test.js
+++ b/tests/engine/create_run_workflow.test.js
@@ -58,7 +58,7 @@ function stateOne(payload) {
 		{ name: 'throwError.wf.ts',
 			input: JSON.stringify("anything"),
 			wantOutput: null,
-			wantErrorMessage: btoa("invoke start: simply failed at stateOne (throwError.wf.ts:3:1(2))"),
+			wantErrorMessage: "invoke start: simply failed at stateOne (throwError.wf.ts:3:1(2))",
 			wantStatus: 'failed',
 			file: `
 function stateOne(payload) {

--- a/ui/src/pages/namespace/Instances/Detail/Main/InputOutput/Input.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/InputOutput/Input.tsx
@@ -1,6 +1,5 @@
 import Editor from "~/design/Editor";
 import Toolbar from "./Toolbar";
-import { decode } from "js-base64";
 import { forwardRef } from "react";
 import { prettifyJsonString } from "~/util/helpers";
 import { useInstanceId } from "../../store/instanceContext";
@@ -12,7 +11,7 @@ const Input = forwardRef<HTMLDivElement>((_, ref) => {
   const { data } = useInstanceInput({ instanceId });
   const theme = useTheme();
 
-  const workflowInput = decode(data?.input ?? "");
+  const workflowInput = data?.input ?? "";
   const workflowInputPretty = prettifyJsonString(workflowInput);
 
   return (

--- a/ui/src/pages/namespace/Instances/Detail/Main/InputOutput/Output.tsx
+++ b/ui/src/pages/namespace/Instances/Detail/Main/InputOutput/Output.tsx
@@ -1,7 +1,6 @@
 import Editor from "~/design/Editor";
 import InfoText from "./OutputInfo";
 import Toolbar from "./Toolbar";
-import { decode } from "js-base64";
 import { forwardRef } from "react";
 import { prettifyJsonString } from "~/util/helpers";
 import { useInstanceId } from "../../store/instanceContext";
@@ -39,7 +38,7 @@ const Output = forwardRef<
     );
   }
 
-  const workflowOutput = decode(data?.output ?? "");
+  const workflowOutput = data?.output ?? "";
   const workflowOutputPretty = prettifyJsonString(workflowOutput);
 
   return (

--- a/ui/src/pages/namespace/Instances/List/Row.tsx
+++ b/ui/src/pages/namespace/Instances/List/Row.tsx
@@ -17,7 +17,6 @@ import { ConditionalWrapper } from "~/util/helpers";
 import { FC } from "react";
 import { InstanceSchemaType } from "~/api/instances/schema";
 import TooltipCopyBadge from "~/design/TooltipCopyBadge";
-import { decode } from "js-base64";
 import moment from "moment";
 import { statusToBadgeVariant } from "../utils";
 import { useNavigate } from "@tanstack/react-router";
@@ -84,7 +83,7 @@ const InstanceTableRow: FC<{
                   <Alert variant="error">
                     <span className="font-bold">{instance.errorCode}</span>
                     <br />
-                    {instance.errorMessage && decode(instance.errorMessage)}
+                    {instance.errorMessage && instance.errorMessage}
                   </Alert>
                 </HoverCardContent>
               </HoverCard>


### PR DESCRIPTION
## Description

This change removes the base64 encoding from instance's **errorMessage**, **input** and **output** fields. Fields **input** and **output** are json values which are safe. Field **errorMessage** is a human readable text.

## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
