### PR TITLE
[TDI-392] Add UI support for files in actions

### DIFF
--- a/internal/engine/runtime/runtime_action.go
+++ b/internal/engine/runtime/runtime_action.go
@@ -30,6 +30,35 @@ type fileSpec struct {
 	Permission string
 }
 
+func (rt *Runtime) parseTimeout(raw any) time.Duration {
+	if raw == nil {
+		return defaultTimeout
+	}
+
+	timeout, ok := raw.(string)
+	if !ok {
+		panic(rt.vm.ToValue(fmt.Errorf("timeout must be a string")))
+	}
+	if timeout == "" {
+		return defaultTimeout
+	}
+
+	to, err := duration.Parse(timeout)
+	if err != nil {
+		panic(rt.vm.ToValue(fmt.Errorf("timeout not a valid ISO8601 string, e.g. PT1M")))
+	}
+
+	return to.ToTimeDuration()
+}
+
+func (rt *Runtime) parseFilesOptional(raw any) []fileSpec {
+	if raw == nil {
+		return nil
+	}
+
+	return rt.parseFiles(raw)
+}
+
 func (rt *Runtime) parseFiles(raw any) []fileSpec {
 	filesArr, ok := raw.([]any)
 	if !ok {
@@ -71,6 +100,15 @@ func (rt *Runtime) parseFiles(raw any) []fileSpec {
 	return specs
 }
 
+func (rt *Runtime) invoke(sd *core.ServiceFileData, payload any, retries int, timeout time.Duration, auth *core.BasicAuthConfig, files []fileSpec) sobek.Value {
+	data, err := rt.callAction(sd, payload, retries, timeout, auth, files)
+	if err != nil {
+		panic(rt.vm.ToValue(err))
+	}
+
+	return rt.vm.ToValue(data)
+}
+
 func (rt *Runtime) service(c map[string]any) sobek.Value {
 	// func (rt *Runtime) service(t, path string, payload any, retries int) sobek.Value {
 
@@ -99,22 +137,7 @@ func (rt *Runtime) service(c map[string]any) sobek.Value {
 		panic(rt.vm.ToValue(fmt.Errorf("retries must be an integer")))
 	}
 
-	endDuration := defaultTimeout
-
-	to, ok := c["timeout"]
-	if ok {
-		timeout, ok := to.(string)
-		if !ok {
-			panic(rt.vm.ToValue(fmt.Errorf("timeout must be a string")))
-		}
-
-		to, err := duration.Parse(timeout)
-		if err != nil {
-			panic(rt.vm.ToValue(fmt.Errorf("timeout not a valid ISO8601 string, e.g. PT1M")))
-		}
-
-		endDuration = to.ToTimeDuration()
-	}
+	endDuration := rt.parseTimeout(c["timeout"])
 
 	telemetry.LogInstance(rt.tracingPack.ctx, telemetry.LogLevelInfo,
 		fmt.Sprintf("service call timeout in %s", endDuration.String()))
@@ -143,20 +166,12 @@ func (rt *Runtime) service(c map[string]any) sobek.Value {
 	}
 
 	// parse file specs to pass along as headers to the sidecar
-	var files []fileSpec
-	if rawFiles, ok := c["files"]; ok {
-		files = rt.parseFiles(rawFiles)
-	}
+	files := rt.parseFilesOptional(c["files"])
 
 	telemetry.LogInstance(rt.tracingPack.ctx, telemetry.LogLevelInfo,
 		fmt.Sprintf("executing service %s in scope %s", path, t))
 
-	data, err := rt.callAction(sd, payload, int(retries), endDuration, nil, files)
-	if err != nil {
-		panic(rt.vm.ToValue(err))
-	}
-
-	return rt.vm.ToValue(data)
+	return rt.invoke(sd, payload, int(retries), endDuration, nil, files)
 }
 
 func (rt *Runtime) action(c map[string]any) sobek.Value {
@@ -213,26 +228,12 @@ func (rt *Runtime) action(c map[string]any) sobek.Value {
 		telemetry.LogInstance(rt.tracingPack.ctx, telemetry.LogLevelInfo,
 			fmt.Sprintf("executing action with image %s", config.Image))
 
-		endDuration := defaultTimeout
-
-		if timeout != "" {
-			to, err := duration.Parse(timeout)
-			if err != nil {
-				panic(rt.vm.ToValue(fmt.Errorf("timeout not a valid ISO8601 string, e.g. PT1M")))
-			}
-
-			endDuration = to.ToTimeDuration()
-		}
+		endDuration := rt.parseTimeout(timeout)
 
 		telemetry.LogInstance(rt.tracingPack.ctx, telemetry.LogLevelInfo,
 			fmt.Sprintf("action timeout in %s", endDuration.String()))
 
-		data, err := rt.callAction(sd, payload, config.Retries, endDuration, config.Auth, files)
-		if err != nil {
-			panic(rt.vm.ToValue(err))
-		}
-
-		return rt.vm.ToValue(data)
+		return rt.invoke(sd, payload, config.Retries, endDuration, config.Auth, files)
 	}
 
 	return rt.vm.ToValue(actionFunc)

--- a/internal/engine/runtime/runtime_action.go
+++ b/internal/engine/runtime/runtime_action.go
@@ -198,32 +198,20 @@ func (rt *Runtime) action(c map[string]any) sobek.Value {
 	sd.Name = sd.GetValueHash()
 
 	actionFunc := func(call sobek.FunctionCall) sobek.Value {
-		var payload any
-		if len(call.Arguments) > 0 {
-			if err := rt.vm.ExportTo(call.Arguments[0], &payload); err != nil {
-				panic(rt.vm.ToValue(fmt.Sprintf("error exporting action payload: %s", err.Error())))
+		var cfg map[string]any
+		if len(call.Arguments) > 0 && call.Arguments[0] != nil {
+			if err := rt.vm.ExportTo(call.Arguments[0], &cfg); err != nil {
+				panic(rt.vm.ToValue(fmt.Sprintf("error exporting action config: %s", err.Error())))
 			}
 		}
-
-		var (
-			timeout string
-			files   []fileSpec
-		)
-
-		// second argument is an optional options object: { timeout: "PT15M", files: [...] }
-		if len(call.Arguments) > 1 {
-			var opts map[string]any
-			if err := rt.vm.ExportTo(call.Arguments[1], &opts); err != nil {
-				panic(rt.vm.ToValue(fmt.Sprintf("error exporting action options: %s", err.Error())))
-			}
-
-			if t, ok := opts["timeout"].(string); ok {
-				timeout = t
-			}
-			if rawFiles, ok := opts["files"]; ok && rawFiles != nil {
-				files = rt.parseFiles(rawFiles)
-			}
+		if cfg == nil {
+			cfg = map[string]any{}
 		}
+
+		payload := cfg["payload"]
+
+		timeout, _ := cfg["timeout"].(string)
+		files := rt.parseFilesOptional(cfg["files"])
 
 		telemetry.LogInstance(rt.tracingPack.ctx, telemetry.LogLevelInfo,
 			fmt.Sprintf("executing action with image %s", config.Image))

--- a/tests/actions/fixtures.js
+++ b/tests/actions/fixtures.js
@@ -25,7 +25,7 @@ function stateFirst() {
     ],
   };
 
-  const result = bash(payload);
+  const result = bash({ payload });
   return finish(result);
 }
 `
@@ -57,7 +57,7 @@ function stateFirst() {
     ],
   };
 
-  const result = bash(payload);
+  const result = bash({ payload });
   return finish(result);
 }
 `
@@ -76,7 +76,7 @@ const echo = generateAction({
 });
 
 function stateFirst(input: unknown) {
-  const result = echo(input);
+  const result = echo({ payload: input });
   return finish(result);
 }
 `
@@ -100,11 +100,9 @@ const echo = generateAction({
 });
 
 function stateFirst() {
-  const bashResult = bash({
-    commands: [{ command: "echo hi" }],
-  });
+  const bashResult = bash({ payload: { commands: [{ command: "echo hi" }] } });
 
-  const echoResult = echo({ hi: "there" });
+  const echoResult = echo({ payload: { hi: "there" } });
 
   return finish({
     bash: bashResult,

--- a/tests/actions/fixtures.js
+++ b/tests/actions/fixtures.js
@@ -110,3 +110,38 @@ function stateFirst() {
   });
 }
 `
+
+export const workflowFilesInActionSrc = `const flow: FlowDefinition = {
+  type: "default",
+  timeout: "PT5M",
+  state: "stateRunAction",
+};
+
+const action = generateAction({
+  image: "direktiv/bash:dev",
+});
+
+function stateRunAction() {
+  const result = action({
+    payload: {
+      commands: [
+        {
+          command: "ls -la",
+        },
+        {
+          command: "cat wf-var-one",
+        },
+        {
+          command: "cat test.wf.ts",
+        },
+      ],
+    },
+    files: [
+      { name: "wf-var-one", scope: "workflow" },
+      { name: "/test.wf.ts", scope: "file", permission: "0644" },
+    ],
+  });
+
+  return finish(result);
+}
+`

--- a/tests/actions/fixtures.js
+++ b/tests/actions/fixtures.js
@@ -138,7 +138,7 @@ function stateRunAction() {
     },
     files: [
       { name: "wf-var-one", scope: "workflow" },
-      { name: "/test.wf.ts", scope: "file", permission: "0644" },
+      { name: "/test.wf.ts", scope: "file", permission: "0600" },
     ],
   });
 

--- a/tests/actions/workflow-action.test.js
+++ b/tests/actions/workflow-action.test.js
@@ -293,18 +293,20 @@ describe('Action usage from workflow', () => {
 
 		const output = JSON.parse(instance.body.data.output)
 
-		// 1) files are listed with ls command (including permissions for 0644)
+		// files are listed with ls command (including permissions for 0600)
 		expect(output?.bash?.[0]?.success).toEqual(true)
 		expect(output?.bash?.[0]?.result).toEqual(expect.stringContaining('test.wf.ts'))
-		expect(output?.bash?.[0]?.result).toEqual(expect.stringMatching(/-rw-r--r--.*\stest\.wf\.ts$/m))
+		expect(output?.bash?.[0]?.result).toEqual(expect.stringMatching(/-rw-------.*\stest\.wf\.ts$/m))
+		expect(output?.bash?.[0]?.result).toEqual(expect.stringContaining('wf-var-one'))
+		expect(output?.bash?.[0]?.result).toEqual(expect.stringMatching(/-rw-r--r--.*\swf-var-one$/m))
 
-		// 2) mounted workflow variable content is readable
+		// mounted workflow variable content is readable
 		expect(output?.bash?.[1]).toMatchObject({
 			success: true,
 			result: 'ht5erf',
 		})
 
-		// 3) mounted file content is readable
+		// mounted file content is readable
 		expect(output?.bash?.[2]?.success).toEqual(true)
 		expect(output?.bash?.[2]?.result).toEqual(expect.stringContaining('const flow: FlowDefinition'))
 	})

--- a/tests/actions/workflow-action.test.js
+++ b/tests/actions/workflow-action.test.js
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals'
 import {
 	workflowEchoActionSrc,
+	workflowFilesInActionSrc,
 	workflowMultiCommandActionSrc,
 	workflowTwoActionsSrc,
 	workflowUsingActionSrc,
@@ -236,5 +237,75 @@ describe('Action usage from workflow', () => {
 				},
 			],
 		})
+	})
+
+	it('mounts workflow variables and namespace files into an action run', async () => {
+		// create workflow
+		const workflowResponse = await request(baseUrl)
+			.post(`/api/v2/namespaces/${namespace}/files`)
+			.set('Content-Type', 'application/json')
+			.send({
+				name: 'files-in-action.wf.ts',
+				type: 'workflow',
+				mimeType: 'application/typescript',
+				data: btoa(workflowFilesInActionSrc),
+			})
+		expect(workflowResponse.statusCode).toEqual(200)
+
+		// set up namespace file mounted via scope "file"
+		const fileResponse = await request(baseUrl)
+			.post(`/api/v2/namespaces/${namespace}/files`)
+			.set('Content-Type', 'application/json')
+			.send({
+				name: 'test.wf.ts',
+				type: 'file',
+				mimeType: 'application/typescript',
+				data: btoa(workflowEchoActionSrc),
+			})
+		expect(fileResponse.statusCode).toEqual(200)
+
+		// set up workflow-scoped variable mounted via scope "workflow"
+		const varResponse = await request(baseUrl)
+			.post(`/api/v2/namespaces/${namespace}/variables`)
+			.send({
+				name: 'wf-var-one',
+				workflowPath: '/files-in-action.wf.ts',
+				data: btoa('ht5erf'),
+				mimeType: 'text/plain',
+			})
+		expect(varResponse.statusCode).toEqual(200)
+
+		// execute workflow
+		const executeResponse = await request(baseUrl).post(
+			`/api/v2/namespaces/${namespace}/instances?path=files-in-action.wf.ts`,
+		)
+		expect(executeResponse.statusCode).toEqual(200)
+
+		const { id } = executeResponse.body.data
+		const instance = await waitForInstanceStatus(
+			baseUrl,
+			namespace,
+			id,
+			'complete',
+		)
+		expect(instance).toBeDefined()
+		expect(instance.body.data.status).toEqual('complete')
+
+		const output = JSON.parse(instance.body.data.output)
+
+		// 1) files are listed with ls command (including permissions for 0644)
+		expect(output?.bash?.[0]?.success).toEqual(true)
+		expect(output?.bash?.[0]?.result).toEqual(expect.stringContaining('test.wf.ts'))
+		expect(output?.bash?.[0]?.result).toEqual(expect.stringMatching(/-rw-r--r--.*\stest\.wf\.ts$/m))
+
+		// 2) mounted workflow variable content is readable
+		expect(output?.bash?.[1]).toMatchObject({
+			success: true,
+			result: 'ht5erf',
+		})
+
+		// 3) mounted file content is readable
+		expect(output?.bash?.[2]?.success).toEqual(true)
+		expect(output?.bash?.[2]?.result).toEqual(expect.stringContaining('const flow: FlowDefinition'))
 	})
 })

--- a/tests/engine/basic_action.test.js
+++ b/tests/engine/basic_action.test.js
@@ -30,7 +30,7 @@ describe('Test js engine', () => {
 			image: "mendhak/http-https-echo:latest"
 		});
 		function stateOne(payload) {
-			let result = echo({foo: "bar", input: payload});
+			let result = echo({ payload: {foo: "bar", input: payload} });
 			return finish(result.json);
 		}
 `,

--- a/tests/engine/basic_auth_action.test.js
+++ b/tests/engine/basic_auth_action.test.js
@@ -27,7 +27,7 @@ describe('Test js engine', () => {
                 auth: { username: "user", password: "pass" },
             });
             function stateOne(payload) {
-                let result = echo({ foo: "bar", input: payload });
+                let result = echo({ payload: { foo: "bar", input: payload } });
                 return finish(result);
             }
             `,
@@ -44,7 +44,7 @@ describe('Test js engine', () => {
                 image: "ramiferdocker/auth-echo:1.5",
             });
             function stateOne(payload) {
-                let result = echo({ foo: "bar", input: payload });
+                let result = echo({ payload: { foo: "bar", input: payload } });
                 return finish(result);
             }
             `,
@@ -62,7 +62,7 @@ describe('Test js engine', () => {
                 auth: { username: "wrong", password: "creds" },
             });
             function stateOne(payload) {
-                let result = echo({ foo: "bar", input: payload });
+                let result = echo({ payload: { foo: "bar", input: payload } });
                 return finish(result);
             }
             `,

--- a/tests/services/files.test.js
+++ b/tests/services/files.test.js
@@ -1,183 +1,142 @@
-import { beforeAll, describe, expect, it } from '@jest/globals'
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals'
+import { bashServiceSrc, workflowFilesInSystemServiceSrc } from './fixtures'
 
 import config from '../common/config'
 import helpers from '../common/helpers'
 import request from '../common/request'
+import { waitForInstanceStatus } from '../instances/utils'
+import { waitForServiceCondition } from './utils'
 
-const namespaceName = 'functionsfiles'
+const baseUrl = config.getDirektivBaseUrl()
+const systemNamespace = 'system'
+let namespace = ''
 
-// Outdated.
-describe.skip('Test function files behaviour', () => {
-	beforeAll(helpers.deleteAllNamespaces)
+describe('Files mounted into execService', () => {
+	beforeEach(async () => {
+		namespace = helpers.randomNamespaceName()
 
-	helpers.itShouldCreateNamespace(it, expect, namespaceName)
+		const systemNsResponse = await request(baseUrl)
+			.post('/api/v2/namespaces')
+			.send({ name: systemNamespace })
+		expect(systemNsResponse.statusCode).toEqual(200)
 
-	helpers.itShouldCreateYamlFile(
-		it,
-		expect,
-		namespaceName,
-		'/',
-		'bash.yaml',
-		'service',
-		`
-direktiv_api: service/v1
-name: bash
-image: direktiv/bash:dev
-cmd: ""
-scale: 1
-`,
-	)
-
-	helpers.itShouldCreateFile(
-		it,
-		expect,
-		namespaceName,
-		'',
-		`a.yaml`,
-		'workflow',
-		'text/plain',
-		btoa(`
-functions:
-- id: bash
-  type: knative-namespace
-  service: /bash.yaml
-
-states:
-- id: set-c
-  type: setter
-  variables:
-  - key: c
-    scope: instance
-    value: 11
-  transition: set-value-fn
-
-- id: set-value-fn
-  type: action
-  action:
-    function: bash
-    input: 
-      commands:
-      - command: bash -c 'cat a'
-      - command: bash -c 'echo -n 5 > out/namespace/a'
-      - command: bash -c 'cat b'
-      - command: bash -c 'echo -n 7 > out/workflow/b'
-      - command: bash -c 'cat c'
-      - command: bash -c 'echo -n 11 > out/instance/c'
-      - command: bash -c 'cat d'
-      - command: bash -c 'echo -n 13 > out/instance/d'
-      - command: bash -c 'cat e'
-    files:
-    - key: a
-      scope: namespace
-    - key: b
-      scope: workflow
-    - key: c
-      scope: instance
-    - key: d
-      scope: instance
-    - key: '/e.yaml'
-      as: e
-      scope: file
-  transition: get-values
-
-- id: get-values
-  type: getter
-  variables:
-  - key: a
-    scope: namespace
-  - key: b
-    scope: workflow
-  - key: c
-    scope: instance
-  - key: d
-    scope: instance
-  - key: '/e.yaml'
-    as: e
-    scope: file
-`),
-	)
-
-	it(`should invoke the '/a.yaml' workflow on a fresh namespace`, async () => {
-		helpers.sleep(10)
-		const req = await request(config.getDirektivBaseUrl()).post(
-			`/api/v2/namespaces/${namespaceName}/instances?path=a.yaml&wait=true`,
-		)
-		expect(req.statusCode).toEqual(200)
-		expect(req.body).toMatchObject({
-			var: {
-				a: 5,
-				b: 7,
-				c: 11,
-				d: 13,
-				e: null,
-			},
-		})
-
-		expect(req.body.return.bash[0]).toMatchObject({
-			result: '',
-			success: true,
-		})
-		expect(req.body.return.bash[2]).toMatchObject({
-			result: '',
-			success: true,
-		})
-		expect(req.body.return.bash[4]).toMatchObject({
-			result: 11,
-			success: true,
-		})
-		expect(req.body.return.bash[6]).toMatchObject({
-			result: '',
-			success: true,
-		})
-		expect(req.body.return.bash[8].result).toBe('')
+		const nsResponse = await request(baseUrl)
+			.post('/api/v2/namespaces')
+			.send({ name: namespace })
+		expect(nsResponse.statusCode).toEqual(200)
 	})
 
-	helpers.itShouldCreateFile(
-		it,
-		expect,
-		namespaceName,
-		'',
-		`e.yaml`,
-		'workflow',
-		'text/plain',
-		btoa(`
-states:
-- id: a
-  type: noop
-  transform:
-    result: x`),
-	)
+	afterEach(async () => {
+		return Promise.all([
+			helpers.deleteNamespace(systemNamespace),
+			helpers.deleteNamespace(namespace),
+		])
+	})
 
-	it(`should invoke the '/a.yaml' workflow on a non-fresh namespace`, async () => {
-		const req = await request(config.getDirektivBaseUrl()).post(
-			`/api/v2/namespaces/${namespaceName}/instances?path=a.yaml&wait=true`,
+	it('mounts namespace variables and namespace files into an execService run', async () => {
+		// create system service
+		const systemServiceFileName = 'bash.svc.json'
+		const systemServiceResponse = await request(baseUrl)
+			.post(`/api/v2/namespaces/${systemNamespace}/files`)
+			.set('Content-Type', 'application/json')
+			.send({
+				name: systemServiceFileName,
+				type: 'service',
+				mimeType: 'application/json',
+				data: btoa(bashServiceSrc),
+			})
+		expect(systemServiceResponse.statusCode).toEqual(200)
+
+		// confirm system service is running
+		const expectedCondition = {
+			type: 'Available',
+			status: 'True',
+		}
+		const service = await waitForServiceCondition(
+			systemNamespace,
+			`/${systemServiceFileName}`,
+			expectedCondition,
 		)
-		expect(req.statusCode).toEqual(200)
-		expect(req.body).toMatchObject({
-			var: {
-				a: 5,
-				b: 7,
-				c: 11,
-				d: 13,
-				e: 'CnN0YXRlczoKLSBpZDogYQogIHR5cGU6IG5vb3AKICB0cmFuc2Zvcm06CiAgICByZXN1bHQ6IHg=',
-			},
-		})
-		expect(req.body.return.bash[0]).toMatchObject({
-			result: 5,
+		expect(service).toBeDefined()
+
+		// create workflow
+		const workflowResponse = await request(baseUrl)
+			.post(`/api/v2/namespaces/${namespace}/files`)
+			.set('Content-Type', 'application/json')
+			.send({
+				name: 'files-in-service.wf.ts',
+				type: 'workflow',
+				mimeType: 'application/typescript',
+				data: btoa(workflowFilesInSystemServiceSrc),
+			})
+		expect(workflowResponse.statusCode).toEqual(200)
+
+		// set up namespace file to be mounted via scope "file"
+		const fileResponse = await request(baseUrl)
+			.post(`/api/v2/namespaces/${namespace}/files`)
+			.set('Content-Type', 'application/json')
+			.send({
+				name: 'test.wf.ts',
+				type: 'file',
+				mimeType: 'application/typescript',
+				data: btoa(`const flow: FlowDefinition = { type: "default" };`),
+			})
+		expect(fileResponse.statusCode).toEqual(200)
+
+		// set up namespace variable to be mounted via scope "namespace"
+		const varResponse = await request(baseUrl)
+			.post(`/api/v2/namespaces/${namespace}/variables`)
+			.send({
+				name: 'foobar',
+				data: btoa('proof-foobar'),
+				mimeType: 'text/plain',
+			})
+		expect(varResponse.statusCode).toEqual(200)
+
+		// execute workflow
+		const executeResponse = await request(baseUrl).post(
+			`/api/v2/namespaces/${namespace}/instances?path=files-in-service.wf.ts`,
+		)
+		expect(executeResponse.statusCode).toEqual(200)
+
+		const { id } = executeResponse.body.data
+		const instance = await waitForInstanceStatus(
+			baseUrl,
+			namespace,
+			id,
+			'complete',
+		)
+		expect(instance).toBeDefined()
+		expect(instance.body.data.status).toEqual('complete')
+
+		const output = JSON.parse(instance.body.data.output)
+
+		// files are listed with ls command (including permissions for 0755);
+		// namespace variables are mounted as files too (e.g. foobar)
+		expect(output?.bash?.[0]?.success).toEqual(true)
+		expect(output?.bash?.[0]?.result).toEqual(
+			expect.stringContaining('test.wf.ts'),
+		)
+		expect(output?.bash?.[0]?.result).toEqual(
+			expect.stringContaining('foobar'),
+		)
+		expect(output?.bash?.[0]?.result).toEqual(
+			expect.stringMatching(/-rw-r--r--.*\stest\.wf\.ts$/m),
+		)
+		expect(output?.bash?.[0]?.result).toEqual(
+			expect.stringMatching(/-rwxr-xr-x.*\sfoobar$/m),
+		)
+
+		// mounted namespace variable content is readable
+		expect(output?.bash?.[1]).toMatchObject({
 			success: true,
+			result: 'proof-foobar',
 		})
-		expect(req.body.return.bash[2]).toMatchObject({
-			result: 7,
-			success: true,
-		})
-		expect(req.body.return.bash[4]).toMatchObject({
-			result: 11,
-			success: true,
-		})
-		expect(req.body.return.bash[6]).toMatchObject({
-			result: '',
-			success: true,
-		})
-		expect(req.body.return.bash[8].result).not.toBe('')
+
+		// mounted file content is readable
+		expect(output?.bash?.[2]?.success).toEqual(true)
+		expect(output?.bash?.[2]?.result).toEqual(
+			expect.stringContaining('const flow: FlowDefinition'),
+		)
 	})
 })

--- a/tests/services/fixtures.js
+++ b/tests/services/fixtures.js
@@ -85,3 +85,38 @@ function stateFirst() {
   return finish(serviceResponse);
 }
 `
+
+export const workflowFilesInSystemServiceSrc = `const SYSTEM_SERVICE_PATH = "/bash.svc.json";
+
+const flow: FlowDefinition = {
+  type: "default",
+  timeout: "PT5M",
+  state: "stateRunService",
+};
+
+function stateRunService() {
+  const result = execService({
+    scope: "system",
+    path: SYSTEM_SERVICE_PATH,
+    payload: {
+      commands: [
+        {
+          command: "ls -la",
+        },
+        {
+          command: "cat foobar",
+        },
+        {
+          command: "cat test.wf.ts",
+        },
+      ],
+    },
+    files: [
+      { name: "foobar", scope: "namespace", permission: "0755" },
+      { name: "/test.wf.ts", scope: "file" },
+    ],
+  });
+
+  return finish(result);
+}
+`

--- a/ui/e2e/utils/workflows.ts
+++ b/ui/e2e/utils/workflows.ts
@@ -106,7 +106,7 @@ function stateFirst(): StateFunction<unknown> {
       },
     ],
   };
-  let result = d(payload);
+  let result = d({ payload });
   return finish(result);
 }
 `;

--- a/ui/src/assets/ts/workflow.d.ts
+++ b/ui/src/assets/ts/workflow.d.ts
@@ -56,10 +56,8 @@ declare function now(): DateObject;
  */
 declare type ActionConfig = {
   image: string;
-  type?: "workflow";
   size?: "small" | "medium" | "large";
   retries?: number;
-  body?: object;
   cmd?: string;
   envs?: {
     name: string;
@@ -68,12 +66,28 @@ declare type ActionConfig = {
 };
 
 /**
+ * Describes a file passed into an action call.
+ */
+declare type ActionFileObject = {
+  name: string;
+  scope: "namespace" | "workflow" | "file";
+  permission?: string;
+};
+
+/**
+ * Optional options for invoking a generated action.
+ */
+declare type ActionInvokeOptions = {
+  timeout?: string;
+  files?: ActionFileObject[];
+};
+
+/**
  * Creates a custom action that can then be called as a
  * typescript function.
  *
  * @param ActionConfig configuration object
  * - image: required, image to run as a container
- * - type: optional, defaults to "workflow"
  * - size: optional, defaults to "medium", or "small" | "large"
  * - retries: optional, number,
  * - cmd: optional, command to run in container
@@ -81,13 +95,13 @@ declare type ActionConfig = {
  */
 declare function generateAction(
   config: ActionConfig
-): (payload?: unknown) => void;
+): (payload?: unknown, options?: ActionInvokeOptions) => unknown;
 
 /**
  * Describes a file passed into a service
  */
 declare type FileObject = {
-  scope: "workflow" | "namespace" | "filesystem";
+  scope: "workflow" | "namespace" | "file";
   name: string;
 };
 
@@ -97,8 +111,9 @@ declare type FileObject = {
 declare type ServiceConfig = {
   scope: "namespace" | "system";
   path: string;
-  payload: object;
-  retries: number;
+  payload?: unknown;
+  retries?: number;
+  timeout?: string;
   files?: FileObject[];
 };
 
@@ -109,10 +124,11 @@ declare type ServiceConfig = {
  * - scope: required, "namespace" or "system"
  * - path: required, path to service definition file
  * - payload: required, input for the service
- * - files: optional, [{ scope: "workflow" | "namespace" | "filesystem", name: string }]
+ * - timeout: optional, ISO8601 duration string, e.g. "PT2M"
+ * - files: optional, [{ scope: "workflow" | "namespace" | "file", name: string }]
  * - retries: optional, number of retries
  */
-declare function execService(config: ServiceConfig): () => void;
+declare function execService(config: ServiceConfig): unknown;
 
 /**
  * Returns a map where the key is the secret name and the value is the value of the secret
@@ -157,7 +173,7 @@ declare function getVariable(config: VariableConfig): string;
  * Returns a base64 encoded string based on the input
  * @param input unencoded data, any JS data type
  */
-declare function base64Encode(inpout: unknown): string;
+declare function base64Encode(input: unknown): string;
 
 /**
  * Decodes a base64 encoded string

--- a/ui/src/assets/ts/workflow.d.ts
+++ b/ui/src/assets/ts/workflow.d.ts
@@ -75,9 +75,13 @@ declare type FileObject = {
 };
 
 /**
- * Optional options for invoking a generated action.
+ * Optional config for invoking a generated action.
  */
-declare type ActionInvokeOptions = {
+declare type ActionInvokeConfig = {
+  /**
+   * Optional JSON payload for the action.
+   */
+  payload?: unknown;
   timeout?: string;
   files?: FileObject[];
 };
@@ -86,13 +90,13 @@ declare interface ActionInvoker {
   /**
    * Invoke the generated action.
    *
-   * @param payload optional JSON payload for the action
-   * @param options optional invoke options
+   * @param config optional configuration object
+   * - payload: optional, JSON payload for the action
    * - timeout: optional, ISO8601 duration string, e.g. "PT2M"
-   * - files: optional, [{ name, scope: "namespace" | "workflow" | "file": octal file mode string }]
+   * - files: optional, [{ name, scope: "namespace" | "workflow" | "file", permission?: octal file mode string }]
    * @returns JSON-decoded action response
    */
-  (payload?: unknown, options?: ActionInvokeOptions): unknown;
+  (config?: ActionInvokeConfig): unknown;
 }
 
 /**
@@ -126,7 +130,7 @@ declare type ServiceConfig = {
  * @param ServiceConfig configuration object
  * - scope: required, "namespace" or "system"
  * - path: required, path to service definition file
- * - payload: required, input for the service
+ * - payload: optional, input for the service
  * - timeout: optional, ISO8601 duration string, e.g. "PT2M"
  * - files: optional, [{ scope: "workflow" | "namespace" | "file", name: string }]
  * - retries: optional, number of retries

--- a/ui/src/assets/ts/workflow.d.ts
+++ b/ui/src/assets/ts/workflow.d.ts
@@ -82,6 +82,19 @@ declare type ActionInvokeOptions = {
   files?: ActionFileObject[];
 };
 
+declare interface ActionInvoker {
+  /**
+   * Invoke the generated action.
+   *
+   * @param payload optional JSON payload for the action
+   * @param options optional invoke options
+   * - timeout: optional, ISO8601 duration string, e.g. "PT2M"
+   * - files: optional, [{ name, scope: "namespace" | "workflow" | "file": octal file mode string }]
+   * @returns JSON-decoded action response
+   */
+  (payload?: unknown, options?: ActionInvokeOptions): unknown;
+}
+
 /**
  * Creates a custom action that can then be called as a
  * typescript function.
@@ -93,9 +106,7 @@ declare type ActionInvokeOptions = {
  * - cmd: optional, command to run in container
  * - envs: optional, { name: string, value: string }[].
  */
-declare function generateAction(
-  config: ActionConfig
-): (payload?: unknown, options?: ActionInvokeOptions) => unknown;
+declare function generateAction(config: ActionConfig): ActionInvoker;
 
 /**
  * Describes a file passed into a service

--- a/ui/src/assets/ts/workflow.d.ts
+++ b/ui/src/assets/ts/workflow.d.ts
@@ -66,9 +66,9 @@ declare type ActionConfig = {
 };
 
 /**
- * Describes a file passed into an action call.
+ * Describes a file passed into an action or service call.
  */
-declare type ActionFileObject = {
+declare type FileObject = {
   name: string;
   scope: "namespace" | "workflow" | "file";
   permission?: string;
@@ -79,7 +79,7 @@ declare type ActionFileObject = {
  */
 declare type ActionInvokeOptions = {
   timeout?: string;
-  files?: ActionFileObject[];
+  files?: FileObject[];
 };
 
 declare interface ActionInvoker {
@@ -107,14 +107,6 @@ declare interface ActionInvoker {
  * - envs: optional, { name: string, value: string }[].
  */
 declare function generateAction(config: ActionConfig): ActionInvoker;
-
-/**
- * Describes a file passed into a service
- */
-declare type FileObject = {
-  scope: "workflow" | "namespace" | "file";
-  name: string;
-};
 
 /**
  * Config for execService

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -307,8 +307,8 @@ const action = generateAction({
 });
 
 function stateRunAction() {
-  const result = action(
-    {
+  const result = action({
+    payload: {
       commands: [
         {
           command: "ls -la",
@@ -321,13 +321,11 @@ function stateRunAction() {
         },
       ],
     },
-    {
-      files: [
-        { name: "wf-var-one", scope: "workflow" },
-        { name: "/test.wf.ts", scope: "file", permission: "0644" },
-      ],
-    },
-  );
+    files: [
+      { name: "wf-var-one", scope: "workflow" },
+      { name: "/test.wf.ts", scope: "file", permission: "0644" },
+    ],
+  });
 
   return finish(result);
 }

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -65,7 +65,7 @@ const actions = {
   state: "stateFirst",
 };
 
-const d = generateAction({
+const action = generateAction({
   image: "ubuntu:24.04",
   cmd: "/usr/share/direktiv/direktiv-cmd",
   size: "small",
@@ -85,7 +85,7 @@ function stateFirst(): StateFunction<unknown> {
       },
     ],
   };
-  let result = d(payload);
+  let result = action({ payload });
   return finish(result);
 }
 `,
@@ -166,9 +166,10 @@ function stateFetchJoke() {
     image: "direktiv/http-request:dev",
   });
 
-  const response = fetch({
-    method: "GET",
-    url: "https://official-joke-api.appspot.com/random_joke",
+  const response = fetch({ payload: {
+      method: "GET",
+      url: "https://official-joke-api.appspot.com/random_joke",
+    },
   });
 
   return transition(stateStoreVariable, response[0].result);

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -355,7 +355,6 @@ function stateRunService() {
     scope: "system",
     path: SYSTEM_SERVICE_PATH,
     payload: {
-      input: "hello",
       commands: [
         {
           command: "ls -la",

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -347,10 +347,10 @@ const SYSTEM_SERVICE_PATH = "/bash.svc.json";
 const flow: FlowDefinition = {
   type: "default",
   timeout: "PT5M",
-  state: "stateQueryService",
+  state: "stateRunService",
 };
 
-function stateQueryService() {
+function stateRunService() {
   const result = execService({
     scope: "system",
     path: SYSTEM_SERVICE_PATH,
@@ -360,12 +360,18 @@ function stateQueryService() {
         {
           command: "ls -la",
         },
-      ],
-      files: [
-        { name: "foobar", scope: "namespace" },
-        { name: "/test.wf.ts", scope: "file" },
+        {
+          command: "cat foobar",
+        },
+        {
+          command: "cat test.wf.ts",
+        },
       ],
     },
+    files: [
+      { name: "foobar", scope: "namespace" },
+      { name: "/test.wf.ts", scope: "file" },
+    ],
   });
 
   return finish(result);

--- a/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
+++ b/ui/src/pages/namespace/Explorer/Tree/components/modals/CreateNew/Workflow/templates.tsx
@@ -289,15 +289,101 @@ states:
 `,
 };
 
+const filesInAction = {
+  name: "files-in-action",
+  data: `// This workflow demonstrates mounting and using files with a generated workflow action.
+// Prerequisites (must exist before the workflow runs):
+// - Variable wf-var-one set in workflow scope
+// - File test.wf.ts in the namespace's filesystem
+
+const flow: FlowDefinition = {
+  type: "default",
+  timeout: "PT5M",
+  state: "stateRunAction",
+};
+
+const action = generateAction({
+  image: "direktiv/bash:dev",
+});
+
+function stateRunAction() {
+  const result = action(
+    {
+      commands: [
+        {
+          command: "ls -la",
+        },
+        {
+          command: "cat wf-var-one",
+        },
+        {
+          command: "cat test.wf.ts",
+        },
+      ],
+    },
+    {
+      files: [
+        { name: "wf-var-one", scope: "workflow" },
+        { name: "/test.wf.ts", scope: "file", permission: "0644" },
+      ],
+    },
+  );
+
+  return finish(result);
+}
+`,
+};
+
+const filesInService = {
+  name: "files-in-service",
+  data: `// This workflow demonstrates mounting and using files in a pre-existing service.
+// Prerequisites (must exist before the workflow runs):
+// - Service definition in "system" namespace at SYSTEM_SERVICE_PATH.
+// - Variable "foobar" set in the namespace
+// - File test.wf.ts in the namespace's filesystem
+
+const SYSTEM_SERVICE_PATH = "/bash.svc.json";
+
+const flow: FlowDefinition = {
+  type: "default",
+  timeout: "PT5M",
+  state: "stateQueryService",
+};
+
+function stateQueryService() {
+  const result = execService({
+    scope: "system",
+    path: SYSTEM_SERVICE_PATH,
+    payload: {
+      input: "hello",
+      commands: [
+        {
+          command: "ls -la",
+        },
+      ],
+      files: [
+        { name: "foobar", scope: "namespace" },
+        { name: "/test.wf.ts", scope: "file" },
+      ],
+    },
+  });
+
+  return finish(result);
+}
+`,
+};
+
 const templates = [
   hello,
+  branches,
   input,
   actions,
   services,
-  secrets,
   variables,
+  secrets,
+  filesInAction,
+  filesInService,
   error,
-  branches,
 ] as const;
 
 export default templates;


### PR DESCRIPTION
## Description

This builds on TDI-193, which added files handling in actions. It adds TS syntax support for specifying files when calling an action in a workflow. It also updates the backend runtime to make config object shape consistent with that of execService (using a single config object, instead of two config objects, as implemented in TDI-193).

What "file support" means:
- inside the container run by an action (or service), files are mounted in the file system.
- in the workflow, you can specify which files are mounted in the container, when invoking the action. These can be variables (the direktiv variable is mounted as a file in the container), or files living in the file system.
- see the tests and templates that are part of this PR.

Summary of changes:

`internal/engine/runtime/runtime_action.go` (AI Assisted):
- updated so the action invoker uses a single config object. The "payload" that is passed into the action container is a property in the single config object. This is consistent with the shape of the execService config object.
- Refactoring (extracting parsing of files and timeout config to separate functions).

`tests`: (AI assisted, but thoroughly reviewed):
- added API test to ensure files are mounted in actions.
- added API test to ensure files are mounted in services (not in the scope of this ticket, but existing test was skipped and easy to add following the same pattern)
- updated "actions" test for compatibility with the new config object shape

`ui`:
- added typescript definitions to support file config in actions in Monaco.
- added workflow templates for using files in actions and services.
- compatibility fix for e2e test workflow template.
 
## Checklist

- [x] Documentation updated if required
- [x] Test coverage is appropriate
      
## Checklist Internal

- [x] Linear issue linked (e.g. [DIR-XXXX] pull request title)
- [x] Has the PR been labeled
